### PR TITLE
tests: various improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -413,10 +413,14 @@ AVSRCS= BUILDING Fixes MAKEDIFFS MAKESHAR NewThings README.md FAQ \
 	complete.tcsh vmsreadme.txt termcap.vms snames.h host.defs \
 	gethost.c tcsh.man2html configure.ac configure config.h.in \
 	tests/testsuite.at aclocal.m4 dot.login dot.tcshrc
-TESTFILES= tests/aliases.at tests/arguments.at tests/commands.at \
-	tests/expr.at tests/lexical.at tests/mb-eucjp.at \
-	tests/mb-utf8.at tests/noexec.at tests/parenthesis.at tests/syntax.at \
-	tests/subst.at tests/variables.at tests/sh.dol.at
+
+# tests/*.at except for tests/testsuite.at
+TESTFILES= \
+	tests/aliases.at tests/arguments.at tests/commands.at \
+	tests/expr.at tests/history.at tests/lexical.at \
+	tests/mb-eucjp.at tests/mb-utf8.at tests/noexec.at \
+	tests/parenthesis.at tests/sh.dol.at tests/subst.at \
+	tests/syntax.at tests/variables.at
 
 VHSRCS=${PVSRCS} ${AVSRCS}
 
@@ -627,7 +631,7 @@ veryclean: clean
 	${RM} -f Makefile config.h config_p.h nls/Makefile
 	${RM} -f config.status config.cache config.log tcsh.ps
 	${RM} -f missing
-	${RM} -f testsuite.log
+	${RM} -f atconfig testsuite.log
 	${RM} -rf testsuite.dir
 	${RM} -rf autom4te.cache
 	${RM} -f *~ #*
@@ -733,7 +737,7 @@ $(srcdir)/stamp-h.in: $(srcdir)/configure.ac
 check test: atconfig $(srcdir)/tests/testsuite
 	$(ENVCMD) - \
 		USER="$(USER)" \
-		$(SHELL) $(srcdir)/tests/testsuite
+		$(SHELL) $(srcdir)/tests/testsuite $(TESTSUITEFLAGS)
 
 #
 # Dependencies

--- a/tests/aliases.at
+++ b/tests/aliases.at
@@ -1,4 +1,5 @@
-# Special aliases
+AT_BANNER([Special aliases])
+
 
 TCSH_UNTESTED([beepcmd])
 
