### PR TITLE
Update FreeBSD mixer(8) autocompletion

### DIFF
--- a/complete.tcsh
+++ b/complete.tcsh
@@ -617,7 +617,7 @@ complete gmake		'c/{--directory=,--include-dir=}/d/' \
 			'n/-f/f/'
 complete mixer		p/1/'(vol bass treble synth pcm speaker mic cd mix \
 			      pcm2 rec igain ogain line1 line2 line3)'/ \
-			p@2@'`mixer $:-1 | awk \{\ print\ \$7\ \}`'@
+			p@2@'`mixer -o $:-1 | awk -F = /volume=/\{\ print\ \$2\ \}`'@
 
 complete mpg123		'c/--/(2to1 4to1 8bit aggressive au audiodevice auth \
 			      buffer cdr check doublespeed equalizer frames \


### PR DESCRIPTION
The command-line interface of the mixer(8) command will
change in FreeBSD 14.0. [1]

[1] https://cgit.freebsd.org/src/commit/usr.sbin/mixer/mixer.c?id=903873ce15600fc02a0ea42cbf888cff232b411d