### PR TITLE
tests/lexical.at: fix regexp for backslash quoting tests for newer 'sed'

### DIFF
--- a/tests/lexical.at
+++ b/tests/lexical.at
@@ -567,10 +567,10 @@ run=3
 ]])
 AT_DATA([uniformity_test.csh],
 [[
-set SERVICE_NAME_LOG = `cat batchsystem.properties | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[:blank:]*\([^$]*\)$/\1/p' | perl -pe 's/\s//g'  |  perl -pe 's/\)/\\\)/g' | perl -pe 's/\(/\\\(/g'`
+set SERVICE_NAME_LOG = `cat batchsystem.properties | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[[:blank:]]*\([^$]*\)$/\1/p' | perl -pe 's/\s//g'  |  perl -pe 's/\)/\\\)/g' | perl -pe 's/\(/\\\(/g'`
 echo -n "$SERVICE_NAME_LOG" > ./output1
 
-cat batchsystem.properties | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[:blank:]*\([^$]*\)$/\1/p' | perl -pe 's/\s//g'  |  perl -pe 's/\)/\\\)/g' | perl -pe 's/\(/\\\(/g' > ./output2
+cat batchsystem.properties | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[[:blank:]]*\([^$]*\)$/\1/p' | perl -pe 's/\s//g'  |  perl -pe 's/\)/\\\)/g' | perl -pe 's/\(/\\\(/g' > ./output2
 
 diff -uprN ./output1 ./output2 >& /dev/null
 
@@ -587,7 +587,7 @@ AT_DATA([quoting_result_test.csh],
 echo "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP\)(HOST=db\)(PORT=1521\)\)(CONNECT_DATA=(SERVER=DEDICATED\)(SERVICE_NAME=bns03\)\)\)" > ./expected_result
 
 set string = "jdbc_url=jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=db)(PORT=1521))(CONNECT_DATA=(SERVER=DEDICATED)(SERVICE_NAME=bns03)))"
-set SERVICE_NAME_LOG  = `echo "$string" | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[:blank:]*\([^$]*\)$/\1/p' | perl -pe 's/\)/\\\)/g'`
+set SERVICE_NAME_LOG  = `echo "$string" | grep '^jdbc_url' | sed -ne 's/^[^=]*=[^@]*@[[:blank:]]*\([^$]*\)$/\1/p' | perl -pe 's/\)/\\\)/g'`
 
 echo "$SERVICE_NAME_LOG" > ./actual_result
 


### PR DESCRIPTION
During the [Fedora 26 Mass Rebuild](https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild), it was discovered build of  *tcsh* would fail in the `make check` phase.
Further investigation showed me that sed was failing with this error message:

```bash
sed: character class syntax is [[:space:]], not [:space:]
```

Apparently, starting with version *4.3* (or [newer version](https://koji.fedoraproject.org/koji/packageinfo?packageID=352) used in Fedora), `sed` no longer supports using simple `[:group:]*`. Instead, the `[[:group:]]*` has to be used.