@@ -13,12 +14,15 @@ AT_CHECK([tcsh -f cwdcmd.csh], ,
 [>> /
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([jobcmd])
+
 TCSH_UNTESTED([helpcommand])
+
 TCSH_UNTESTED([periodic])
+
 TCSH_UNTESTED([precmd])
 
 
@@ -36,7 +40,7 @@ foo
 foo
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([shell])
@@ -53,4 +57,4 @@ AT_CHECK([tcsh -f shell.csh], ,
 [OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/arguments.at
+++ b/tests/arguments.at
@@ -1,4 +1,5 @@
-# Command-line argument handling
+AT_BANNER([Command-line argument handling])
+
 
 AT_SETUP([-b])
 
@@ -8,7 +9,7 @@ AT_DATA([-script.csh],
 AT_CHECK([tcsh -f -b -script.csh --version], , [--version
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([-c])
@@ -28,7 +29,7 @@ AT_CHECK([tcsh -f -c 'echo \\'], ,
 
 AT_CHECK([tcsh -f -c])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([-d])
@@ -40,7 +41,7 @@ AT_SETUP([-e])
 AT_CHECK([tcsh -f -e -c 'echo 1; (exit 3); echo 2'], 3, [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([-f])
@@ -53,7 +54,7 @@ AT_CHECK([echo 'echo $1' | tcsh -f -q -i foo], ,
 > exit
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 # Warning message contains strerror(EBADF), libc-dependent; can't be turned
@@ -69,12 +70,13 @@ TCSH_UNTESTED([-m])
 
 
 TCSH_UNTESTED([-q])
+
 #AT_SETUP([-q])
 
 # Nested to make the SIGQUIT reporting predictable
 #AT_CHECK([tcsh -f -q -c 'kill -QUIT $$'], 131, ,)
 
-#AT_CLEANUP
+#AT_CLEANUP()
 
 
 AT_SETUP([-s])
@@ -82,7 +84,7 @@ AT_SETUP([-s])
 AT_CHECK([echo 'echo $1' | tcsh -f -s foo], , [foo
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([-t])
@@ -94,7 +96,7 @@ AT_DATA([input.csh],
 AT_CHECK([tcsh -f -t < input.csh], , [1 2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([-v])
@@ -106,7 +108,7 @@ OK
 [repeat 2 echo OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([-x])
@@ -120,14 +122,15 @@ echo OK
 echo OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([-V])
+
 TCSH_UNTESTED([-X])
 
-
 TCSH_UNTESTED([--help])
+
 TCSH_UNTESTED([--version])
 
 
@@ -138,8 +141,7 @@ AT_CHECK([tcsh -f -Z], 1, ,
 Usage: tcsh [ -bcdefilmnqstvVxX ] [ argument ... ].
 ]])
 
-AT_CLEANUP
-
+AT_CLEANUP()
 
 
 AT_SETUP([non-option arguments])
@@ -163,4 +165,4 @@ AT_DATA([unreadable.csh],
 chmod 0 unreadable.csh
 AT_CHECK([tcsh -f unreadable.csh], 1, [], [ignore])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/commands.at
+++ b/tests/commands.at
@@ -1,4 +1,5 @@
-# Individual built-in commands
+AT_BANNER([Individual built-in commands])
+
 
 TCSH_UNTESTED([%])
 
@@ -7,7 +8,7 @@ AT_SETUP([:])
 
 AT_CHECK([tcsh -f -c ': foo'])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([@])
@@ -39,7 +40,7 @@ AT_CHECK([[tcsh -f -c \
 0 1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([alias])
@@ -74,13 +75,16 @@ AT_CHECK([tcsh -f alias.csh 2>&1], ,
 bar
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([alloc])
+
 TCSH_UNTESTED([bg])
+
 TCSH_UNTESTED([bindkey])
-#TCSH_UNTESTED([bs2cmd])
+
+dnl TCSH_UNTESTED([bs2cmd])
 
 
 AT_SETUP([break])
@@ -127,7 +131,7 @@ AT_CHECK([tcsh -f break2.csh], ,
 Line 2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([builtins])
@@ -200,7 +204,7 @@ AT_CHECK([tcsh -f chdir.csh], , [expout],
 Usage: chdir [-plvn][-|<dir>].
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([complete])
@@ -217,7 +221,7 @@ AT_CHECK([tcsh -f complete.csh], ,
 'n/A/t:*/_' 'n/[^A]/t:*/_'
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([continue])
@@ -263,7 +267,7 @@ AT_CHECK([tcsh -f continue2.csh], ,
 Line 2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([dirs])
@@ -331,8 +335,7 @@ AT_CHECK([echo x"`/bin/pwd`"x > /tmp/x && sed "s,`/bin/pwd`,CWD,g" < saved], ,
 pushd CWD/a
 ])
 
-AT_CLEANUP
-
+AT_CLEANUP()
 
 
 AT_SETUP([echo])
@@ -342,7 +345,7 @@ AT_CHECK([tcsh -f -c 'echo OK'], ,
 [OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([echotc])
@@ -354,7 +357,7 @@ AT_CHECK([tcsh -f -c 'set cmd="echo OK"; eval $cmd'], ,
 [OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([exec])
@@ -363,7 +366,7 @@ AT_CHECK([tcsh -f -c 'exec echo OK'], ,
 [OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([exit])
@@ -372,7 +375,7 @@ AT_CHECK([tcsh -f -c 'exit (50 * 4)'], 200)
 
 AT_CHECK([tcsh -f -c '(exit 50); exit'], 0)
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([fg])
@@ -502,7 +505,7 @@ AT_CHECK([tcsh -f -c 'filetest -N unknown'], ,
 [-1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([foreach])
@@ -518,10 +521,11 @@ b
 c
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([getspath])
+
 TCSH_UNTESTED([getxvers])
 
 
@@ -533,7 +537,7 @@ AT_CHECK([[tcsh -f -c 'glob a b c' | od -c] dnl
 0000005
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([goto])
@@ -558,7 +562,7 @@ Here
 OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([hashstat])
@@ -691,7 +695,7 @@ set savehist= ( 5 merge )
 history -S hist3
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([hup])
@@ -713,7 +717,7 @@ AT_CHECK([tcsh -f -c 'onintr -; nohup tcsh -f hup.csh' < /dev/null], ignore,
 
 # The prefix form requires job control and is not tested
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([if])
@@ -772,10 +776,11 @@ OK
 OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([inlib])
+
 TCSH_UNTESTED([jobs])
 
 
@@ -793,7 +798,7 @@ AT_CHECK([tcsh -f -c 'tcsh -f -i -q < kill.csh'], ignore,
 
 # kill %job, kill -l untested untested
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([limit])
@@ -807,7 +812,7 @@ log
 ]])
 AT_CHECK([tcsh -f log.csh])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([login])
@@ -819,7 +824,7 @@ AT_CHECK([tcsh -f -c 'logout'], 1, [],
 [Not a login shell.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([ls-F])
@@ -887,7 +892,7 @@ lnowhere@
 pipe|
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([migrate])
@@ -902,7 +907,7 @@ AT_CHECK([tcsh -f -c 'nice set var=1; echo $?var'], ,
 ])
 
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([nohup])
@@ -919,7 +924,7 @@ AT_CHECK([tcsh -f -c 'onintr -; nohup tcsh -f nohup.csh' < /dev/null], ,
 [OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([notify])
@@ -944,7 +949,7 @@ AT_CHECK([tcsh -f onintr.csh], ,
 OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([popd])
@@ -989,7 +994,7 @@ CWD @&t@
 Usage: popd [-plvn] [-|+<n>].
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([printenv])
@@ -1002,7 +1007,7 @@ AT_CHECK([env_var=value tcsh -f -c 'printenv' | grep env_var], ,
 [env_var=value
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([pushd])
@@ -1069,14 +1074,14 @@ CWD / @&t@
 Usage: pushd [-plvn] [-|<dir>|+<n>].
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([rehash])
 
 AT_CHECK([tcsh -f -c 'rehash'])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([repeat])
@@ -1089,10 +1094,11 @@ OK
 
 AT_CHECK([tcsh -f -c 'repeat 0 echo > file' && test -f file -a ! -s file])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([rootnode])
+
 TCSH_UNTESTED([sched]) # We don't want to wait for minutes, so ...
 
 
@@ -1133,7 +1139,7 @@ val2a val2x
 [set: $my_var4 is read-only.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([setenv])
@@ -1154,13 +1160,17 @@ AT_CHECK([tcsh -f -c 'setenv env_var value; ./output.sh'], ,
 [value
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([setpath])
+
 TCSH_UNTESTED([setspath])
+
 TCSH_UNTESTED([settc])
+
 TCSH_UNTESTED([setty])
+
 TCSH_UNTESTED([setxvers])
 
 
@@ -1201,7 +1211,7 @@ shift: No more words.
 4]
 )
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([source])
@@ -1240,10 +1250,11 @@ AT_DATA([unreadable.csh],
 chmod 000 unreadable.csh
 AT_CHECK([tcsh -f -c 'source unreadable.csh'], 1, [], [ignore])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([stop])
+
 TCSH_UNTESTED([suspend])
 
 
@@ -1300,7 +1311,7 @@ OK2
 OK3
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([telltc])
@@ -1327,7 +1338,7 @@ AT_CHECK([tcsh -f umask.csh], ,
 2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([unalias])
@@ -1340,7 +1351,7 @@ alias
 ]])
 AT_CHECK([tcsh -f unalias.csh])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([uncomplete])
@@ -1353,17 +1364,18 @@ complete
 ]])
 AT_CHECK([tcsh -f uncomplete.csh])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([unhash])
 
 AT_CHECK([tcsh -f -c 'unhash'])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([universe])
+
 TCSH_UNTESTED([unlimit])
 
 
@@ -1379,7 +1391,7 @@ AT_CHECK([tcsh -f unset.csh], ,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([unsetenv])
@@ -1393,7 +1405,7 @@ AT_CHECK([env_bar=value tcsh -f unsetenv.csh], ,
 [
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([ver])
@@ -1404,10 +1416,11 @@ AT_SETUP([wait])
 # Not really...
 AT_CHECK([tcsh -f -c 'wait'])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([warp])
+
 TCSH_UNTESTED([watchlog])
 
 
@@ -1427,7 +1440,7 @@ ls-F is a shell built-in
 CWD/ls-F
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([which])
@@ -1452,7 +1465,7 @@ this_does_not_exist: Command not found.
 echo: 	 aliased to echo_alias
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([while])
@@ -1472,7 +1485,7 @@ AT_CHECK([tcsh -f while.csh], ,
 OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([jobs output])
@@ -1491,10 +1504,10 @@ endif
 ]])
 AT_CHECK([tcsh -f jobs_stdout.csh], 0, [ignore])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([time output])
-
 
 AT_DATA([time_output.csh],
 [[
@@ -1510,4 +1523,4 @@ endif
 ]])
 AT_CHECK([tcsh -f time_output.csh], 0, [ignore])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/expr.at
+++ b/tests/expr.at
@@ -1,4 +1,5 @@
-# Expression evaluation
+AT_BANNER([Expression evaluation])
+
 
 AT_SETUP([Arithmetic operators])
 
@@ -70,7 +71,7 @@ AT_CHECK([tcsh -f -c 'exit (~ 254)'], 1)
 
 AT_CHECK([tcsh -f -c 'exit ((3))'], 3)
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Primary expressions])
@@ -163,5 +164,5 @@ AT_CHECK([tcsh -f -c 'exit ( -Z nonempty )'], 1)
 
 AT_CHECK([tcsh -f -c 'exit ( -N unknown )'], 255)
 
-AT_CLEANUP
+AT_CLEANUP()
 

--- a/tests/history.at
+++ b/tests/history.at
@@ -1,6 +1,9 @@
 # Test of the history functions.  Some of these are already tested in
 # variables and commands.
 
+AT_BANNER([history])
+
+
 AT_SETUP([history])
 
 # Check history duplicate erase
@@ -116,7 +119,8 @@ AT_CHECK([[{ cat hist-base.csh; sed 's/x !6/: !6/' hist-ev.csh;}] dnl
 # +     7 TIME : 4
 #       8 TIME : : 1
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([history performance])
 
@@ -196,7 +200,8 @@ Done at TIME
 # different histdup settings ("all", "prev", or "") and with merge (for
 # savehist) set to 0 instead of 1.
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 ### AT_SETUP([history faults])
 ###
@@ -225,7 +230,8 @@ AT_CLEANUP
 ### [history: Badly formed number.
 ### ])
 ###
-### AT_CLEANUP
+### AT_CLEANUP()
+
 
 AT_SETUP([history hup])
 
@@ -433,4 +439,4 @@ AT_CHECK([if cc -o hist-kill hist-kill.c -lutil; ] dnl
 	 [ else echo C compiler failed, skipping this approach; fi],
  	 0, stdout, stderr)
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/lexical.at
+++ b/tests/lexical.at
@@ -1,4 +1,5 @@
-# Lexical analysis and substitutions
+AT_BANNER([Lexical analysis and substitutions])
+
 
 AT_SETUP([Word splitting])
 
@@ -25,7 +26,7 @@ AT_CHECK([tcsh -f oneword.csh], ,
 [&|;<>()&||<<>>space tab end
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Comments])
@@ -47,7 +48,7 @@ AT_CHECK([tcsh -f comment2.csh], ,
 [testing... OK
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Escaping special characters])
@@ -78,7 +79,7 @@ dnl " Pacify emacs
 AT_CHECK([tcsh -f -c "echo 'foo\'bar'"], 1, , [Unmatched '''.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Preventing substitution])
@@ -149,7 +150,7 @@ AT_CHECK([tcsh -f noalias.csh])
 AT_CHECK([tcsh -f -c 'echo "g?*b"'], , [g?*b
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([History basics])
@@ -199,7 +200,7 @@ AT_CHECK([tcsh -f nohist.csh], ,
 [[! space ! tab != !( newline !
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Event specification])
@@ -341,7 +342,7 @@ numberx
 echo numberx
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Word selection])
@@ -390,7 +391,7 @@ echo 2 3 4
 echo 1 2 3 4 5
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([History modifiers])
@@ -465,7 +466,7 @@ set var= ( foo b r b z quux )
 set var= ( foo b r b z quux )
 ]])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Alias substitution])
@@ -493,7 +494,7 @@ no bug
 [Alias loop.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Variable substitution])
@@ -545,7 +546,7 @@ arg1 arg2
 `"{}$@'
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Quoting of expansions in `...`])
@@ -604,7 +605,8 @@ endif
 AT_CHECK([tcsh -f uniformity_test.csh], 0,[OK])
 AT_CHECK([tcsh -f quoting_result_test.csh], 0, [OK])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([\echo for git_tcsh_completion])
 
@@ -625,7 +627,8 @@ AT_CHECK([tcsh -f escape_echo.csh], 0,
 3
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([:gas work as described in the man pages])
 
@@ -647,7 +650,8 @@ qq we qq wb
 QQ we QQ wb
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([avoid infinite loop in :gas])
 
@@ -661,7 +665,8 @@ AT_CHECK([tcsh -f replace_all.csh], 0,
 [baba
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([/a.b/c:r doesn't remove path elements])
 
@@ -675,7 +680,8 @@ AT_CHECK([tcsh -f colon_r_no_extension.csh], 0,
 [/a.b/c
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$x:q:h does not cause out of memory crash and yields the full string])
 
@@ -689,7 +695,8 @@ AT_CHECK([tcsh -f x_colon_q_colon_h.csh], 0,
 [a/b c/d.e
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$x:q:t does not cause out of memory crash and yields the full string])
 
@@ -703,7 +710,8 @@ AT_CHECK([tcsh -f x_colon_q_colon_h.csh], 0,
 [a/b c/d.e
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$x:q:r yields the full string])
 
@@ -717,7 +725,8 @@ AT_CHECK([tcsh -f x_colon_q_colon_r.csh], 0,
 [a/b c/d.e
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$x:q:e yields nothing])
 
@@ -731,5 +740,4 @@ AT_CHECK([tcsh -f x_colon_q_colon_e.csh], 0,
 [
 ])
 
-AT_CLEANUP
-
+AT_CLEANUP()

--- a/tests/mb-eucjp.at
+++ b/tests/mb-eucjp.at
@@ -1,5 +1,8 @@
 # EUC-JP multibyte handling test case.  This file uses the EUC-JP encoding.
 
+AT_BANNER([EUC-JP multibyte])
+
+
 AT_SETUP([EUC-JP multibyte test])
 
 AT_DATA([input.csh],
@@ -94,4 +97,4 @@ AT_CHECK([LC_ALL=en_US.UTF-8 tcsh -f input.csh], ,
 [AAA
 ])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/mb-utf8.at
+++ b/tests/mb-utf8.at
@@ -1,5 +1,8 @@
 # UTF-8 multibyte handling test case.  This file uses the UTF-8 encoding.
 
+AT_BANNER([UTF-8 multibyte])
+
+
 AT_SETUP([UTF-8 multibyte test])
 
 AT_DATA([input.csh],
@@ -94,4 +97,4 @@ AT_CHECK([LC_ALL=ja_JP.eucjp tcsh -f input.csh], ,
 [AAA
 ])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/noexec.at
+++ b/tests/noexec.at
@@ -1,4 +1,5 @@
-# '-n' handling
+AT_BANNER([-n handling])
+
 
 AT_SETUP([-n])
 
@@ -138,4 +139,4 @@ end
 AT_CHECK([tcsh -f -n continuenoskip.csh], 1, [], [Missing name for redirect.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/parenthesis.at
+++ b/tests/parenthesis.at
@@ -1,6 +1,8 @@
-# Parenthesis handling
+AT_BANNER([Parenthesis handling])
+
 
 AT_SETUP([Parenthesis no space])
+
 AT_DATA([no-space.csh],
 [[
 if(1 == 1) then
@@ -12,12 +14,15 @@ else
   echo 3
 endif
 ]])
+
 AT_CHECK([tcsh -f < no-space.csh], ,[1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([Parenthesis space])
+
 AT_DATA([space.csh],
 [[
 if (1 == 1) then
@@ -29,12 +34,15 @@ else
   echo 3
 endif
 ]])
+
 AT_CHECK([tcsh -f < space.csh], ,[1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([Parenthesis space escaped])
+
 AT_DATA([space-escaped.csh],
 [[
 if (1 == 1) then
@@ -46,18 +54,23 @@ else
   echo 3
 endif
 ]])
+
 AT_CHECK([tcsh -f < space-escaped.csh], ,[1
 ])
-AT_CLEANUP
+
+AT_CLEANUP()
+
 
 AT_SETUP([Parenthesis escaped])
+
 AT_DATA([parenthesis-escaped.csh],
 [[
 if ( ')' == \) ) then
   echo 1
 endif
 ]])
+
 AT_CHECK([tcsh -f < parenthesis-escaped.csh], ,[1
 ])
-AT_CLEANUP
 
+AT_CLEANUP()

--- a/tests/sh.dol.at
+++ b/tests/sh.dol.at
@@ -1,4 +1,5 @@
-# $... substitution handling
+AT_BANNER([$... substitution handling])
+
 
 AT_SETUP([$<])
 
@@ -11,10 +12,12 @@ end
 END:
   exit 0
 ]])
+
 AT_DATA([input],
 [[foo
 !@#$%^&*()_+-=[]{};':"\|,./<>?`~
 ]])
+
 AT_CHECK([tcsh -f cat.csh < input | cmp -s input -])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/subst.at
+++ b/tests/subst.at
@@ -1,4 +1,5 @@
-# Optional substitutions
+AT_BANNER([Optional substitutions])
+
 
 AT_SETUP([Command substitution])
 
@@ -14,6 +15,7 @@ set csubstnonl
 echo `echo 1; \\
   echo 2`
 ]])
+
 AT_CHECK([tcsh -f backq.csh], 1,
 [4
 2
@@ -23,7 +25,7 @@ AT_CHECK([tcsh -f backq.csh], 1,
 [ : Command not found.
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Filename substitution])
@@ -41,6 +43,7 @@ echo nothing*
 set noglob
 echo foo* ab{c,d} ^fo*
 ]])
+
 AT_CHECK([tcsh -f files.csh], ,
 [bar baz foo foo .quux ./foo ./foo ./.quux *
 bar baz foo * Fiz foo * Fiz baz foo
@@ -80,7 +83,7 @@ echo "echo ~$(id -un)/foo; echo \"\$HOME/foo\"" | tcsh -f | uniq dnl
 ], , [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Directory stack substitution])
@@ -115,4 +118,4 @@ Directory stack not that deep.
 2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/syntax.at
+++ b/tests/syntax.at
@@ -1,4 +1,5 @@
-# Command syntax
+AT_BANNER([Command syntax])
+
 
 AT_SETUP([Command combinations])
 
@@ -36,7 +37,7 @@ async
 [[[1]    Done                          ( sleep 1; echo async )]]
 )
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([Command execution])
@@ -81,6 +82,7 @@ cat << `EOF`
 $var
 `EOF`
 ]])
+
 AT_CHECK([tcsh -f heredoc.csh], ,
 [[$\`
 abc
@@ -191,4 +193,4 @@ dnl touch output
 dnl AT_CHECK([tcsh -f -c 'set noclobber=(notempty ask); echo OK >& output'])
 
 
-AT_CLEANUP
+AT_CLEANUP()

--- a/tests/testsuite.at
+++ b/tests/testsuite.at
@@ -1,12 +1,15 @@
 # Process this file with autom4te to create testsuite. -*- Autotest -*-
 
-AT_INIT
+AT_INIT([tcsh])
+
+AT_COLOR_TESTS()
+
 AT_TESTED([tcsh])
 
-m4_define([TCSH_UNTESTED],
-[AT_SETUP([$1])
+m4_define([TCSH_UNTESTED], [dnl
+AT_SETUP([$1])
 AT_CHECK([exit 77])
-AT_CLEANUP
+AT_CLEANUP()
 ])
 
 m4_include([aliases.at])
@@ -17,10 +20,9 @@ m4_include([history.at])
 m4_include([lexical.at])
 m4_include([mb-eucjp.at])
 m4_include([mb-utf8.at])
+m4_include([noexec.at])
 m4_include([parenthesis.at])
+m4_include([sh.dol.at])
 m4_include([subst.at])
 m4_include([syntax.at])
 m4_include([variables.at])
-
-m4_include([noexec.at])
-m4_include([sh.dol.at])

--- a/tests/variables.at
+++ b/tests/variables.at
@@ -1,27 +1,34 @@
-# Special shell variables
+AT_BANNER([Special shell variables])
+
 
 # The space after $ is to avoid expanding the variables in testsuite output,
-# to work-around a bug in autotest
+# and to allow the variable names to be used as a testsuite keyword
+# (e.g., "-k time").
+# If the space is not desired, use "$[]foo" instead of "$ foo".
 
-# Not testing any functionality
-m4_define([VAR_UNSET],
-[AT_SETUP([$ $1])
+
+dnl VAR_UNSET - Not testing any specific functionality for variable
+dnl
+m4_define([VAR_UNSET], [dnl
+AT_SETUP([$ $1])
 AT_CHECK([tcsh -f -c 'echo $?$1'], ,
 [0
 ])
-AT_CLEANUP
+AT_CLEANUP()
 ])
-m4_define([ENV_SET],
-[AT_SETUP([$ $1])
+
+m4_define([ENV_SET], [dnl
+AT_SETUP([$ $1])
 AT_CHECK([tcsh -f -c 'printenv $1'], 0, [ignore])
-AT_CLEANUP
+AT_CLEANUP()
 ])
-m4_define([ENV_UNSET],
-[AT_SETUP([$ $1])
+
+m4_define([ENV_UNSET], [dnl
+AT_SETUP([$ $1])
 AT_CHECK([tcsh -f -c 'printenv $1'], 1,
 [0
 ])
-AT_CLEANUP
+AT_CLEANUP()
 ])
 
 
@@ -32,10 +39,11 @@ AT_CHECK([tcsh -f -c 'echo $?addsuffix'], ,
 ])
 # Nothing more
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([afsuser])
+
 VAR_UNSET([ampm])
 
 
@@ -61,7 +69,7 @@ AT_CHECK([tcsh -f exit_status.csh],,
 1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ argv])
@@ -71,12 +79,15 @@ AT_CHECK([tcsh -f -c 'echo $argv; echo $2' foo bar baz], ,
 bar
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([autocorrect])
+
 VAR_UNSET([autoexpand])
+
 VAR_UNSET([autolist])
+
 TCSH_UNTESTED([$ autologout])
 
 
@@ -115,7 +126,7 @@ foo\bar
 foo\bar
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([catalog])
@@ -137,10 +148,11 @@ AT_CHECK([tcsh -f cdpath.csh], ,
 ~/tcsh_test_dir @&t@
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([color])
+
 VAR_UNSET([colorcat])
 
 
@@ -157,12 +169,15 @@ AT_CHECK([tcsh -f command.csh], ,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([complete])
+
 VAR_UNSET([continue])
+
 VAR_UNSET([continue_args])
+
 VAR_UNSET([correct])
 
 
@@ -211,7 +226,7 @@ Invalid null command.
 4
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ cwd])
@@ -244,10 +259,11 @@ CWD
 foo
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([dextract]) # Behavior tested with pushd
+
 VAR_UNSET([dirsfile])
 
 
@@ -273,10 +289,11 @@ AT_CHECK([tcsh -f dirstack.csh | sed "s,$PWD,CWD,g"], ,
 /dev CWD
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 TCSH_UNTESTED([$ dspmbyte])
+
 VAR_UNSET([dunique]) # Behavior tested with pushd
 
 
@@ -309,7 +326,7 @@ some_file
 echo some_*
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ echo_style])
@@ -339,7 +356,7 @@ foob	r
 b\tr
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ echo_hex])
@@ -372,7 +389,8 @@ a
 ag
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$ edit])
 
@@ -386,7 +404,7 @@ AT_CHECK([TERM=dumb tcsh -f -c 'echo $?edit'], ,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ ellipsis])
@@ -414,10 +432,11 @@ AT_CHECK([tcsh -f -i -q < ellipsis0.csh], ,
 [> ~...b exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([fignore])
+
 VAR_UNSET([filec])
 
 
@@ -427,7 +446,7 @@ AT_CHECK([(tcsh -f -c 'echo $gid'; id -gr) | uniq | wc -l | tr -d ' \t'], ,
 [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ group])
@@ -445,7 +464,7 @@ foo
 bar
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ histchars])
@@ -468,7 +487,7 @@ Ok
 echo Ok
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ histdup])
@@ -522,7 +541,7 @@ AT_CHECK([[tcsh -f -q -i < histdup.csh] dnl
 > exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([histfile])
@@ -591,7 +610,7 @@ history
 history -S hist2
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ history])
@@ -610,7 +629,7 @@ CWD,~,     6,     6,     6,%,0,value,>,history
 > exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ home])
@@ -645,7 +664,7 @@ AT_CHECK([(unset HOME; tcsh -f -c 'echo $?home; printenv HOME')], 1,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([ignoreeof])
@@ -686,10 +705,11 @@ cd ~/subdir
 > exit
 ], [experr])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([inputmode])
+
 VAR_UNSET([killdup])
 
 
@@ -700,7 +720,7 @@ AT_CHECK([tcsh -f -c 'echo $killring'], ,
 ])
 # Nothing more
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ listflags])
@@ -720,14 +740,20 @@ AT_CHECK([tcsh -f listflags.csh], ,
 -xFA -something .
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([listjobs])
-VAR_UNSET([listlinks]) # Functionality tested with ls-F
+
+# Functionality tested with ls-F
+VAR_UNSET([listlinks])
+
 VAR_UNSET([listmax])
+
 VAR_UNSET([listmaxrows])
-VAR_UNSET([loginsh]) # Can't test the other case
+
+VAR_UNSET([loginsh]) dnl Can't test the other case
+
 VAR_UNSET([logout])
 
 
@@ -747,7 +773,7 @@ AT_CHECK([tcsh -f mail.csh], ,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ cdtohome])
@@ -763,22 +789,34 @@ esac;
 export HOME;
 tcsh -f -c 'cd'
 ], 0)
-AT_CLEANUP
+AT_CLEANUP()
+
+
 AT_SETUP([$ noimplicithome])
+
 AT_CHECK([tcsh -f -c 'unset cdtohome; cd'], 1, , [cd: Too few arguments.
 ])
-AT_CLEANUP
+
+AT_CLEANUP()
 
 
 VAR_UNSET([matchbeep])
+
 VAR_UNSET([nobeep])
-VAR_UNSET([noclobber]) # Functionality tested with "Command execution"
+
+# Functionality tested with "Command execution"
+VAR_UNSET([noclobber])
+
 VAR_UNSET([noding])
+
 # Functionality tested with "Filename substitution" and
 # "Directory stack substitution"
 VAR_UNSET([noglob])
+
 VAR_UNSET([nostat])
+
 VAR_UNSET([notify])
+
 TCSH_UNTESTED([$ oid])
 
 
@@ -802,7 +840,7 @@ CWD
 /bin
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ path])
@@ -833,7 +871,7 @@ subdir:.
 . foo . bar .
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ printexitvalue])
@@ -854,7 +892,7 @@ Exit 1
 Exit 3
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ prompt])
@@ -873,7 +911,7 @@ AT_CHECK([tcsh -f -i -q < prompt.csh | sed "s,$PWD,CWD,"], ,
 CWD/a/b,~/a/b,b,b,~/a/b,~/a/b,~/<1>b,~/<1>b,b,8,8,8,%,0,value,>,50 exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ prompt2])
@@ -882,7 +920,7 @@ AT_CHECK([echo 'echo "$prompt2"' | tcsh -f], ,
 [%R? @&t@
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ prompt3])
@@ -891,7 +929,8 @@ AT_CHECK([echo 'echo "$prompt3"' | tcsh -f], ,
 [CORRECT>%R (y|n|e|a)? @&t@
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
+
 
 AT_SETUP([$ promptchars])
 
@@ -904,13 +943,19 @@ AT_CHECK([tcsh -f  -i -q < promptchars.csh], ,
 _ exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
-VAR_UNSET([pushdtohome]) # Functionality tested with pushd
-VAR_UNSET([pushdsilent]) # Functionality tested with pushd
+# Functionality tested with pushd
+VAR_UNSET([pushdtohome])
+
+# Functionality tested with pushd
+VAR_UNSET([pushdsilent])
+
 VAR_UNSET([recexact])
+
 VAR_UNSET([recognize_only_executablers])
+
 VAR_UNSET([rmstar])
 
 
@@ -930,11 +975,13 @@ AT_CHECK([tcsh -f -i -q < rprompt.csh | sed "s,$PWD,CWD,"], ,
 > CWD/a/b,~/a/b,b,b,~/a/b,~/a/b,~/<1>b,~/<1>b,b,8,8,8,%,0,value,>,50 exit
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([savedirs])
+
 VAR_UNSET([savehist])
+
 VAR_UNSET([sched])
 
 
@@ -948,7 +995,7 @@ AT_CHECK([SHELL=foo/tcsh tcsh -f -c 'echo $shell'], ,
 [foo/tcsh
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ shlvl])
@@ -974,7 +1021,7 @@ AT_CHECK([env SHLVL=5 tcsh -f shlvl.csh], ,
 4
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ status])
@@ -993,7 +1040,7 @@ OK
 0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ symlinks])
@@ -1024,7 +1071,7 @@ CWD
 1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ tcsh])
@@ -1033,7 +1080,7 @@ AT_CHECK([tcsh -f -c 'echo $?tcsh'], ,
 [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ term])
@@ -1055,10 +1102,11 @@ AT_CHECK([(unset TERM; tcsh -f -c 'echo $?term; printenv TERM')], 1,
 [0
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([time])
+
 VAR_UNSET([tperiod])
 
 
@@ -1068,7 +1116,7 @@ AT_CHECK([tcsh -f -c 'echo ">$tty<"' < /dev/null], ,
 [><
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ uid])
@@ -1077,7 +1125,7 @@ AT_CHECK([(tcsh -f -c 'echo $uid'; id -ru) | uniq | wc -l | tr -d ' \t'], ,
 [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ user])
@@ -1106,7 +1154,7 @@ AT_CHECK([(unset LOGNAME; USER=foo tcsh -f -c 'echo $user; printenv LOGNAME')],
 foo
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ verbose])
@@ -1132,7 +1180,7 @@ AT_CHECK([tcsh -f -i -q < verbose.csh], ,
 echo $verbose
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 AT_SETUP([$ version])
@@ -1141,12 +1189,15 @@ AT_CHECK([tcsh -f -c 'echo $?version'], ,
 [1
 ])
 
-AT_CLEANUP
+AT_CLEANUP()
 
 
 VAR_UNSET([visiblebell])
+
 VAR_UNSET([watch])
+
 VAR_UNSET([who])
+
 VAR_UNSET([wordchars])
 
 


### PR DESCRIPTION
Makefile.in:
- Remove atconfig in veryclean
- Lexicographic order TESTFILES, and add missing history.at
- Support passing arguments to testsuite via $(TESTSUITEFLAGS). E.g., "make check TESTSUITEFLAGS=5-10" will test groups 5-10.

tests/testsuite:
- Enable color tests.
- Add banners before each test group collection
- Consistent () to macro arguments (for vim syntax highlighting).
- Consistent double-blank-line between test groups.
- Include testfiles in lexicographic order.