### PR TITLE
Fix shlvl test in variables.at with bash 5.2

### DIFF
--- a/tests/variables.at
+++ b/tests/variables.at
@@ -964,7 +964,7 @@ tcsh -f -c 'tcsh -f -c "printenv SHLVL"'
 tcsh -f -c 'exec tcsh -f -c "printenv SHLVL"'
 tcsh -f -c '(exec tcsh -f -c "printenv SHLVL")'
 ]])
-AT_CHECK([SHLVL=5 tcsh -f shlvl.csh], ,
+AT_CHECK([env SHLVL=5 tcsh -f shlvl.csh], ,
 [6
 8
 2


### PR DESCRIPTION
bash 5.2 uses implicit exec for "SHLVL=5 tcsh", which causes it to decrement SHLVL before executing tcsh. Use env to avoid that.