### PR TITLE
Fix #30

### DIFF
--- a/sh.lex.c
+++ b/sh.lex.c
@@ -1044,14 +1044,16 @@ domod(Char *cp, Char type)
 
     case 'h':
     case 't':
-	if (!any(short2str(cp), '/'))
-	    return (type == 't' ? Strsave(cp) : 0);
-	wp = Strrchr(cp, '/');
-	if (type == 'h')
-	    xp = Strnsave(cp, wp - cp);
-	else
-	    xp = Strsave(wp + 1);
-	return (xp);
+	wp = Strend(cp);
+	for (wp--; wp >= cp; wp--)
+	    if (*wp == '/') {
+		if (type == 'h')
+		    xp = Strnsave(cp, wp - cp);
+		else
+		    xp = Strsave(wp + 1);
+		return (xp);
+	    }
+	return (Strsave(type == 'h' ? STRNULL : cp));
 
     case 'e':
     case 'r':

--- a/tests/lexical.at
+++ b/tests/lexical.at
@@ -663,3 +663,59 @@ AT_CHECK([tcsh -f replace_all.csh], 0,
 
 AT_CLEANUP
 
+AT_SETUP([$x:q:h does not cause out of memory crash and yields nothing])
+
+AT_DATA([x_colon_q_colon_h.csh],
+[[set x='a/b c/d.e'
+echo $x:q:h
+exit 0
+]])
+
+AT_CHECK([tcsh -f x_colon_q_colon_h.csh], 0,
+[
+])
+
+AT_CLEANUP
+
+AT_SETUP([$x:q:t does not cause out of memory crash and yields the full string])
+
+AT_DATA([x_colon_q_colon_h.csh],
+[[set x='a/b c/d.e'
+echo $x:q:t
+exit 0
+]])
+
+AT_CHECK([tcsh -f x_colon_q_colon_h.csh], 0,
+[a/b c/d.e
+])
+
+AT_CLEANUP
+
+AT_SETUP([$x:q:r yields the full string])
+
+AT_DATA([x_colon_q_colon_r.csh],
+[[set x='a/b c/d.e'
+echo $x:q:r
+exit 0
+]])
+
+AT_CHECK([tcsh -f x_colon_q_colon_r.csh], 0,
+[a/b c/d.e
+])
+
+AT_CLEANUP
+
+AT_SETUP([$x:q:e yields nothing])
+
+AT_DATA([x_colon_q_colon_e.csh],
+[[set x='a/b c/d.e'
+echo $x:q:e
+exit 0
+]])
+
+AT_CHECK([tcsh -f x_colon_q_colon_e.csh], 0,
+[
+])
+
+AT_CLEANUP
+


### PR DESCRIPTION
Running the following kills the shell with 'Out of memory':

    set x='a/b c/d.e'
    echo $x:q:h

In sh.lex.c, it was checking if any / was in the string, but after unquoting
the candidate string. Next, it was trying to find the last /, but this
time on the quoted string (so it wouldn't find it). It would then try
to copy a string of size >>really large number<<, which failed.

Rewrote the code that handles :h and :t to be like the code for :r and
:e, which avoids the crash and makes it consistent.

Added tests for executing :h, :t, :r, :e on a :q'uoted string.

See #30