### PR TITLE
Add FreeBSD to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
     compiler: gcc
 os:
 - linux
+- freebsd
 - osx
 script: >-
   if [ "${COVERITY_SCAN_BRANCH}" != 1 ] ;


### PR DESCRIPTION
TravisCI [supports](https://github.com/travis-ci/travis-build/pulls?q=is%3Apr+freebsd+is%3Aclosed) FreeBSD nowadays. Let's see how well it works. CC @lwhsu (via [wiki](https://wiki.freebsd.org/HostedCI))

Caveats:
- Affected by #23 due to `PWD=/home/travis/build/tcsh-org/tcsh`
