### PR TITLE
Fix https://github.com/tcsh-org/tcsh/issues/24

### DIFF
--- a/sh.dol.c
+++ b/sh.dol.c
@@ -723,8 +723,8 @@ fixDolMod(void)
 	ndolflags = 0;
 	do {
 	    ++ndolflags;
-	    dolmcnts = xrealloc(dolmcnts, ndolflags);
-	    dolaflags = xrealloc(dolaflags, ndolflags);
+	    dolmcnts = xrealloc(dolmcnts, ndolflags * sizeof(int));
+	    dolaflags = xrealloc(dolaflags, ndolflags * sizeof(int));
 	    c = DgetC(0), dolmcnts[ndolflags - 1] = 1, dolaflags[ndolflags - 1] = 0;
 	    if (c == 'g' || c == 'a') {
 		if (c == 'g') {


### PR DESCRIPTION
bad invocation of xrealloc not taking the size of the underlying data type into account.

make check passes on centos7/gcc 4.8.5 with gcc -m32

the particular gas test passes on FreeBSD 12.0-RELEASE amd64 with CC="gcc -m32"