### PR TITLE
lukem/man fixes

### DIFF
--- a/tcsh.man
+++ b/tcsh.man
@@ -25,45 +25,45 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.\" 
+.\"
 .\" Style notes for the tcsh man page:
-.\" 
+.\"
 .\" - Tags in lists are bold, except in the FILES section where they are
 .\"   italic.
-.\" 
+.\"
 .\" - References are bold for section headings and environment and shell
 .\"   variables and italic for commands (externals, builtins, aliases, and
 .\"   editor commands) and arguments to commands.
-.\" 
+.\"
 .\" - Be careful with the .B and .I macros: they handle only a limited number
 .\"   of words. Work around this with \fB and \fI, but only if absolutely
 .\"   necessary, because tcsh.man2html uses .B/.I to find name anchors.
-.\" 
+.\"
 .\" - Indent in multiples of 4, usually 8.
-.\" 
+.\"
 .\" - Use `', not '' or "", except of course in shell syntax examples.
 .\"   '' at the beginning of a line will vanish!
 .\"
 .\" - Use \` for literal back-quote (`).
 .\"
 .\" - Use \e for literal backslash (\).
-.\" 
+.\"
 .\" - Use \-, not -.
-.\" 
+.\"
 .\" - Include the tilde when naming dot files. `~/.login', not `.login'.
-.\" 
+.\"
 .\" - Refer to external commands in man page format, e.g., `csh(1)'. However,
 .\"   tcsh is `tcsh', not `tcsh(1)', because this is the tcsh man page (and
 .\"   see the next note anyway).
-.\" 
+.\"
 .\" - Say `the shell', not `tcsh', unless distinguishing between tcsh and csh.
-.\" 
+.\"
 .\" - Say `shell variable'/`environment variable' instead of `variable'
 .\"   and `builtin command'/`editor command' instead of `builtin' or `command'
 .\"   unless the distinction is absolutely clear from context.
-.\" 
+.\"
 .\" - Use the simple present tense. `The shell uses', not `The shell will use'.
-.\" 
+.\"
 .\" - IMPORTANT: Cross-reference as much as possible. Commands, variables,
 .\"   etc. in the reference section should be mentioned in the appropriate
 .\"   descriptive section, or at least in the reference-section description
@@ -71,18 +71,18 @@
 .\"   section. Remember to note OS-specific things in "OS variant support",
 .\"   new features in NEW FEATURES and referenced external commands in SEE
 .\"   ALSO.
-.\" 
+.\"
 .\" - tcsh.man2html depends heavily on the specific nroff commands used in the
 .\"   man page when the script was written. Please stick closely to the style
 .\"   used here if you can. In particular, please don't use nroff commands
 .\"   which aren't already used herein.
-.\" 
+.\"
 .\" UPDATE NEXT LINE FOR RELEASE
 .TH TCSH 1 "12 May 2022" "Astron 6.24.01"
 .SH NAME
 tcsh \- C shell with file name completion and command line editing
 .SH SYNOPSIS
-.B tcsh \fR[\fB\-bcdefFimnqstvVxX\fR] [\fB\-Dname\fR[\fB=value\fR]] [arg ...]
+.B tcsh \fR[\fB\-bcdefFimnqstvVxX\fR] [\fB\-D\fIname\fR[=\fIvalue\fR]] [\fIarg\fR] ...
 .br
 .B tcsh \-l
 .SH DESCRIPTION
@@ -135,7 +135,7 @@ The shell exits if any invoked command terminates abnormally or
 yields a non-zero exit status.
 .TP 4
 .B \-f
-The shell does not load any resource or startup files, or perform any 
+The shell does not load any resource or startup files, or perform any
 command hashing, and thus starts faster.
 .TP 4
 .B \-F
@@ -226,7 +226,7 @@ which need be run only once per login, usually go in one's \fI~/.login\fR file.
 Users who need to use the same set of files with both \fIcsh\fR(1) and
 \fItcsh\fR can have only a \fI~/.cshrc\fR which checks for the existence of the
 \fBtcsh\fR shell variable (q.v.) before using \fItcsh\fR-specific commands,
-or can have both a \fI~/.cshrc\fR and a \fI~/.tcshrc\fR which \fIsource\fRs
+or can have both a \fI~/.cshrc\fR and a \fI~/.tcshrc\fR which \fBsource\fRs
 (see the builtin command) \fI~/.cshrc\fR.
 The rest of this manual uses `\fI~/.tcshrc\fR' to mean `\fI~/.tcshrc\fR or,
 if \fI~/.tcshrc\fR is not found, \fI~/.cshrc\fR'.
@@ -260,10 +260,10 @@ Command-line input can be edited using key sequences much like those used in
 \fIemacs\fR(1) or \fIvi\fR(1).
 The editor is active only when the \fBedit\fR shell variable is set, which
 it is by default in interactive shells.
-The \fIbindkey\fR builtin can display and change key bindings.
+The \fBbindkey\fR builtin can display and change key bindings.
 \fIemacs\fR(1)\-style key bindings are used by default
 (unless the shell was compiled otherwise; see the \fBversion\fR shell variable),
-but \fIbindkey\fR can change the key bindings to \fIvi\fR(1)\-style bindings en masse.
+but \fBbindkey\fR can change the key bindings to \fIvi\fR(1)\-style bindings en masse.
 .PP
 The shell always binds the arrow keys (as defined in the \fBTERMCAP\fR
 environment variable) to
@@ -272,27 +272,27 @@ environment variable) to
 .RS +4
 .TP 8
 down
-\fIdown-history\fR
+\fBdown-history\fR
 .TP 8
 up
-\fIup-history\fR
+\fBup-history\fR
 .TP 8
 left
-\fIbackward-char\fR
+\fBbackward-char\fR
 .TP 8
 right
-\fIforward-char\fR
+\fBforward-char\fR
 .PD
 .RE
 .PP
 unless doing so would alter another single-character binding.
-One can set the arrow key escape sequences to the empty string with \fIsettc\fR
+One can set the arrow key escape sequences to the empty string with \fBsettc\fR
 to prevent these bindings.
 The ANSI/VT100 sequences for arrow keys are always bound.
 .PP
 Other key bindings are, for the most part, what \fIemacs\fR(1) and \fIvi\fR(1)
-users would expect and can easily be displayed by \fIbindkey\fR, so there
-is no need to list them here.  Likewise, \fIbindkey\fR can list the editor
+users would expect and can easily be displayed by \fBbindkey\fR, so there
+is no need to list them here.  Likewise, \fBbindkey\fR can list the editor
 commands with a short description of each.
 Certain key bindings have different behavior depending if \fIemacs\fR(1) or \fIvi\fR(1)
 style bindings are being used; see \fBvimode\fR for more information.
@@ -305,7 +305,7 @@ and some of the characters with special meanings to it, listed under
 .SS "Completion and listing (+)"
 The shell is often able to complete words when given a unique abbreviation.
 Type part of a word (for example `ls /usr/lost') and hit the tab key to
-run the \fIcomplete-word\fR editor command.
+run the \fBcomplete-word\fR editor command.
 The shell completes the filename `/usr/lost' to `/usr/lost+found/',
 replacing the incomplete word with the complete word in the input buffer.
 (Note the terminal `/'; completion adds a `/' to the
@@ -339,8 +339,8 @@ A word beginning with `$' is considered to be a variable.
 Anything else is a filename.  An empty line is `completed' as a filename.
 .PP
 You can list the possible completions of a word at any time by typing `^D'
-to run the \fIdelete-char-or-list-or-eof\fR editor command.
-The shell lists the possible completions using the \fIls\-F\fR builtin (q.v.)
+to run the \fBdelete-char-or-list-or-eof\fR editor command.
+The shell lists the possible completions using the \fBls\-F\fR builtin (q.v.)
 and reprints the prompt and unfinished command line, for example:
 .IP "" 4
 > ls /usr/l[^D]
@@ -360,7 +360,8 @@ libtermcap.a@ libtermlib.a@
 .br
 > nm /usr/lib/libterm
 .PP
-If \fBautolist\fR is set to `ambiguous', choices are listed only when
+If the \fBautolist\fR shell variable is set to `ambiguous',
+choices are listed only when
 completion fails and adds no new characters to the word being completed.
 .PP
 A filename to be completed can contain variables, your own or others' home
@@ -389,18 +390,19 @@ bin/ etc/ lib/ man/ src/
 > ls $local/
 .PP
 Note that variables can also be expanded explicitly with the
-\fIexpand-variables\fR editor command.
+\fBexpand-variables\fR editor command.
 .PP
-\fIdelete-char-or-list-or-eof\fR lists at only the end of the line;
+\fBdelete-char-or-list-or-eof\fR lists at only the end of the line;
 in the middle of a line it deletes the character under the cursor and
-on an empty line it logs one out or, if \fBignoreeof\fR is set, does nothing.
-`M-^D', bound to the editor command \fIlist-choices\fR, lists completion
-possibilities anywhere on a line, and \fIlist-choices\fR (or any one of the
+on an empty line it logs one out or, if the \fBignoreeof\fR variable is set,
+does nothing.
+`M-^D', bound to the editor command \fBlist-choices\fR, lists completion
+possibilities anywhere on a line, and \fBlist-choices\fR (or any one of the
 related editor commands that do or don't delete, list and/or log out,
-listed under \fIdelete-char-or-list-or-eof\fR) can be bound to `^D' with
-the \fIbindkey\fR builtin command if so desired.
+listed under \fBdelete-char-or-list-or-eof\fR) can be bound to `^D' with
+the \fBbindkey\fR builtin command if so desired.
 .PP
-The \fIcomplete-word-fwd\fR and \fIcomplete-word-back\fR editor commands
+The \fBcomplete-word-fwd\fR and \fBcomplete-word-back\fR editor commands
 (not bound to any keys by default) can be used to cycle up and down through
 the list of possible completions, replacing the current word with the next or
 previous word in the list.
@@ -455,13 +457,13 @@ hyphens or underscores.
 If the \fBcomplete\fR shell variable is set to `Enhance', completion
 ignores case and differences between a hyphen and an underscore word
 separator only when the user types a lowercase character or a hyphen.
-Entering an uppercase character or an underscore will not match the 
-corresponding lowercase character or hyphen word separator.  
-Typing `rm a\-\-file[^D]' in the directory of the previous example would 
-still list all three files, but typing `rm A\-\-file' would match only 
-`A_silly_file' and typing `rm a__file[^D]' would match just `A_silly_file' 
-and `another_silly_file' because the user explicitly used an uppercase 
-or an underscore character.  
+Entering an uppercase character or an underscore will not match the
+corresponding lowercase character or hyphen word separator.
+Typing `rm a\-\-file[^D]' in the directory of the previous example would
+still list all three files, but typing `rm A\-\-file' would match only
+`A_silly_file' and typing `rm a__file[^D]' would match just `A_silly_file'
+and `another_silly_file' because the user explicitly used an uppercase
+or an underscore character.
 .PP
 Completion and listing are affected by several other shell variables:
 \fBrecexact\fR can be set to complete on the shortest possible unique
@@ -484,7 +486,7 @@ another `o',
 .PP
 the completion completes on `foo', even though `food' and `foonly'
 also match.
-\fBautoexpand\fR can be set to run the \fIexpand-history\fR editor command
+\fBautoexpand\fR can be set to run the \fBexpand-history\fR editor command
 before each completion attempt, \fBautocorrect\fR can be set to
 spelling-correct the word to be completed (see \fBSpelling correction\fR)
 before each completion attempt and \fBcorrect\fR can be set to complete
@@ -499,18 +501,18 @@ and rows (respectively) that are listed without asking first.
 \fBrecognize_only_executables\fR can be set to make the shell list only
 executables when listing commands, but it is quite slow.
 .PP
-Finally, the \fIcomplete\fR builtin command can be used to tell the shell how
+Finally, the \fBcomplete\fR builtin command can be used to tell the shell how
 to complete words other than filenames, commands and variables.
 Completion and listing do not work on glob-patterns (see \fBFilename substitution\fR),
-but the \fIlist-glob\fR and \fIexpand-glob\fR editor commands perform
+but the \fBlist-glob\fR and \fBexpand-glob\fR editor commands perform
 equivalent functions for glob-patterns.
 .SS "Spelling correction (+)"
 The shell can sometimes correct the spelling of filenames, commands and variable names
 as well as completing and listing them.
 .PP
-Individual words can be spelling-corrected with the \fIspell-word\fR
+Individual words can be spelling-corrected with the \fBspell-word\fR
 editor command (usually bound to M-s and M-S)
-and the entire input buffer with \fIspell-line\fR (usually bound to M-$).
+and the entire input buffer with \fBspell-line\fR (usually bound to M-$).
 The \fBcorrect\fR shell variable can be set to `cmd' to correct the
 command name or `all' to correct the entire line each time return is typed,
 and \fBautocorrect\fR can be set to correct the word to be completed
@@ -532,7 +534,7 @@ One can answer `y' or space to execute the corrected line,
 anything else to execute the original line unchanged.
 .PP
 Spelling correction recognizes user-defined completions (see the
-\fIcomplete\fR builtin command).  If an input word in a position for
+\fBcomplete\fR builtin command).  If an input word in a position for
 which a completion is defined resembles a word in the completion list,
 spelling correction registers a misspelling and suggests the latter
 word as a correction.  However, if the input word does not match any of
@@ -580,7 +582,7 @@ Word boundary behavior modified by \fBvimode\fR.
 Completes a word as described under \fBCompletion and listing\fR.
 .TP 8
 .B complete-word-back \fR(not bound)
-Like \fIcomplete-word-fwd\fR, but steps up from the end of the list.
+Like \fBcomplete-word-fwd\fR, but steps up from the end of the list.
 .TP 8
 .B complete-word-fwd \fR(not bound)
 Replaces the current word with the first word in the list of possible
@@ -588,43 +590,43 @@ completions.  May be repeated to step down through the list.
 At the end of the list, beeps and reverts to the incomplete word.
 .TP 8
 .B complete-word-raw \fR(^X-tab)
-Like \fIcomplete-word\fR, but ignores user-defined completions.
+Like \fBcomplete-word\fR, but ignores user-defined completions.
 .TP 8
 .B copy-prev-word \fR(M-^_)
 Copies the previous word in the current line into the input buffer.
-See also \fIinsert-last-word\fR.
+See also \fBinsert-last-word\fR.
 Word boundary behavior modified by \fBvimode\fR.
 .TP 8
 .B dabbrev-expand \fR(M-/)
 Expands the current word to the most recent preceding one for which
 the current is a leading substring, wrapping around the history list
 (once) if necessary.
-Repeating \fIdabbrev-expand\fR without any intervening typing
+Repeating \fBdabbrev-expand\fR without any intervening typing
 changes to the next previous word etc., skipping identical matches
-much like \fIhistory-search-backward\fR does.
+much like \fBhistory-search-backward\fR does.
 .TP 8
 .B delete-char \fR(not bound)
 Deletes the character under the cursor.
-See also \fIdelete-char-or-list-or-eof\fR.
+See also \fBdelete-char-or-list-or-eof\fR.
 Cursor behavior modified by \fBvimode\fR.
 .TP 8
 .B delete-char-or-eof \fR(not bound)
-Does \fIdelete-char\fR if there is a character under the cursor
-or \fIend-of-file\fR on an empty line.
-See also \fIdelete-char-or-list-or-eof\fR.
+Does \fBdelete-char\fR if there is a character under the cursor
+or \fBend-of-file\fR on an empty line.
+See also \fBdelete-char-or-list-or-eof\fR.
 Cursor behavior modified by \fBvimode\fR.
 .TP 8
 .B delete-char-or-list \fR(not bound)
-Does \fIdelete-char\fR if there is a character under the cursor
-or \fIlist-choices\fR at the end of the line.
-See also \fIdelete-char-or-list-or-eof\fR.
+Does \fBdelete-char\fR if there is a character under the cursor
+or \fBlist-choices\fR at the end of the line.
+See also \fBdelete-char-or-list-or-eof\fR.
 .TP 8
 .B delete-char-or-list-or-eof \fR(^D)
-Does \fIdelete-char\fR if there is a character under the cursor,
-\fIlist-choices\fR at the end of the line
-or \fIend-of-file\fR on an empty line.
+Does \fBdelete-char\fR if there is a character under the cursor,
+\fBlist-choices\fR at the end of the line
+or \fBend-of-file\fR on an empty line.
 See also those three commands, each of which does only a single action, and
-\fIdelete-char-or-eof\fR, \fIdelete-char-or-list\fR and \fIlist-or-eof\fR,
+\fBdelete-char-or-eof\fR, \fBdelete-char-or-list\fR and \fBlist-or-eof\fR,
 each of which does a different two out of the three.
 .TP 8
 .B delete-word \fR(M-d, M-D)
@@ -632,7 +634,7 @@ Cut from cursor to end of current word \- save in cut buffer.
 Word boundary behavior modified by \fBvimode\fR.
 .TP 8
 .B down-history \fR(down-arrow, ^N)
-Like \fIup-history\fR, but steps down, stopping at the original input line.
+Like \fBup-history\fR, but steps down, stopping at the original input line.
 .TP 8
 .B downcase-word \fR(M-l, M-L)
 Lowercase the characters from cursor to end of current word.
@@ -641,7 +643,7 @@ Word boundary behavior modified by \fBvimode\fR.
 .B end-of-file \fR(not bound)
 Signals an end of file, causing the shell to exit unless the \fBignoreeof\fR
 shell variable (q.v.) is set to prevent this.
-See also \fIdelete-char-or-list-or-eof\fR.
+See also \fBdelete-char-or-list-or-eof\fR.
 .TP 8
 .B end-of-line \fR(^E, end)
 Move cursor to end of line.
@@ -650,7 +652,7 @@ Cursor behavior modified by \fBvimode\fR.
 .B expand-history \fR(M-space)
 Expands history substitutions in the current word.
 See \fBHistory substitution\fR.
-See also \fImagic-space\fR, \fItoggle-literal-history\fR and
+See also \fBmagic-space\fR, \fBtoggle-literal-history\fR and
 the \fBautoexpand\fR shell variable.
 .TP 8
 .B expand-glob \fR(^X-*)
@@ -658,7 +660,7 @@ Expands the glob-pattern to the left of the cursor.
 See \fBFilename substitution\fR.
 .TP 8
 .B expand-line \fR(not bound)
-Like \fIexpand-history\fR, but
+Like \fBexpand-history\fR, but
 expands history substitutions in each word in the input buffer.
 .TP 8
 .B expand-variables \fR(^X-$)
@@ -679,21 +681,21 @@ the current contents of the input buffer up to the cursor and copies it
 into the input buffer.
 The search string may be a glob-pattern (see \fBFilename substitution\fR)
 containing `*', `?', `[]' or `{}'.
-\fIup-history\fR and \fIdown-history\fR will proceed from the
+\fBup-history\fR and \fBdown-history\fR will proceed from the
 appropriate point in the history list.
 Emacs mode only.
-See also \fIhistory-search-forward\fR and \fIi-search-back\fR.
+See also \fBhistory-search-forward\fR and \fBi-search-back\fR.
 .TP 8
 .B history-search-forward \fR(M-n, M-N)
-Like \fIhistory-search-backward\fR, but searches forward.
+Like \fBhistory-search-backward\fR, but searches forward.
 .TP 8
 .B i-search-back \fR(not bound)
-Searches backward like \fIhistory-search-backward\fR, copies the first match
+Searches backward like \fBhistory-search-backward\fR, copies the first match
 into the input buffer with the cursor positioned at the end of the pattern,
 and prompts with `bck: ' and the first match.  Additional characters may be
-typed to extend the search, \fIi-search-back\fR may be typed to continue
+typed to extend the search, \fBi-search-back\fR may be typed to continue
 searching with the same pattern, wrapping around the history list if
-necessary, (\fIi-search-back\fR must be bound to a
+necessary, (\fBi-search-back\fR must be bound to a
 single character for this to work) or one of the following special characters
 may be typed:
 .PP
@@ -704,7 +706,7 @@ may be typed:
 ^W
 Appends the rest of the word under the cursor to the search pattern.
 .TP 8
-delete (or any character bound to \fIbackward-delete-char\fR)
+delete (or any character bound to \fBbackward-delete-char\fR)
 Undoes the effect of the last character typed and deletes a character
 from the search pattern if appropriate.
 .TP 8
@@ -717,42 +719,42 @@ Ends the search, leaving the current line in the input buffer.
 .RE
 .PD
 .PP
-Any other character not bound to \fIself-insert-command\fR terminates the
+Any other character not bound to \fBself-insert-command\fR terminates the
 search, leaving the current line in the input buffer, and
 is then interpreted as normal input.  In particular, a carriage return
 causes the current line to be executed.
-See also \fIi-search-fwd\fR and \fIhistory-search-backward\fR.
+See also \fBi-search-fwd\fR and \fBhistory-search-backward\fR.
 Word boundary behavior modified by \fBvimode\fR.
 .RE
 .TP 8
 .B i-search-fwd \fR(not bound)
-Like \fIi-search-back\fR, but searches forward.
+Like \fBi-search-back\fR, but searches forward.
 Word boundary behavior modified by \fBvimode\fR.
 .TP 8
 .B insert-last-word \fR(M-_)
 Inserts the last word of the previous input line (`!$') into the input buffer.
-See also \fIcopy-prev-word\fR.
+See also \fBcopy-prev-word\fR.
 .TP 8
 .B list-choices \fR(M-^D)
 Lists completion possibilities as described under \fBCompletion and listing\fR.
-See also \fIdelete-char-or-list-or-eof\fR and \fIlist-choices-raw\fR.
+See also \fBdelete-char-or-list-or-eof\fR and \fBlist-choices-raw\fR.
 .TP 8
 .B list-choices-raw \fR(^X-^D)
-Like \fIlist-choices\fR, but ignores user-defined completions.
+Like \fBlist-choices\fR, but ignores user-defined completions.
 .TP 8
 .B list-glob \fR(^X-g, ^X-G)
-Lists (via the \fIls\-F\fR builtin) matches to the glob-pattern
+Lists (via the \fBls\-F\fR builtin) matches to the glob-pattern
 (see \fBFilename substitution\fR) to the left of the cursor.
 .TP 8
 .B list-or-eof \fR(not bound)
-Does \fIlist-choices\fR
-or \fIend-of-file\fR on an empty line.
-See also \fIdelete-char-or-list-or-eof\fR.
+Does \fBlist-choices\fR
+or \fBend-of-file\fR on an empty line.
+See also \fBdelete-char-or-list-or-eof\fR.
 .TP 8
 .B magic-space \fR(not bound)
 Expands history substitutions in the current line,
-like \fIexpand-history\fR, and inserts a space.
-\fImagic-space\fR is designed to be bound to the space bar,
+like \fBexpand-history\fR, and inserts a space.
+\fBmagic-space\fR is designed to be bound to the space bar,
 but is not bound by default.
 .TP 8
 .B normalize-command \fR(^X-?)
@@ -785,7 +787,7 @@ can do this even more easily.
 .B run-help \fR(M-h, M-H)
 Searches for documentation on the current command, using the same notion of
 `current command' as the completion routines, and prints it.  There is no way
-to use a pager; \fIrun-help\fR is designed for short help files.
+to use a pager; \fBrun-help\fR is designed for short help files.
 If the special alias \fBhelpcommand\fR is defined, it is run with the
 command name as a sole argument.  Else,
 documentation should be in a file named \fIcommand\fR.help, \fIcommand\fR.1,
@@ -799,19 +801,19 @@ In overwrite mode, replaces the character under the cursor with the typed charac
 The input mode is normally preserved between lines, but the
 \fBinputmode\fR shell variable can be set to `insert' or `overwrite' to put the
 editor in that mode at the beginning of each line.
-See also \fIoverwrite-mode\fR.
+See also \fBoverwrite-mode\fR.
 .TP 8
 .B sequence-lead-in \fR(arrow prefix, meta prefix, ^X)
 Indicates that the following characters are part of a
 multi-key sequence.  Binding a command to a multi-key sequence really creates
-two bindings: the first character to \fIsequence-lead-in\fR and the
+two bindings: the first character to \fBsequence-lead-in\fR and the
 whole sequence to the command.  All sequences beginning with a character
-bound to \fIsequence-lead-in\fR are effectively bound to \fIundefined-key\fR
+bound to \fBsequence-lead-in\fR are effectively bound to \fBundefined-key\fR
 unless bound to another command.
 .TP 8
 .B spell-line \fR(M-$)
 Attempts to correct the spelling of each word in the input buffer, like
-\fIspell-word\fR, but ignores words whose first character is one of
+\fBspell-word\fR, but ignores words whose first character is one of
 `\-', `!', `^' or `%', or which contain `\e', `*' or `?', to avoid problems
 with switches, substitutions and the like.
 See \fBSpelling correction\fR.
@@ -823,7 +825,7 @@ Checks each component of a word which appears to be a pathname.
 .TP 8
 .B toggle-literal-history \fR(M-r, M-R)
 Expands or `unexpands' history substitutions in the input buffer.
-See also \fIexpand-history\fR and the \fBautoexpand\fR shell variable.
+See also \fBexpand-history\fR and the \fBautoexpand\fR shell variable.
 .TP 8
 .B undefined-key \fR(any unbound key)
 Beeps.
@@ -847,7 +849,7 @@ Word boundary behavior modified by \fBvimode\fR.
 .TP 8
 .B vi-search-back \fR(?)
 Prompts with `?' for a search string (which may be a glob-pattern, as with
-\fIhistory-search-backward\fR), searches for it and copies it into the
+\fBhistory-search-backward\fR), searches for it and copies it into the
 input buffer.  The bell rings if no match is found.
 Hitting return ends the search and leaves the last match in the input
 buffer.
@@ -855,18 +857,18 @@ Hitting escape ends the search and executes the match.
 \fIvi\fR mode only.
 .TP 8
 .B vi-search-fwd \fR(/)
-Like \fIvi-search-back\fR, but searches forward.
+Like \fBvi-search-back\fR, but searches forward.
 .TP 8
 .B which-command \fR(M-?)
-Does a \fIwhich\fR (see the description of the builtin command) on the
+Does a \fBwhich\fR (see the description of the builtin command) on the
 first word of the input buffer.
 .TP 8
 .B yank-pop \fR(M-y)
-When executed immediately after a \fIyank\fR or another \fIyank-pop\fR,
+When executed immediately after a \fByank\fR or another \fByank-pop\fR,
 replaces the yanked string with the next previous string from the
 killring. This also has the effect of rotating the killring, such that
 this string will be considered the most recently killed by a later
-\fIyank\fR command. Repeating \fIyank-pop\fR will cycle through the
+\fByank\fR command. Repeating \fByank-pop\fR will cycle through the
 killring any number of times.
 .SS "Lexical structure"
 The shell splits input lines into words at blanks and tabs.  The special
@@ -890,7 +892,7 @@ can be prevented by enclosing the strings (or parts of strings)
 in which they appear with single quotes or by quoting the crucial character(s)
 (e.g., `$' or `\`' for \fBVariable substitution\fR or \fBCommand substitution\fR respectively)
 with `\e'.  (\fBAlias substitution\fR is no exception: quoting in any way any
-character of a word for which an \fIalias\fR has been defined prevents
+character of a word for which an \fBalias\fR has been defined prevents
 substitution of the alias.  The usual way of quoting an alias is to precede it
 with a backslash.) \fBHistory substitution\fR is prevented by
 backslashes but not by single quotes.  Strings quoted with double or backward
@@ -919,7 +921,7 @@ always quote `\e', `'', and `"'.  (+) This may make complex quoting tasks
 easier, but it can cause syntax errors in \fIcsh\fR(1) scripts.
 .SS "Escape sequences (+)"
 The following escape sequences are always recognized inside a string
-constructed using `$''', and optionally by the \fIecho\fR builtin command as
+constructed using `$''', and optionally by the \fBecho\fR builtin command as
 controlled by the \fBecho_style\fR shell variable.
 .RS +4
 .TP 14
@@ -1007,7 +1009,7 @@ The shell actually saves history in expanded and literal (unexpanded) forms.
 If the \fBhistlit\fR shell variable is set, commands that display and store
 history use the literal form.
 .PP
-The \fIhistory\fR builtin command can print, store in a file, restore
+The \fBhistory\fR builtin command can print, store in a file, restore
 and clear the history list at any time,
 and the \fBsavehist\fR and \fBhistfile\fR shell variables can be set to
 store the history list automatically on logout and restore it on login.
@@ -1270,18 +1272,20 @@ rather than `$'.
 .PP
 Finally, history can be accessed through the editor as well as through
 the substitutions just described.
-The \fIup-\fR and \fIdown-history\fR, \fIhistory-search-backward\fR and
-\fI-forward\fR, \fIi-search-back\fR and \fI-fwd\fR,
-\fIvi-search-back\fR and \fI-fwd\fR, \fIcopy-prev-word\fR
-and \fIinsert-last-word\fR editor commands search for
+The \fBup-history\fR and \fBdown-history\fR,
+\fBhistory-search-backward\fR and \fBhistory-search-forward\fR,
+\fBi-search-back\fR and \fBi-search-fwd\fR,
+\fBvi-search-back\fR and \fBvi-search-fwd\fR,
+\fBcopy-prev-word\fR
+and \fBinsert-last-word\fR editor commands search for
 events in the history list and copy them into the input buffer.
-The \fItoggle-literal-history\fR editor command switches between the
+The \fBtoggle-literal-history\fR editor command switches between the
 expanded and literal forms of history lines in the input buffer.
-\fIexpand-history\fR and \fIexpand-line\fR expand history substitutions
+\fBexpand-history\fR and \fBexpand-line\fR expand history substitutions
 in the current word and in the entire input buffer respectively.
 .SS "Alias substitution"
 The shell maintains a list of aliases which can be set, unset and printed by
-the \fIalias\fR and \fIunalias\fR commands.  After a command line is parsed
+the \fBalias\fR and \fBunalias\fR commands.  After a command line is parsed
 into simple commands (see \fBCommands\fR) the first word of each command,
 left-to-right, is checked to see if it has an alias.  If so, the first word is
 replaced by the alias.  If the alias contains a history reference, it undergoes
@@ -1306,10 +1310,10 @@ Some aliases are referred to by the shell; see \fBSpecial aliases\fR.
 The shell maintains a list of variables, each of which has as value a list of
 zero or more words.
 The values of shell variables can be displayed and changed with the
-\fIset\fR and \fIunset\fR commands.
+\fBset\fR and \fBunset\fR commands.
 The system maintains its own list of ``environment'' variables.
-These can be displayed and changed with \fIprintenv\fR, \fIsetenv\fR and
-\fIunsetenv\fR.
+These can be displayed and changed with \fBprintenv\fR, \fBsetenv\fR and
+\fBunsetenv\fR.
 .PP
 (+) Variables may be made read-only with `set \-r' (q.v.).
 Read-only variables may not be modified or unset;
@@ -1335,8 +1339,9 @@ the second and subsequent words of multi-word values are ignored.
 .PP
 After the input line is aliased and parsed, and before each command is
 executed, variable substitution is performed keyed by `$' characters.  This
-expansion can be prevented by preceding the `$' with a `\e' except within `"'s
-where it \fIalways\fR occurs, and within `''s where it \fInever\fR occurs.
+expansion can be prevented by preceding the `$' with a `\e' except within `"'
+pairs where it \fIalways\fR occurs,
+and within `'' pairs where it \fInever\fR occurs.
 Strings quoted by `\`' are interpreted later (see \fBCommand substitution\fR
 below) so `$' substitution does not occur there until later,
 if at all.  A `$' is passed unchanged if followed by a blank, tab, or
@@ -1450,13 +1455,13 @@ Substitutes the command line of the last command executed.  (+)
 $<
 Substitutes a line from the standard input, with no further interpretation
 thereafter.  It can be used to read from the keyboard in a shell script.
-(+) While \fIcsh\fR always quotes $<, as if it were equivalent to `$<:q',
+(+) While \fIcsh\fR always quotes `$<', as if it were equivalent to `$<:q',
 \fItcsh\fR does not.  Furthermore, when \fItcsh\fR is waiting for a line to be
 typed the user may type an interrupt to interrupt the sequence into
 which the line is to be substituted, but \fIcsh\fR does not allow this.
 .PD
 .PP
-The editor command \fIexpand-variables\fR, normally bound to `^X-$',
+The editor command \fBexpand-variables\fR, normally bound to `^X-$',
 can be used to interactively expand individual variables.
 .SS "Command, filename and directory stack substitution"
 The remaining substitutions are applied selectively to the arguments of builtin
@@ -1477,7 +1482,7 @@ final newline does not force a new word in any case.  It is thus possible for a
 command substitution to yield only part of a word, even if the command outputs
 a complete line.
 .PP
-By default, the shell since version 6.12 replaces all newline and carriage 
+By default, the shell since version 6.12 replaces all newline and carriage
 return characters in the command by spaces.  If this is switched off by
 unsetting \fBcsubstnonl\fR, newlines separate commands as usual.
 .SS "Filename substitution"
@@ -1493,9 +1498,9 @@ explicitly (unless either
 .B globdot
 or
 .B globstar
-or both are set(+)).  The character `*' matches any string of characters, 
-including the null string.  The character `?' matches any single character.  
-The sequence `[...]' matches any one of the characters enclosed.  
+or both are set (+)).  The character `*' matches any string of characters,
+including the null string.  The character `?' matches any single character.
+The sequence `[...]' matches any one of the characters enclosed.
 Within `[...]', a pair of
 characters separated by `\-' matches any character lexically between the two.
 .PP
@@ -1547,27 +1552,27 @@ only if there were no files in the current directory ending in `.a', `.c', or
 of patterns) which matches nothing is left unchanged rather than causing
 an error.
 .PP
-The \fBglobstar\fR shell variable can be set to allow `**' or `***' as 
+The \fBglobstar\fR shell variable can be set to allow `**' or `***' as
 a file glob pattern that matches any string of characters including `/',
-recursively traversing any existing sub-directories.  For example, 
+recursively traversing any existing sub-directories.  For example,
 `ls **.c' will list all the .c files in the current directory tree.
 If used by itself, it will match zero or more sub-directories
 (e.g. `ls /usr/include/**/time.h' will list any file named `time.h'
-in the /usr/include directory tree; `ls /usr/include/**time.h' will match 
+in the /usr/include directory tree; `ls /usr/include/**time.h' will match
 any file in the /usr/include directory tree ending in `time.h'; and
 `ls /usr/include/**time**.h' will match any .h file with `time' either
 in a subdirectory name or in the filename itself).
-To prevent problems with recursion, the `**' glob-pattern will not 
+To prevent problems with recursion, the `**' glob-pattern will not
 descend into a symbolic link containing a directory.  To override this,
 use `***' (+)
 .PP
 The \fBnoglob\fR shell variable can be set to prevent filename substitution,
-and the \fIexpand-glob\fR editor command, normally bound to `^X-*', can be
+and the \fBexpand-glob\fR editor command, normally bound to `^X-*', can be
 used to interactively expand individual filename substitutions.
 .SS "Directory stack substitution (+)"
 The directory stack is a list of directories, numbered from zero, used by the
-\fIpushd\fR, \fIpopd\fR and \fIdirs\fR builtin commands (q.v.).
-\fIdirs\fR can print, store in a file, restore and clear the directory stack
+\fBpushd\fR, \fBpopd\fR and \fBdirs\fR builtin commands (q.v.).
+\fBdirs\fR can print, store in a file, restore and clear the directory stack
 at any time, and the \fBsavedirs\fR and \fBdirsfile\fR shell variables can be set to
 store the directory stack automatically on logout and restore it on login.
 The \fBdirstack\fR shell variable can be examined to see the directory stack and
@@ -1597,7 +1602,7 @@ the stack.  For example,
 .br
 /usr/accts/sys
 .PP
-The \fBnoglob\fR and \fBnonomatch\fR shell variables and the \fIexpand-glob\fR
+The \fBnoglob\fR and \fBnonomatch\fR shell variables and the \fBexpand-glob\fR
 editor command apply to directory stack as well as filename substitutions.
 .SS "Other substitutions (+)"
 There are several more transformations involving filenames, not strictly
@@ -1605,10 +1610,10 @@ related to the above but mentioned here for completeness.
 \fIAny\fR filename may be expanded to a full path when the
 \fBsymlinks\fR variable (q.v.) is set to `expand'.
 Quoting prevents this expansion, and
-the \fInormalize-path\fR editor command does it on demand.
-The \fInormalize-command\fR editor command expands commands in PATH into
+the \fBnormalize-path\fR editor command does it on demand.
+The \fBnormalize-command\fR editor command expands commands in PATH into
 full paths on demand.
-Finally, \fIcd\fR and \fIpushd\fR interpret `\-' as the old working directory
+Finally, \fBcd\fR and \fBpushd\fR interpret `\-' as the old working directory
 (equivalent to the shell variable \fBowd\fR).
 This is not a substitution at all, but an abbreviation recognized by only
 those commands.  Nonetheless, it too can be prevented by quoting.
@@ -1645,7 +1650,7 @@ thus prints the \fBhome\fR directory, leaving you where you were
 cd; pwd
 .PP
 leaves you in the \fBhome\fR directory.  Parenthesized commands are most often
-used to prevent \fIcd\fR from affecting the current shell.
+used to prevent \fBcd\fR from affecting the current shell.
 .PP
 When a command to be executed is found not to be a builtin command the shell
 attempts to execute the command via \fIexecve\fR(2).  Each word in the variable
@@ -1658,7 +1663,7 @@ number of directories are present in the search path. This hashing mechanism is
 not used:
 .TP 4
 .B 1.
-If hashing is turned explicitly off via \fIunhash\fR.
+If hashing is turned explicitly off via \fBunhash\fR.
 .TP 4
 .B 2.
 If the shell was given a \fB\-f\fR argument.
@@ -1676,7 +1681,7 @@ then attempts to execute it. If execution is successful, the search stops.
 If the file has execute permissions but is not an executable to the system
 (i.e., it is neither an executable binary nor a script that specifies its
 interpreter), then it is assumed to be a file containing shell commands and
-a new shell is spawned to read it.  The \fIshell\fR special alias may be set
+a new shell is spawned to read it.  The \fBshell\fR special alias may be set
 to specify an interpreter other than the shell itself.
 .PP
 On systems which do not understand the `#!' script interpreter convention
@@ -1699,18 +1704,18 @@ expanded) as the standard input.
 Read the shell input up to a line which is identical to \fIword\fR.  \fIword\fR
 is not subjected to variable, filename or command substitution, and each input
 line is compared to \fIword\fR before any substitutions are done on this input
-line.  Unless a quoting `\e', `"', `' or `\`' appears in \fIword\fR variable and
+line.  Unless a quoting `\e', `"', `'' or `\`' appears in \fIword\fR variable and
 command substitution is performed on the intervening lines, allowing `\e' to
 quote `$', `\e' and `\`'.  Commands which are substituted have all blanks, tabs,
 and newlines preserved, except for the final newline which is dropped.  The
 resultant text is placed in an anonymous temporary file which is given to the
 command as standard input.
 .PP
-> \fIname
+> \fIname\fR
 .br
->! \fIname
+>! \fIname\fR
 .br
->& \fIname
+>& \fIname\fR
 .TP 8
 >&! \fIname
 The file \fIname\fR is used as standard output.  If the file does not exist
@@ -1733,11 +1738,11 @@ input filenames are.
 .PD 0
 .RE
 .PP
->> \fIname
+>> \fIname\fR
 .br
->>& \fIname
+>>& \fIname\fR
 .br
->>! \fIname
+>>! \fIname\fR
 .TP 8
 >>&! \fIname
 Like `>', but appends output to the end of \fIname\fR.
@@ -1774,18 +1779,19 @@ useful ways) from terminal input.  These commands all operate by forcing the
 shell to reread or skip in its input and, due to the implementation,
 restrict the placement of some of the commands.
 .PP
-The \fIforeach\fR, \fIswitch\fR, and \fIwhile\fR statements, as well as the
-\fIif-then-else\fR form of the \fIif\fR statement, require that the major
+The \fBforeach\fR, \fBswitch\fR, and \fBwhile\fR statements, as well as the
+\fBif ... then ... else\fR form of the \fBif\fR statement,
+require that the major
 keywords appear in a single simple command on an input line as shown below.
 .PP
 If the shell's input is not seekable, the shell buffers up input whenever
 a loop is being read and performs seeks in this internal buffer to
 accomplish the rereading implied by the loop.  (To the extent that this
-allows, backward \fIgoto\fRs will succeed on non-seekable inputs.)
+allows, backward \fBgoto\fRs will succeed on non-seekable inputs.)
 .SS Expressions
-The \fIif\fR, \fIwhile\fR and \fIexit\fR builtin commands
+The \fBif\fR, \fBwhile\fR and \fBexit\fR builtin commands
 use expressions with a common syntax.  The expressions can include any
-of the operators described in the next three sections.  Note that the \fI@\fR
+of the operators described in the next three sections.  Note that the \fB@\fR
 builtin command (q.v.) has its own separate syntax.
 .SS "Logical, arithmetical and comparison operators"
 These operators are similar to those of C and have the same precedence.
@@ -1801,7 +1807,7 @@ groups, at the same level.  The `==' `!=' `=~' and `!~' operators compare
 their arguments as strings; all others operate on numbers.  The operators
 `=~' and `!~' are like `==' and `!=' except that the right hand side is a
 glob-pattern (see \fBFilename substitution\fR) against which the left hand
-operand is matched.  This reduces the need for use of the \fIswitch\fR
+operand is matched.  This reduces the need for use of the \fBswitch\fR
 builtin command in shell scripts when all that is really needed is
 pattern matching.
 .PP
@@ -2000,11 +2006,11 @@ For example, if one tests a file with \fB\-w\fR whose permissions would
 ordinarily allow writing but which is on a file system mounted read-only,
 the test will succeed in a POSIX shell but fail in a non-POSIX shell.
 .PP
-File inquiry operators can also be evaluated with the \fIfiletest\fR builtin
+File inquiry operators can also be evaluated with the \fBfiletest\fR builtin
 command (q.v.) (+).
 .SS Jobs
 The shell associates a \fIjob\fR with each pipeline.  It keeps a table of
-current jobs, printed by the \fIjobs\fR command, and assigns them small integer
+current jobs, printed by the \fBjobs\fR command, and assigns them small integer
 numbers.  When a job is started asynchronously with `&', the shell prints a
 line which looks like
 .IP "" 4
@@ -2018,16 +2024,16 @@ key (usually `^Z'),
 which sends a STOP signal to the current job.  The shell will then normally
 indicate that the job has been `Suspended' and print another prompt.
 If the \fBlistjobs\fR shell variable is set, all jobs will be listed
-like the \fIjobs\fR builtin command; if it is set to `long' the listing will
+like the \fBjobs\fR builtin command; if it is set to `long' the listing will
 be in long format, like `jobs \-l'.
 You can then manipulate the state of the suspended job.
 You can put it in the
-``background'' with the \fIbg\fR command or run some other commands and
-eventually bring the job back into the ``foreground'' with \fIfg\fR.
-(See also the \fIrun-fg-editor\fR editor command.)
+``background'' with the \fBbg\fR command or run some other commands and
+eventually bring the job back into the ``foreground'' with \fBfg\fR.
+(See also the \fBrun-fg-editor\fR editor command.)
 A `^Z' takes effect immediately and is like an interrupt
 in that pending output and unread input are discarded when it is typed.
-The \fIwait\fR builtin command causes the shell to wait for all background
+The \fBwait\fR builtin command causes the shell to wait for all background
 jobs to complete.
 .PP
 The `^]' key sends a delayed suspend signal, which does not generate a STOP
@@ -2057,13 +2063,13 @@ is only one such job.
 The shell maintains a notion of the current and previous jobs.  In output
 pertaining to jobs, the current job is marked with a `+' and the previous job
 with a `\-'.  The abbreviations `%+', `%', and (by analogy with the syntax of
-the \fIhistory\fR mechanism) `%%' all refer to the current job, and `%\-' refers
+the \fBhistory\fR mechanism) `%%' all refer to the current job, and `%\-' refers
 to the previous job.
 .PP
 The job control mechanism requires that the \fIstty\fR(1) option `new' be set
 on some systems.  It is an artifact from a `new' implementation of the tty
 driver which allows generation of interrupt characters from the keyboard to
-tell jobs to stop.  See \fIstty\fR(1) and the \fIsetty\fR builtin command for
+tell jobs to stop.  See \fIstty\fR(1) and the \fBsetty\fR builtin command for
 details on setting options in the new tty driver.
 .SS "Status reporting"
 The shell learns immediately whenever a process changes state.  It normally
@@ -2071,13 +2077,13 @@ informs you whenever a job becomes blocked so that no further progress is
 possible, but only right before it prints a prompt.  This is done so that it
 does not otherwise disturb your work.  If, however, you set the shell variable
 \fBnotify\fR, the shell will notify you immediately of changes of status in
-background jobs.  There is also a shell command \fInotify\fR which marks a
+background jobs.  There is also a builtin command \fBnotify\fR which marks a
 single process so that its status changes will be immediately reported.  By
-default \fInotify\fR marks the current process; simply say `notify' after
+default \fBnotify\fR marks the current process; simply say `notify' after
 starting a background job to mark it.
 .PP
 When you try to leave the shell while jobs are stopped, you will be
-warned that `There are suspended jobs.' You may use the \fIjobs\fR command to
+warned that `There are suspended jobs.' You may use the \fBjobs\fR command to
 see what they are.  If you do this or immediately try to exit again, the shell
 will not warn you a second time, and the suspended jobs will be terminated.
 .SS "Automatic, periodic and timed events (+)"
@@ -2086,16 +2092,18 @@ at various times in the ``life cycle'' of the shell.  They are summarized here,
 and described in detail under the appropriate \fBBuiltin commands\fR,
 \fBSpecial shell variables\fR and \fBSpecial aliases\fR.
 .PP
-The \fIsched\fR builtin command puts commands in a scheduled-event list,
+The \fBsched\fR builtin command puts commands in a scheduled-event list,
 to be executed by the shell at a given time.
 .PP
-The \fIbeepcmd\fR, \fIcwdcmd\fR, \fIperiodic\fR, \fIprecmd\fR, \fIpostcmd\fR,
-and \fIjobcmd\fR
-\fBSpecial aliases\fR can be set, respectively, to execute commands when the shell wants
-to ring the bell, when the working directory changes, every \fBtperiod\fR
-minutes, before each prompt, before each command gets executed, after each
-command gets executed, and when a job is started or is brought into the
-foreground.
+The \fBbeepcmd\fR, \fBcwdcmd\fR, \fBjobcmd\fR, \fBperiodic\fR, \fBprecmd\fR,
+and \fBpostcmd\fR
+\fBSpecial aliases\fR can be set, respectively, to execute commands:
+when the shell wants to ring the bell,
+when the working directory changes,
+when a job is started or is brought into the foreground,
+every \fBtperiod\fR minutes,
+before each prompt,
+and before each command gets executed.
 .PP
 The \fBautologout\fR shell variable can be set to log out or lock the shell
 after a given number of minutes of inactivity.
@@ -2108,12 +2116,12 @@ of commands which exit with a status other than zero.
 The \fBrmstar\fR shell variable can be set to ask the user, when `rm *' is
 typed, if that is really what was meant.
 .PP
-The \fBtime\fR shell variable can be set to execute the \fItime\fR builtin
+The \fBtime\fR shell variable can be set to execute the \fBtime\fR builtin
 command after the completion of any process that takes more than a given
 number of CPU seconds.
 .PP
 The \fBwatch\fR and \fBwho\fR shell variables can be set to report when
-selected users log in or out, and the \fIlog\fR builtin command reports
+selected users log in or out, and the \fBlog\fR builtin command reports
 on those users at any time.
 .SS "Native Language System support (+)"
 The shell is eight bit clean
@@ -2138,14 +2146,14 @@ their values.  Sorting is not affected for the simulated NLS.
 .PP
 In addition, with both real and simulated NLS, all printable
 characters in the range \e200\-\e377, i.e., those that have
-M-\fIchar\fR bindings, are automatically rebound to \fIself-insert-command\fR.
+M-\fIchar\fR bindings, are automatically rebound to \fBself-insert-command\fR.
 The corresponding binding for the escape-\fIchar\fR sequence, if any, is
 left alone.
 These characters are not rebound if the \fBNOREBIND\fR environment variable
 is set.  This may be useful for the simulated NLS or a primitive real NLS
 which assumes full ISO 8859-1.  Otherwise, all M-\fIchar\fR bindings in the
 range \e240\-\e377 are effectively undone.
-Explicitly rebinding the relevant keys with \fIbindkey\fR
+Explicitly rebinding the relevant keys with \fBbindkey\fR
 is of course still possible.
 .PP
 Unknown characters (i.e., those that are neither printable nor control
@@ -2163,25 +2171,25 @@ particular operating systems.  All are described in detail in the
 \fBBuiltin commands\fR section.
 .PP
 On systems that support TCF (aix-ibm370, aix-ps2),
-\fIgetspath\fR and \fIsetspath\fR get and set the system execution path,
-\fIgetxvers\fR and \fIsetxvers\fR get and set the experimental version prefix
-and \fImigrate\fR migrates processes between sites.  The \fIjobs\fR builtin
+\fBgetspath\fR and \fBsetspath\fR get and set the system execution path,
+\fBgetxvers\fR and \fBsetxvers\fR get and set the experimental version prefix
+and \fBmigrate\fR migrates processes between sites.  The \fBjobs\fR builtin
 prints the site on which each job is executing.
 .PP
-Under BS2000, \fIbs2cmd\fR executes commands of the underlying BS2000/OSD
+Under BS2000, \fBbs2cmd\fR executes commands of the underlying BS2000/OSD
 operating system.
 .PP
-Under Domain/OS, \fIinlib\fR adds shared libraries to the current environment,
-\fIrootnode\fR changes the rootnode and \fIver\fR changes the systype.
+Under Domain/OS, \fBinlib\fR adds shared libraries to the current environment,
+\fBrootnode\fR changes the rootnode and \fBver\fR changes the systype.
 .PP
-Under Mach, \fIsetpath\fR is equivalent to Mach's \fIsetpath\fR(1).
+Under Mach, \fBsetpath\fR is equivalent to Mach's \fIsetpath\fR(1).
 .PP
-Under Masscomp/RTU and Harris CX/UX, \fIuniverse\fR sets the universe.
+Under Masscomp/RTU and Harris CX/UX, \fBuniverse\fR sets the universe.
 .PP
-Under Harris CX/UX, \fIucb\fR or \fIatt\fR runs a command under the specified
+Under Harris CX/UX, \fBucb\fR or \fBatt\fR runs a command under the specified
 universe.
 .PP
-Under Convex/OS, \fIwarp\fR prints or sets the universe.
+Under Convex/OS, \fBwarp\fR prints or sets the universe.
 .PP
 The \fBVENDOR\fR, \fBOSTYPE\fR and \fBMACHTYPE\fR environment variables
 indicate respectively the vendor, operating system and machine type
@@ -2198,7 +2206,7 @@ appropriate directory.
 The \fBversion\fR shell
 variable indicates what options were chosen when the shell was compiled.
 .PP
-Note also the \fInewgrp\fR builtin, the \fBafsuser\fR and
+Note also the \fBnewgrp\fR builtin, the \fBafsuser\fR and
 \fBecho_style\fR shell variables and the system-dependent locations of
 the shell's input files (see \fBFILES\fR).
 .SS "Signal handling"
@@ -2209,13 +2217,13 @@ terminate behavior from their parents.
 Other signals have the values which the shell inherited from its parent.
 .PP
 In shell scripts, the shell's handling of interrupt and terminate signals
-can be controlled with \fIonintr\fR, and its handling of hangups can be
-controlled with \fIhup\fR and \fInohup\fR.
+can be controlled with \fBonintr\fR, and its handling of hangups can be
+controlled with \fBhup\fR and \fBnohup\fR.
 .PP
 The shell exits on a hangup (see also the \fBlogout\fR shell variable).  By
 default, the shell's children do too, but the shell does not send them a
-hangup when it exits.  \fIhup\fR arranges for the shell to send a hangup to
-a child when it exits, and \fInohup\fR sets a child to ignore hangups.
+hangup when it exits.  \fBhup\fR arranges for the shell to send a hangup to
+a child when it exits, and \fBnohup\fR sets a child to ignore hangups.
 .SS "Terminal management (+)"
 The shell uses three different sets of terminal (``tty'') modes:
 `edit', used when editing, `quote', used when quoting literal characters,
@@ -2224,11 +2232,11 @@ The shell holds some settings in each mode constant, so commands which leave
 the tty in a confused state do not interfere with the shell.
 The shell also matches changes in the speed and padding of the tty.
 The list of tty modes that are kept constant
-can be examined and modified with the \fIsetty\fR builtin.
+can be examined and modified with the \fBsetty\fR builtin.
 Note that although the editor uses CBREAK mode (or its equivalent),
 it takes typed-ahead characters anyway.
 .PP
-The \fIechotc\fR, \fIsettc\fR and \fItelltc\fR commands can be used to
+The \fBechotc\fR, \fBsettc\fR and \fBtelltc\fR commands can be used to
 manipulate and debug terminal capabilities from the command line.
 .PP
 On systems that support SIGWINCH or SIGWINDOW, the shell
@@ -2243,10 +2251,10 @@ The next sections of this manual describe all of the available
 .SS "Builtin commands"
 .TP 8
 .B %\fIjob
-A synonym for the \fIfg\fR builtin command.
+A synonym for the \fBfg\fR builtin command.
 .TP 8
 .B %\fIjob \fB&
-A synonym for the \fIbg\fR builtin command.
+A synonym for the \fBbg\fR builtin command.
 .TP 8
 .B :
 Does nothing, successfully.
@@ -2271,7 +2279,7 @@ component of \fIname\fR; both \fIname\fR and its \fIindex\fR'th component
 must already exist.
 .PP
 \fIexpr\fR may contain the operators `*', `+', etc., as in C.
-If \fIexpr\fR contains `<', `>', `&' or `' then at least that part of
+If \fIexpr\fR contains `<', `>', `&' or `|' then at least that part of
 \fIexpr\fR must be placed within `()'.
 Note that the syntax of \fIexpr\fR has nothing to do with that described
 under \fBExpressions\fR.
@@ -2292,7 +2300,7 @@ With \fIname\fR and \fIwordlist\fR, assigns
 \fIwordlist\fR as the alias of \fIname\fR.
 \fIwordlist\fR is command and filename substituted.
 \fIname\fR may not be `alias' or `unalias'.
-See also the \fIunalias\fR builtin command.
+See also the \fBunalias\fR builtin command.
 .TP 8
 .B alloc
 Shows the amount of dynamic memory acquired, broken down into used and free
@@ -2357,7 +2365,7 @@ or an extended prefix key written X-\fIcharacter\fR (e.g., `X-A').
 .B \-r
 Removes \fIkey\fR's binding.
 Be careful: `bindkey \-r' does \fInot\fR bind \fIkey\fR to
-\fIself-insert-command\fR (q.v.), it unbinds \fIkey\fR completely.
+\fBself-insert-command\fR (q.v.), it unbinds \fIkey\fR completely.
 .TP 4
 .B \-c
 \fIcommand\fR is interpreted as a builtin or external command instead of an
@@ -2378,10 +2386,10 @@ Prints a usage message.
 .PP
 \fIkey\fR may be a single character or a string.
 If a command is bound to a string, the first character of the string is bound to
-\fIsequence-lead-in\fR and the entire string is bound to the command.
+\fBsequence-lead-in\fR and the entire string is bound to the command.
 .PP
 Control characters in \fIkey\fR can be literal (they can be typed by preceding
-them with the editor command \fIquoted-insert\fR, normally bound to `^V') or
+them with the editor command \fBquoted-insert\fR, normally bound to `^V') or
 written caret-character style, e.g., `^A'.  Delete is written `^?'
 (caret-question mark).  \fIkey\fR and \fIcommand\fR can contain backslashed
 escape sequences (in the style of System V \fIecho\fR(1)) as follows:
@@ -2428,26 +2436,26 @@ not possible to execute any command that would overlay the image
 of the current process, like /EXECUTE or /CALL-PROCEDURE. (BS2000 only)
 .TP 8
 .B break
-Causes execution to resume after the \fIend\fR of the nearest
-enclosing \fIforeach\fR or \fIwhile\fR.  The remaining commands on the
+Causes execution to resume after the \fBend\fR of the nearest
+enclosing \fBforeach\fR or \fBwhile\fR.  The remaining commands on the
 current line are executed.  Multi-level breaks are thus
 possible by writing them all on one line.
 .TP 8
 .B breaksw
-Causes a break from a \fIswitch\fR, resuming after the \fIendsw\fR.
+Causes a break from a \fBswitch\fR, resuming after the \fBendsw\fR.
 .TP 8
 .B builtins \fR(+)
 Prints the names of all builtin commands.
 .TP 8
 .B bye \fR(+)
-A synonym for the \fIlogout\fR builtin command.
+A synonym for the \fBlogout\fR builtin command.
 Available only if the shell was so compiled;
 see the \fBversion\fR shell variable.
 .TP 8
 .B case \fIlabel\fB:
-A label in a \fIswitch\fR statement as discussed below.
+A label in a \fBswitch\fR statement as discussed below.
 .TP 8
-.B cd \fR[\fB\-p\fR] [\fB\-l\fR] [\fB\-n\fR|\fB\-v\fR] [\I--\fR] [\fIname\fR]
+.B cd \fR[\fB\-p\fR] [\fB\-l\fR] [\fB\-n\fR|\fB\-v\fR] [\fB--\fR] [\fIname\fR]
 If a directory \fIname\fR is given, changes the shell's working directory
 to \fIname\fR.  If not, changes to \fBhome\fR, unless the \fBcdtohome\fR
 variable is not set, in which case a \fIname\fR is required.
@@ -2461,9 +2469,9 @@ begins with `/' or '.', then this is tried to see if it is a directory, and
 the \fB\-p\fR option is implied.
 .RS +8
 .PP
-With \fB\-p\fR, prints the final directory stack, just like \fIdirs\fR.
-The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fIcd\fR
-as on \fIdirs\fR, and they imply \fB\-p\fR.  (+)
+With \fB\-p\fR, prints the final directory stack, just like \fBdirs\fR.
+The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fBcd\fR
+as on \fBdirs\fR, and they imply \fB\-p\fR.  (+)
 Using \fB\-\-\fR forces a break from option processing so the next word
 is taken as the directory \fIname\fR even if it begins with '\-'. (+)
 .PP
@@ -2471,7 +2479,7 @@ See also the \fBimplicitcd\fR and \fBcdtohome\fR shell variables.
 .RE
 .TP 8
 .B chdir
-A synonym for the \fIcd\fR builtin command.
+A synonym for the \fBcd\fR builtin command.
 .TP 8
 .B complete \fR[\fIcommand\fR [\fIword\fB/\fIpattern\fB/\fIlist\fR[\fB:\fIselect\fR]\fB/\fR[[\fIsuffix\fR]\fB/\fR] ...]] (+)
 Without arguments, lists all completions.
@@ -2575,7 +2583,7 @@ Any variables
 Usernames
 .TP 8
 .B x
-Like \fBn\fR, but prints \fIselect\fR when \fIlist-choices\fR is used.
+Like \fBn\fR, but prints \fIselect\fR when \fBlist-choices\fR is used.
 .TP 8
 .B X
 Completions
@@ -2596,19 +2604,19 @@ If given, words from only \fIlist\fR that match \fIselect\fR are considered
 and the \fBfignore\fR shell variable is ignored.
 The last three types of completion may not have a \fIselect\fR
 pattern, and \fBx\fR uses \fIselect\fR as an explanatory message when
-the \fIlist-choices\fR editor command is used.
+the \fBlist-choices\fR editor command is used.
 .PP
 \fIsuffix\fR is a single character to be appended to a successful
 completion.  If null, no character is appended.  If omitted (in which
 case the fourth delimiter can also be omitted), a slash is appended to
 directories and a space to other words.
 .PP
-\fIcommand\fR invoked from \`...\` version has additional environment
-variable set, the variable name is \%\fBCOMMAND_LINE\fR\% and
+\fIcommand\fR invoked from \fIlist\fR \`...\` has the additional environment
+variable \fBCOMMAND_LINE\fR set, which
 contains (as its name indicates) contents of the current (already
 typed in) command line. One can examine and use contents of the
-\%\fBCOMMAND_LINE\fR\% variable in her custom script to build more
-sophisticated completions (see completion for svn(1) included in
+\fBCOMMAND_LINE\fR environment variable in a custom script to build more
+sophisticated completions (see completion for \fIsvn\fR(1) included in
 this package).
 .PP
 Now for some examples.  Some commands take only directories as arguments,
@@ -2661,7 +2669,7 @@ and `set' with shell variables.
 `true' doesn't have any options, so \fBx\fR does nothing when completion
 is attempted and prints `Truth has no options.' when completion choices are listed.
 .PP
-Note that the \fIman\fR example, and several other examples below, could
+Note that the \fBman\fR example, and several other examples below, could
 just as well have used 'c/*' or 'n/*' as 'p/*'.
 .PP
 Words can be completed from a variable evaluated at completion time,
@@ -2690,7 +2698,7 @@ or from a command run at completion time:
 .br
 23113 23377 23380 23406 23429 23529 23530 PID
 .PP
-Note that the \fIcomplete\fR command does not itself quote its arguments,
+Note that the \fBcomplete\fR command does not itself quote its arguments,
 so the braces, space and `$' in `{print $1}' must be quoted explicitly.
 .PP
 One command can have multiple completions:
@@ -2718,7 +2726,7 @@ described under \fBFilename substitution\fR.  One might use
 .PP
 to exclude precious source code from `rm' completion.  Of course, one
 could still type excluded names manually or override the completion
-mechanism using the \fIcomplete-word-raw\fR or \fIlist-choices-raw\fR
+mechanism using the \fBcomplete-word-raw\fR or \fBlist-choices-raw\fR
 editor commands (q.v.).
 .PP
 The `C', `D', `F' and `T' \fIlist\fRs are like `c', `d', `f' and `t'
@@ -2729,7 +2737,8 @@ directory.  One might use
 .IP "" 4
 > complete elm c@=@F:$HOME/Mail/@
 .PP
-to complete `elm \-f =' as if it were `elm \-f ~/Mail/'.  Note that we used `@'
+to complete `elm \-f =' as if it were `elm \-f ~/Mail/'.  Note that we used
+the separator `@'
 instead of `/' to avoid confusion with the \fIselect\fR argument, and we used
 `$HOME' instead of `~' because home directory substitution works at only the
 beginning of a word.
@@ -2776,16 +2785,16 @@ and completes anything not otherwise completed to a directory.  Whew.
 .PP
 Remember that programmed completions are ignored if the word being completed
 is a tilde substitution (beginning with `~') or a variable (beginning with `$').
-See also the \fIuncomplete\fR builtin command.
+See also the \fBuncomplete\fR builtin command.
 .RE
 .TP 8
 .B continue
-Continues execution of the nearest enclosing \fIwhile\fR or \fIforeach\fR.
+Continues execution of the nearest enclosing \fBwhile\fR or \fBforeach\fR.
 The rest of the commands on the current line are executed.
 .TP 8
 .B default:
-Labels the default case in a \fIswitch\fR statement.
-It should come after all \fIcase\fR labels.
+Labels the default case in a \fBswitch\fR statement.
+It should come after all \fBcase\fR labels.
 .PP
 .B dirs \fR[\fB\-l\fR] [\fB\-n\fR|\fB\-v\fR]
 .br
@@ -2805,7 +2814,7 @@ If more than one of \fB\-n\fR or \fB\-v\fR is given, \fB\-v\fR takes precedence.
 .RS +8
 .PP
 With \fB\-S\fR, the second form saves the directory stack to \fIfilename\fR
-as a series of \fIcd\fR and \fIpushd\fR commands.
+as a series of \fBcd\fR and \fBpushd\fR commands.
 With \fB\-L\fR, the shell sources \fIfilename\fR, which is presumably
 a directory stack file saved by the \fB\-S\fR option or the \fBsavedirs\fR
 mechanism.
@@ -2824,14 +2833,14 @@ The last form clears the directory stack.
 Writes each \fIword\fR to the shell's standard
 output, separated by spaces and terminated with a newline.
 The \fBecho_style\fR shell variable may be set to emulate (or not) the flags and escape
-sequences of the BSD and/or System V versions of \fIecho\fR; see \fBEscape sequences\fR
+sequences of the BSD and/or System V versions of \fBecho\fR; see \fBEscape sequences\fR
 and \fIecho\fR(1).
 .TP 8
 .B echotc \fR[\fB\-sv\fR] \fIarg\fR ... (+)
-Exercises the terminal capabilities (see \fItermcap\fR(5)) in \fIargs\fR.
+Exercises the terminal capabilities (see \fItermcap\fR(5)) in \fIarg\fR.
 For example, 'echotc home' sends the cursor to the home position,
 \&'echotc cm 3 10' sends it to column 3 and row 10, and
-\&'echotc ts 0; echo "This is a test."; echotc fs' prints "This is a test."
+\&'echotc ts 0; echo "This is a test."; echotc fs' prints `This is a test.'
 in the status line.
 .RS +8
 .PP
@@ -2869,8 +2878,8 @@ With \fB\-v\fR, messages are verbose.
 .PD 0
 .TP 8
 .B endsw
-See the description of the \fIforeach\fR, \fIif\fR, \fIswitch\fR, and
-\fIwhile\fR statements below.
+See the description of the \fBforeach\fR, \fBif\fR, \fBswitch\fR, and
+\fBwhile\fR statements below.
 .PD
 .TP 8
 .B eval \fIarg\fR ...
@@ -2879,7 +2888,7 @@ shell and executes the resulting command(s) in the context
 of the current shell.  This is usually used to execute commands
 generated as the result of command or variable substitution,
 because parsing occurs before these substitutions.
-See \fItset\fR(1) for a sample use of \fIeval\fR.
+See \fItset\fR(1) for a sample use of \fBeval\fR.
 .TP 8
 .B exec \fIcommand\fR
 Executes the specified command in place of the current shell.
@@ -2894,7 +2903,7 @@ Brings the specified jobs (or, without arguments, the current job)
 into the foreground, continuing each if it is stopped.
 \fIjob\fR may be a number, a string, `', `%', `+' or `\-' as described
 under \fBJobs\fR.
-See also the \fIrun-fg-editor\fR editor command.
+See also the \fBrun-fg-editor\fR editor command.
 .TP 8
 .B filetest \-\fIop file\fR ... (+)
 Applies \fIop\fR (which is a file inquiry operator as described under
@@ -2909,10 +2918,10 @@ space-separated list.
 .B end
 Successively sets the variable \fIname\fR to each member of
 \fIwordlist\fR and executes the sequence of commands between this command
-and the matching \fIend\fR.  (Both \fIforeach\fR and \fIend\fR
+and the matching \fBend\fR.  (Both \fBforeach\fR and \fBend\fR
 must appear alone on separate lines.)  The builtin command
-\fIcontinue\fR may be used to continue the loop prematurely and
-the builtin command \fIbreak\fR to terminate it prematurely.
+\fBcontinue\fR may be used to continue the loop prematurely and
+the builtin command \fBbreak\fR to terminate it prematurely.
 When this command is read from the terminal, the loop is read once
 prompting with `foreach? ' (or \fBprompt2\fR) before any statements in
 the loop are executed.  If you make a mistake typing in a
@@ -2925,8 +2934,8 @@ Prints the system execution path.  (TCF only)
 .B getxvers \fR(+)
 Prints the experimental version prefix.  (TCF only)
 .TP 8
-.B glob \fIwordlist
-Like \fIecho\fR, but the `-n' parameter is not recognized and words are
+.B glob \fIword\fR ...
+Like \fBecho\fR, but the `-n' parameter is not recognized and words are
 delimited by null characters in the output.  Useful for
 programs which wish to use the shell to filename expand a list of words.
 .TP 8
@@ -2940,7 +2949,7 @@ continues execution after that line.
 .B hashstat
 Prints a statistics line indicating how effective the
 internal hash table has been at locating commands (and avoiding
-\fIexec\fR's).  An \fIexec\fR is attempted for each component of the
+\fBexec\fR's).  An \fBexec\fR is attempted for each component of the
 \fBpath\fR where the hash function indicates a possible hit, and
 in each component which does not begin with a `/'.
 .IP
@@ -3001,16 +3010,16 @@ The last form clears the history list.
 With \fIcommand\fR, runs \fIcommand\fR such that it will exit on a hangup
 signal and arranges for the shell to send it a hangup signal when the shell
 exits.
-Note that commands may set their own response to hangups, overriding \fIhup\fR.
+Note that commands may set their own response to hangups, overriding \fBhup\fR.
 Without an argument, causes the non-interactive shell only to
 exit on a hangup for the remainder of the script.
-See also \fBSignal handling\fR and the \fInohup\fR builtin command.
+See also \fBSignal handling\fR and the \fBnohup\fR builtin command.
 .TP 8
 .B if (\fIexpr\fB) \fIcommand
 If \fIexpr\fR (an expression, as described under \fBExpressions\fR)
 evaluates true, then \fIcommand\fR is executed.
 Variable substitution on \fIcommand\fR happens early, at the same time it
-does for the rest of the \fIif\fR command.
+does for the rest of the \fBif\fR command.
 \fIcommand\fR must be a simple command, not an alias, a pipeline, a command list
 or a parenthesized command list, but it may have arguments.
 Input/output redirection occurs even if \fIexpr\fR is
@@ -3031,13 +3040,13 @@ false and \fIcommand\fR is thus \fInot\fR executed; this is a bug.
 .TP 8
 .B endif
 If the specified \fIexpr\fR is true then the commands to the
-first \fIelse\fR are executed; otherwise if \fIexpr2\fR is true then
-the commands to the second \fIelse\fR are executed, etc.  Any
-number of \fIelse-if\fR pairs are possible; only one \fIendif\fR is
-needed.  The \fIelse\fR part is likewise optional.  (The words
-\fIelse\fR and \fIendif\fR must appear at the beginning of input lines;
-the \fIif\fR must appear alone on its input line or after an
-\fIelse\fR.)
+first \fBelse\fR are executed; otherwise if \fIexpr2\fR is true then
+the commands to the second \fBelse\fR are executed, etc.  Any
+number of \fBelse if\fR pairs are possible; only one \fBendif\fR is
+needed.  The \fBelse\fR part is likewise optional.  (The words
+\fBelse\fR and \fBendif\fR must appear at the beginning of input lines;
+the \fBif\fR must appear alone on its input line or after an
+\fBelse\fR.)
 .PD
 .TP 8
 .B inlib \fIshared-library\fR ... (+)
@@ -3055,7 +3064,7 @@ the site on which each job is executing.
 .RS +8
 .PP
 The \fB-Z\fR option sets the process title to \fItitle\fR using
-setproctitle(3) where available.
+\fIsetproctitle\fR(3) where available.
 If no \fItitle\fR is provided, the process title will be cleared.
 .RE
 .PP
@@ -3063,7 +3072,7 @@ If no \fItitle\fR is provided, the process title will be cleared.
 .PD 0
 .TP 8
 .B kill \-l
-The first and second forms sends the specified \fIsignal\fR (or, if none
+The first form sends the specified \fIsignal\fR (or, if none
 is given, the TERM (terminate) signal) to the specified jobs or processes.
 \fIjob\fR may be a number, a string, `', `%', `+' or `\-' as described
 under \fBJobs\fR.
@@ -3073,7 +3082,7 @@ There is no default \fIjob\fR; saying just `kill' does not send a signal
 to the current job.  If the signal being sent is TERM (terminate)
 or HUP (hangup), then the job or process is sent a
 CONT (continue) signal as well.
-The third form lists the signal names.
+The second form lists the signal names.
 .PD
 .TP 8
 .B limit \fR[\fB\-h\fR] [\fIresource\fR [\fImaximum-use\fR]]
@@ -3088,103 +3097,100 @@ limits.  Only the super-user may raise the hard limits, but
 a user may lower or raise the current limits within the legal range.
 .RS +8
 .PP
-Controllable resources currently include (if supported by the OS):
+Controllable \fIresource\fR types currently include (if supported by the OS):
 .TP
-\fIcputime\fR
+\fBcputime\fR
 the maximum number of cpu-seconds to be used by each process
 .TP
-\fIfilesize\fR
+\fBfilesize\fR
 the largest single file which can be created
 .TP
-\fIdatasize\fR
-the maximum growth of the data+stack region via sbrk(2) beyond
+\fBdatasize\fR
+the maximum growth of the data+stack region via \fIsbrk\fR(2) beyond
 the end of the program text
 .TP
-\fIstacksize\fR
+\fBstacksize\fR
 the maximum size of the automatically-extended stack region
 .TP
-\fIcoredumpsize\fR
+\fBcoredumpsize\fR
 the size of the largest core dump that will be created
 .TP
-\fImemoryuse\fR
+\fBmemoryuse\fR
 the maximum amount of physical memory a process
 may have allocated to it at a given time
 .TP
-\fIvmemoryuse\fR
+\fBvmemoryuse\fR
 the maximum amount of virtual memory a process
 may have allocated to it at a given time (address space)
 .TP
-\fIvmemoryuse\fR
-the maximum amount of virtual memory a process
-may have allocated to it at a given time
-.TP
-\fIheapsize\fR
+\fBheapsize\fR
 the maximum amount of memory a process
-may allocate per \fIbrk()\fR system call
+may allocate per \fIbrk\fR(2) system call
 .TP
-\fIdescriptors\fR or \fIopenfiles\fR
+\fBdescriptors\fR or \fBopenfiles\fR
 the maximum number of open files for this process
 .TP
-\fIpseudoterminals\fR
+\fBpseudoterminals\fR
 the maximum number of pseudo-terminals for this user
 .TP
-\fIkqueues\fR
+\fBkqueues\fR
 the maximum number of kqueues allocated for this process
 .TP
-\fIconcurrency\fR
+\fBconcurrency\fR
 the maximum number of threads for this process
 .TP
-\fImemorylocked\fR
-the maximum size which a process may lock into memory using mlock(2)
+\fBmemorylocked\fR
+the maximum size which a process may lock into memory using \fImlock\fR(2)
 .TP
-\fImaxproc\fR
+\fBmaxproc\fR
 the maximum number of simultaneous processes for this user id
 .TP
-\fImaxthread\fR
+\fBmaxthread\fR
 the maximum number of simultaneous threads (lightweight processes) for this
 user id
 .TP
-\fIthreads\fR
+\fBthreads\fR
 the maximum number of threads for this process
 .TP
-\fIsbsize\fR
+\fBsbsize\fR
 the maximum size of socket buffer usage for this user
 .TP
-\fIswapsize\fR
+\fBswapsize\fR
 the maximum amount of swap space reserved or used for this user
 .TP
-\fImaxlocks\fR
+\fBmaxlocks\fR
 the maximum number of locks for this user
 .TP
-\fIposixlocks\fR
+\fBposixlocks\fR
 the maximum number of POSIX advisory locks for this user
 .TP
-\fImaxsignal\fR
+\fBmaxsignal\fR
 the maximum number of pending signals for this user
 .TP
-\fImaxmessage\fR
+\fBmaxmessage\fR
 the maximum number of bytes in POSIX mqueues for this user
 .TP
-\fImaxnice\fR
+\fBmaxnice\fR
 the maximum nice priority the user is allowed to raise mapped from [19...-20]
 to [0...39] for this user
 .TP
-\fImaxrtprio\fR
+\fBmaxrtprio\fR
 the maximum realtime priority for this user
-\fImaxrttime\fR
-the timeout for RT tasks in microseconds for this user.
+.TP
+\fBmaxrttime\fR
+the timeout for RT tasks in microseconds for this user
 .PP
 \fImaximum-use\fR may be given as a (floating point or
 integer) number followed by a scale factor.  For all limits
-other than \fIcputime\fR the default scale is `k' or `kilobytes'
+other than \fBcputime\fR the default scale is `k' or `kilobytes'
 (1024 bytes); a scale factor of `m' or `megabytes' or `g' or `gigabytes'
-may also be used.  For \fIcputime\fR the default scaling is `seconds',
+may also be used.  For \fBcputime\fR the default scaling is `seconds',
 while `m' for minutes or `h' for hours, or a time of the
 form `mm:ss' giving minutes and seconds may be used.
 .PP
 If \fImaximum-use\fR  is `unlimited',
 then the limitation on the specified \fIresource\fR
-is removed (this is equivalent to the \fIunlimit\fR builtin command).
+is removed (this is equivalent to the \fBunlimit\fR builtin command).
 .PP
 For both \fIresource\fR names and scale factors, unambiguous
 prefixes of the names suffice.
@@ -3193,7 +3199,7 @@ prefixes of the names suffice.
 .B log \fR(+)
 Prints the \fBwatch\fR shell variable and reports on each user indicated
 in \fBwatch\fR who is logged in, regardless of when they last logged in.
-See also \fIwatchlog\fR.
+See also \fBwatchlog\fR.
 .TP 8
 .B login
 Terminates a login shell, replacing it with an instance of
@@ -3253,16 +3259,16 @@ Symbolic link to a directory
 Symbolic link to nowhere
 .PD
 .PP
-\fBlistlinks\fR also slows down \fIls\-F\fR and causes partitions holding
+\fBlistlinks\fR also slows down \fBls\-F\fR and causes partitions holding
 files pointed to by symbolic links to be mounted.
 .PP
 If the \fBlistflags\fR shell variable is set to `x', `a' or `A', or any
-combination thereof (e.g., `xA'), they are used as flags to \fIls\-F\fR,
+combination thereof (e.g., `xA'), they are used as flags to \fBls\-F\fR,
 making it act like `ls \-xF', `ls \-Fa', `ls \-FA' or a combination
 (e.g., `ls \-FxA').
-On machines where `ls \-C' is not the default, \fIls\-F\fR acts like `ls \-CF',
+On machines where `ls \-C' is not the default, \fBls\-F\fR acts like `ls \-CF',
 unless \fBlistflags\fR contains an `x', in which case it acts like `ls \-xF'.
-\fIls\-F\fR passes its arguments to \fIls\fR(1) if it is given any switches,
+\fBls\-F\fR passes its arguments to \fIls\fR(1) if it is given any switches,
 so `alias ls ls\-F' generally does the right thing.
 .PP
 The \fBls\-F\fR builtin can list files using different colors depending on the
@@ -3295,14 +3301,14 @@ The greater the \fInumber\fR, the less cpu
 the process gets.  The super-user may specify negative
 priority by using `nice \-number ...'.  Command is always
 executed in a sub-shell, and the restrictions placed on
-commands in simple \fIif\fR statements apply.
+commands in simple \fBif\fR statements apply.
 .TP 8
 .B nohup \fR[\fIcommand\fR]
 With \fIcommand\fR, runs \fIcommand\fR such that it will ignore hangup signals.
-Note that commands may set their own response to hangups, overriding \fInohup\fR.
+Note that commands may set their own response to hangups, overriding \fBnohup\fR.
 Without an argument, causes the non-interactive shell only to
 ignore hangups for the remainder of the script.
-See also \fBSignal handling\fR and the \fIhup\fR builtin command.
+See also \fBSignal handling\fR and the \fBhup\fR builtin command.
 .TP 8
 .B notify \fR[\fB%\fIjob\fR ...]
 Causes the shell to notify the user asynchronously when the status of any
@@ -3322,18 +3328,18 @@ With \fIlabel\fR, causes the shell to execute a `goto \fIlabel\fR'
 when an interrupt is received or a child process terminates because it was
 interrupted.
 .IP "" 8
-\fIonintr\fR is ignored if the shell is running detached and in system
+\fBonintr\fR is ignored if the shell is running detached and in system
 startup files (see \fBFILES\fR), where interrupts are disabled anyway.
 .TP 8
 .B popd \fR[\fB\-p\fR] [\fB\-l\fR] [\fB\-n\fR|\fB\-v\fR] \fR[\fB+\fIn\fR]
 Without arguments, pops the directory stack and returns to the new top directory.
-With a number `+\fIn\fR', discards the \fIn\fR'th entry in the stack.
+With a number `+\fIn\fR', discards the \fIn\fRth entry in the stack.
 .IP "" 8
-Finally, all forms of \fIpopd\fR print the final directory stack,
-just like \fIdirs\fR.  The \fBpushdsilent\fR shell variable can be set to
+Finally, all forms of \fBpopd\fR print the final directory stack,
+just like \fBdirs\fR.  The \fBpushdsilent\fR shell variable can be set to
 prevent this and the \fB\-p\fR flag can be given to override \fBpushdsilent\fR.
-The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fIpopd\fR
-as on \fIdirs\fR.  (+)
+The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fBpopd\fR
+as on \fBdirs\fR.  (+)
 .TP 8
 .B printenv \fR[\fIname\fR] (+)
 Prints the names and values of all environment variables or,
@@ -3341,24 +3347,24 @@ with \fIname\fR, the value of the environment variable \fIname\fR.
 .TP 8
 .B pushd \fR[\fB\-p\fR] [\fB\-l\fR] [\fB\-n\fR|\fB\-v\fR] [\fIname\fR|\fB+\fIn\fR]
 Without arguments, exchanges the top two elements of the directory stack.
-If \fBpushdtohome\fR is set, \fIpushd\fR without arguments does `pushd ~',
-like \fIcd\fR.  (+)
+If \fBpushdtohome\fR is set, \fBpushd\fR without arguments does `pushd ~',
+like \fBcd\fR.  (+)
 With \fIname\fR, pushes the current working directory onto the directory
 stack and changes to \fIname\fR.
 If \fIname\fR is `\-' it is interpreted as the previous working directory
 (see \fBFilename substitution\fR).  (+)
-If \fBdunique\fR is set, \fIpushd\fR removes any instances of \fIname\fR
+If \fBdunique\fR is set, \fBpushd\fR removes any instances of \fIname\fR
 from the stack before pushing it onto the stack.  (+)
 With a number `+\fIn\fR', rotates the \fIn\fRth element of the
 directory stack around to be the top element and changes to it.
 If \fBdextract\fR is set, however, `pushd +\fIn\fR' extracts the \fIn\fRth
 directory, pushes it onto the top of the stack and changes to it.  (+)
 .IP "" 8
-Finally, all forms of \fIpushd\fR print the final directory stack,
-just like \fIdirs\fR.  The \fBpushdsilent\fR shell variable can be set to
+Finally, all forms of \fBpushd\fR print the final directory stack,
+just like \fBdirs\fR.  The \fBpushdsilent\fR shell variable can be set to
 prevent this and the \fB\-p\fR flag can be given to override \fBpushdsilent\fR.
-The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fIpushd\fR
-as on \fIdirs\fR.  (+)
+The \fB\-l\fR, \fB\-n\fR and \fB\-v\fR flags have the same effect on \fBpushd\fR
+as on \fBdirs\fR.  (+)
 .TP 8
 .B rehash
 Causes the internal hash table of the contents of the
@@ -3374,7 +3380,7 @@ built by tilde expansion.
 .B repeat \fIcount command
 The specified \fIcommand\fR,
 which is subject to the same restrictions as the \fIcommand\fR
-in the one line \fIif\fR statement above, is executed \fIcount\fR times.
+in the one line \fBif\fR statement above, is executed \fIcount\fR times.
 I/O redirections occur exactly once, even if \fIcount\fR is 0.
 .TP 8
 .B rootnode //\fInodename \fR(+)
@@ -3435,7 +3441,7 @@ This mechanism is similar to, but not the same as, the \fIat\fR(1)
 command on some Unix systems.
 Its major disadvantage is that it may not run a command at exactly the
 specified time.
-Its major advantage is that because \fIsched\fR runs directly from
+Its major advantage is that because \fBsched\fR runs directly from
 the shell, it has access to shell variables and other structures.
 This provides a mechanism for changing one's working environment
 based on the time of day.
@@ -3480,7 +3486,7 @@ in a single set command.  Note, however, that variable expansion
 happens for all arguments before any setting occurs.  Note also that `=' can
 be adjacent to both \fIname\fR and \fIword\fR or separated from both by
 whitespace, but cannot be adjacent to only one or the other.
-See also the \fIunset\fR builtin command.
+See also the \fBunset\fR builtin command.
 .TP 8
 .B setenv \fR[\fIname \fR[\fIvalue\fR]]
 Without arguments, prints the names and values of all environment variables.
@@ -3503,11 +3509,11 @@ wrapping at the rightmost column.
 .B setty \fR[\fB\-d\fR|\fB\-q\fR|\fB\-x\fR] [\fB\-a\fR] [[\fB+\fR|\fB\-\fR]\fImode\fR] (+)
 Controls which tty modes (see \fBTerminal management\fR)
 the shell does not allow to change.
-\fB\-d\fR, \fB\-q\fR or \fB\-x\fR tells \fIsetty\fR to act
+\fB\-d\fR, \fB\-q\fR or \fB\-x\fR tells \fBsetty\fR to act
 on the `edit', `quote' or `execute' set of tty modes respectively; without
 \fB\-d\fR, \fB\-q\fR or \fB\-x\fR, `execute' is used.
 .IP "" 8
-Without other arguments, \fIsetty\fR lists the modes in the chosen set
+Without other arguments, \fBsetty\fR lists the modes in the chosen set
 which are fixed on (`+mode') or off (`\-mode').
 The available modes, and thus the display, vary from system to system.
 With \fB\-a\fR, lists all tty modes in the chosen set
@@ -3531,10 +3537,10 @@ same function on \fIvariable\fR.
 The shell reads and executes commands from \fIname\fR.
 The commands are not placed on the history list.
 If any \fIargs\fR are given, they are placed in \fBargv\fR.  (+)
-\fIsource\fR commands may be nested;
+\fBsource\fR commands may be nested;
 if they are nested too deeply the shell may run out of file descriptors.
-An error in a \fIsource\fR at any level terminates all nested
-\fIsource\fR commands.
+An error in a \fBsource\fR at any level terminates all nested
+\fBsource\fR commands.
 With \fB\-h\fR, commands are placed on the history list instead of being
 executed, much like `history \-L'.
 .TP 8
@@ -3575,19 +3581,19 @@ in the case labels, which are variable expanded.  If none
 of the labels match before a `default' label is found, then
 the execution begins after the default label.  Each case
 label and the default label must appear at the beginning of
-a line.  The command \fIbreaksw\fR causes execution to continue
-after the \fIendsw\fR.  Otherwise control may fall through case
+a line.  The command \fBbreaksw\fR causes execution to continue
+after the \fBendsw\fR.  Otherwise control may fall through case
 labels and default labels as in C.  If no label matches and
-there is no default, execution continues after the \fIendsw\fR.
+there is no default, execution continues after the \fBendsw\fR.
 .PD
 .TP 8
 .B telltc \fR(+)
 Lists the values of all terminal capabilities (see \fItermcap\fR(5)).
 .TP 8
-.B termname \fR[\fIterminal type\fR] \fR(+)
-Tests if \fIterminal type\fR (or the current value of \fBTERM\fR if no
-\fIterminal type\fR is given) has an entry in the hosts termcap(5) or
-terminfo(5) database. Prints the terminal type to stdout and returns 0
+.B termname \fR[\fItermtype\fR] \fR(+)
+Tests if \fItermtype\fR (or the current value of \fBTERM\fR if no
+\fItermtype\fR is given) has an entry in the hosts \fItermcap\fR(5) or
+\fIterminfo\fR(5) database. Prints the terminal type to stdout and returns 0
 if an entry is present otherwise returns 1.
 .TP 8
 .B time \fR[\fIcommand\fR]
@@ -3610,12 +3616,12 @@ Without \fIvalue\fR, prints the current file creation mask.
 .br
 Removes all aliases whose names match \fIpattern\fR.
 `unalias *' thus removes all aliases.
-It is not an error for nothing to be \fIunalias\fRed.
+It is not an error for nothing to be \fBunalias\fRed.
 .TP 8
 .B uncomplete \fIpattern\fR (+)
 Removes all completions whose names match \fIpattern\fR.
 `uncomplete *' thus removes all completions.
-It is not an error for nothing to be \fIuncomplete\fRd.
+It is not an error for nothing to be \fBuncomplete\fRd.
 .TP 8
 .B unhash
 Disables use of the internal hash table to speed location of
@@ -3630,20 +3636,20 @@ specified, all \fIresource\fR limitations.
 With \fB\-h\fR, the corresponding hard limits are removed.
 Only the super-user may do this.
 Note that \fBunlimit\fR may not exit successful, since most systems
-do not allow \fIdescriptors\fR to be unlimited.
+do not allow \fBdescriptors\fR to be unlimited.
 With \fB\-f\fR errors are ignored.
 .TP 8
 .B unset \fIpattern
 Removes all variables whose names match \fIpattern\fR, unless they are read-only.
 `unset *' thus removes all variables unless they are read-only;
 this is a bad idea.
-It is not an error for nothing to be \fIunset\fR.
+It is not an error for nothing to be \fBunset\fR.
 .TP 8
 .B unsetenv \fIpattern
 Removes all environment variables whose names match \fIpattern\fR.
 `unsetenv *' thus removes all environment variables;
 this is a bad idea.
-It is not an error for nothing to be \fIunsetenv\fRed.
+It is not an error for nothing to be \fBunsetenv\fRed.
 .TP 8
 .B ver \fR[\fIsystype\fR [\fIcommand\fR]] (+)
 Without arguments, prints \fBSYSTYPE\fR.  With \fIsystype\fR, sets \fBSYSTYPE\fR
@@ -3660,7 +3666,7 @@ numbers of all outstanding jobs.
 Sets the universe to \fIuniverse\fR.  (Convex/OS only)
 .TP 8
 .B watchlog \fR(+)
-An alternate name for the \fIlog\fR builtin command (q.v.).
+An alternate name for the \fBlog\fR builtin command (q.v.).
 Available only if the shell was so compiled;
 see the \fBversion\fR shell variable.
 .TP 8
@@ -3673,7 +3679,7 @@ Displays the command that will be executed by the shell after substitutions,
 \fBpath\fR searching, etc.
 The builtin command is just like \fIwhich\fR(1), but it correctly reports
 \fItcsh\fR aliases and builtins and is 10 to 100 times faster.
-See also the \fIwhich-command\fR editor command.
+See also the \fBwhich-command\fR editor command.
 .PP
 .B while (\fIexpr\fB)\fR
 .br
@@ -3681,14 +3687,14 @@ See also the \fIwhich-command\fR editor command.
 .PD 0
 .TP 8
 .B end
-Executes the commands between the \fIwhile\fR and the matching \fIend\fR
+Executes the commands between the \fBwhile\fR and the matching \fBend\fR
 while \fIexpr\fR (an expression, as described under \fBExpressions\fR)
 evaluates non-zero.
-\fIwhile\fR and \fIend\fR must appear alone on their input lines.
-\fIbreak\fR and \fIcontinue\fR may be used to terminate or continue the
+\fBwhile\fR and \fBend\fR must appear alone on their input lines.
+\fBbreak\fR and \fBcontinue\fR may be used to terminate or continue the
 loop prematurely.
 If the input is a terminal, the user is prompted the first time
-through the loop as with \fIforeach\fR.
+through the loop as with \fBforeach\fR.
 .PD
 .SS "Special aliases (+)"
 If set, each of these aliases executes automatically at the indicated time.
@@ -3714,14 +3720,14 @@ A fancier way to do that is
 This will put the hostname and working directory on the title bar but
 only the hostname in the icon manager menu.
 .PP
-Note that putting a \fIcd\fR, \fIpushd\fR or \fIpopd\fR in \fIcwdcmd\fR
+Note that putting a \fBcd\fR, \fBpushd\fR or \fBpopd\fR in \fBcwdcmd\fR
 may cause an infinite loop.  It is the author's opinion that anyone doing
 so will get what they deserve.
 .RE
 .TP 8
 .B jobcmd
 Runs before each command gets executed, or when the command changes state.
-This is similar to \fIpostcmd\fR, but it does not print builtins.
+This is similar to \fBpostcmd\fR, but it does not print builtins.
 .RS +8
 .IP "" 4
 > alias jobcmd  'echo \-n "^[]2\e;\e!#:q^G"'
@@ -3754,8 +3760,8 @@ if one does
 > alias periodic checknews
 .PP
 then the \fIchecknews\fR(1) program runs every 30 minutes.
-If \fIperiodic\fR is set but \fBtperiod\fR is unset or set to 0,
-\fIperiodic\fR behaves like \fIprecmd\fR.
+If \fBperiodic\fR is set but \fBtperiod\fR is unset or set to 0,
+\fBperiodic\fR behaves like \fBprecmd\fR.
 .RE
 .TP 8
 .B precmd
@@ -3765,7 +3771,7 @@ Runs just before each prompt is printed.  For example, if one does
 > alias precmd date
 .PP
 then \fIdate\fR(1) runs just before the shell prompts for each command.
-There are no limits on what \fIprecmd\fR can be set to do, but discretion
+There are no limits on what \fBprecmd\fR can be set to do, but discretion
 should be used.
 .RE
 .TP 8
@@ -3824,12 +3830,12 @@ i.e., `$1' is replaced by `$argv[1]', etc.
 Set by default, but usually empty in interactive shells.
 .TP 8
 .B autocorrect \fR(+)
-If set, the \fIspell-word\fR editor command is invoked automatically before
+If set, the \fBspell-word\fR editor command is invoked automatically before
 each completion attempt.
 .TP 8
 .B autoexpand \fR(+)
-If set, the \fIexpand-history\fR editor command is invoked automatically
-before each completion attempt. If this is set to \fIonlyhistory\fR, then
+If set, the \fBexpand-history\fR editor command is invoked automatically
+before each completion attempt. If this is set to \fBonlyhistory\fR, then
 only history will be expanded and a second completion will expand filenames.
 .TP 8
 .B autolist \fR(+)
@@ -3843,14 +3849,14 @@ logout.  The optional second word is the number of minutes of inactivity
 before automatic locking.
 When the shell automatically logs out, it prints `auto-logout', sets the
 variable \fBlogout\fR to `automatic' and exits.
-When the shell automatically locks, the user is required to enter his password
+When the shell automatically locks, the user is required to enter their password
 to continue working.  Five incorrect attempts result in automatic logout.
 Set to `60' (automatic logout after 60 minutes, and no locking) by default
 in login and superuser shells, but not if the shell thinks it is running
 under a window system (i.e., the \fBDISPLAY\fR environment variable is set),
 the tty is a pseudo-tty (pty) or the shell was not so compiled (see the
 \fBversion\fR shell variable).
-Unset or set to `0' to disable automatic logout.
+Unset \fBautologout\fR or set it to `0' to disable automatic logout.
 See also the \fBafsuser\fR and \fBlogout\fR shell variables.
 .TP 8
 .B autorehash \fR(+)
@@ -3869,15 +3875,15 @@ scripts.
 .TP 8
 .B catalog
 The file name of the message catalog.
-If set, tcsh use `tcsh.${catalog}' as a message catalog instead of
+If set, tcsh uses `tcsh.${catalog}' as a message catalog instead of
 default `tcsh'.
 .TP 8
 .B cdpath
-A list of directories in which \fIcd\fR should search for
+A list of directories in which \fBcd\fR should search for
 subdirectories if they aren't found in the current directory.
 .TP 8
 .B cdtohome \fR(+)
-If not set, \fIcd\fR requires a directory \fIname\fR, and will not go to the
+If not set, \fBcd\fR requires a directory \fIname\fR, and will not go to the
 \fBhome\fR directory if it's omitted.
 This is set by default.
 .TP 8
@@ -3971,13 +3977,13 @@ character
 .\" (position in this table?)
 is set to number 0,1,2 and 3.  Each number has the following meaning:
 .br
-  0 ... not used for multi-byte characters.
+  0 Not used for multi-byte characters.
 .br
-  1 ... used for the first byte of a multi-byte character.
+  1 Used for the first byte of a multi-byte character.
 .br
-  2 ... used for the second byte of a multi-byte character.
+  2 Used for the second byte of a multi-byte character.
 .br
-  3 ... used for both the first byte and second byte of a multi-byte character.
+  3 Used for both the first byte and second byte of a multi-byte character.
 .\" SHK: I tried my best to get the following to be grammatically correct.
 .\" However, I still don't understand what's going on here.  In the
 .\" following example, there are three bytes, but the text seems to refer to
@@ -3993,13 +3999,13 @@ If set to `001322', the first character (means 0x00 of the ASCII code) and
 second character (means 0x01 of ASCII code) are set to `0'.  Then, it is not
 used for multi-byte characters.  The 3rd character (0x02) is set to '1',
 indicating that it is used for the first byte of a multi-byte character.
-The 4th character(0x03) is set '3'.  It is used for both the first byte and
+The 4th character (0x03) is set '3'.  It is used for both the first byte and
 the second byte of a multi-byte character.  The 5th and 6th characters
 (0x04,0x05) are set to '2', indicating that they are used for the second
 byte of a multi-byte character.
 .PP
 The GNU fileutils version of ls cannot display multi-byte
-filenames without the -N ( --literal ) option.   If you are using
+filenames without the -N (--literal) option.   If you are using
 this version, set the second word of dspmbyte to "ls".  If not, for
 example, "ls-F -l" cannot display multi-byte filenames.
 .PP
@@ -4010,7 +4016,7 @@ compile time.
 .RE
 .TP 8
 .B dunique \fR(+)
-If set, \fIpushd\fR removes any instances of \fIname\fR
+If set, \fBpushd\fR removes any instances of \fIname\fR
 from the stack before pushing it onto the stack.
 .TP 8
 .B echo
@@ -4021,7 +4027,7 @@ substitution, because these substitutions are then done selectively.
 Set by the \fB\-x\fR command line option.
 .TP 8
 .B echo_style \fR(+)
-The style of the \fIecho\fR builtin.  May be set to
+The style of the \fBecho\fR builtin.  May be set to
 .PP
 .RS +8
 .PD 0
@@ -4050,12 +4056,12 @@ If set, the command-line editor is used.  Set by default in interactive
 shells.
 .TP 8
 .B editors \fR(+)
-A list of command names for the \fIrun-fg-editor\fR editor command to match.
+A list of command names for the \fBrun-fg-editor\fR editor command to match.
 If not set, the \fBEDITOR\fR (`ed' if unset) and \fBVISUAL\fR (`vi' if unset)
 environment variables will be used instead.
 .TP 8
 .B ellipsis \fR(+)
-If set, the `%c'/`%.' and `%C' prompt sequences (see the \fBprompt\fR
+If set, the `%c', `%.' and `%C' prompt sequences (see the \fBprompt\fR
 shell variable) indicate skipped directories with an ellipsis (`...')
 instead of `/<skipped>'.
 .TP 8
@@ -4070,7 +4076,7 @@ Lists file name suffixes to be ignored by completion.
 .TP 8
 .B filec
 In \fItcsh\fR, completion is always used and this variable is ignored
-by default. If 
+by default. If
 .B edit
 is unset, then the traditional \fIcsh\fR completion is used.
 If set in \fIcsh\fR, filename completion is used.
@@ -4080,26 +4086,26 @@ The user's real group ID.
 .TP 8
 .B globdot \fR(+)
 If set, wild-card glob patterns will match files and directories beginning
-with `.' except for `.' and `..'
+with `.' except for `.' and `..'.
 .TP 8
 .B globstar \fR(+)
-If set, the `**' and `***' file glob patterns will match any string of 
-characters including `/' traversing any existing sub-directories.  (e.g. 
+If set, the `**' and `***' file glob patterns will match any string of
+characters including `/' traversing any existing sub-directories.  (e.g.
 `ls **.c' will list all the .c files in the current directory tree).
 If used by itself, it will match zero or more sub-directories
 (e.g. `ls /usr/include/**/time.h' will list any file named `time.h'
 in the /usr/include directory tree; whereas `ls /usr/include/**time.h'
 will match any file in the /usr/include directory tree ending in `time.h').
-To prevent problems with recursion, the `**' glob-pattern will not 
+To prevent problems with recursion, the `**' glob-pattern will not
 descend into a symbolic link containing a directory.  To override this,
-use `***'
+use `***'.
 .TP 8
 .B group \fR(+)
 The user's group name.
 .TP 8
 .B highlight
-If set, the incremental search match (in \fIi-search-back\fR and
-\fIi-search-fwd\fR) and the region between the mark and the cursor are
+If set, the incremental search match (in \fBi-search-back\fR and
+\fBi-search-fwd\fR) and the region between the mark and the cursor are
 highlighted in reverse video.
 .IP "" 8
 Highlighting requires more frequent terminal writes, which introduces extra
@@ -4134,7 +4140,7 @@ or when saving separate histories on different terminals.  Because only
 .B histlit \fR(+)
 If set, builtin and editor commands and the \fBsavehist\fR mechanism
 use the literal (unexpanded) form of lines in the history list.  See
-also the \fItoggle-literal-history\fR editor command.
+also the \fBtoggle-literal-history\fR editor command.
 .TP 8
 .B history
 The first word indicates the number of history events to save.  The
@@ -4149,18 +4155,18 @@ expansion of `\fI~\fR' refers to this variable.
 .TP 8
 .B ignoreeof
 If set to the empty string or `0' and the input device is a terminal,
-the \fIend-of-file\fR command (usually generated by the user by typing
+the \fBend-of-file\fR command (usually generated by the user by typing
 `^D' on an empty line) causes the shell to print `Use "exit" to leave
 tcsh.' instead of exiting.  This prevents the shell from accidentally
 being killed.  Historically this setting exited after 26 successive
 EOF's to avoid infinite loops.  If set to a number \fIn\fR, the shell
-ignores \fIn - 1\fR consecutive \fIend-of-file\fRs and exits on the
+ignores \fIn - 1\fR consecutive \fBend-of-file\fRs and exits on the
 \fIn\fRth.  (+) If unset, `1' is used, i.e., the shell exits on a
 single `^D'.
 .TP 8
 .B implicitcd \fR(+)
 If set, the shell treats a directory name typed as a command as though
-it were a request to change to that directory.  If set to \fIverbose\fR,
+it were a request to change to that directory.  If set to \fBverbose\fR,
 the change of directory is echoed to the standard output.  This behavior
 is inhibited in non-interactive shell scripts, or for command strings
 with more than one word.  Changing directory takes precedence over
@@ -4184,34 +4190,34 @@ Indicates the number of killed strings to keep in memory.  Set to `30'
 by default.  If unset or set to less than `2', the shell will only
 keep the most recently killed string.
 Strings are put in the killring by the editor commands that delete
-(kill) strings of text, e.g. \fIbackward-delete-word\fR,
-\fIkill-line\fR, etc, as well as the \fIcopy-region-as-kill\fR command.
-The \fIyank\fR editor command will yank the most recently killed string
-into the command-line, while \fIyank-pop\fR (see \fBEditor commands\fR)
+(kill) strings of text, e.g. \fBbackward-delete-word\fR,
+\fBkill-line\fR, etc, as well as the \fBcopy-region-as-kill\fR command.
+The \fByank\fR editor command will yank the most recently killed string
+into the command-line, while \fByank-pop\fR (see \fBEditor commands\fR)
 can be used to yank earlier killed strings.
 .TP 8
 .B listflags \fR(+)
 If set to `x', `a' or `A', or any combination thereof (e.g., `xA'), they
-are used as flags to \fIls\-F\fR, making it act like `ls \-xF', `ls
+are used as flags to \fBls\-F\fR, making it act like `ls \-xF', `ls
 \-Fa', `ls \-FA' or a combination (e.g., `ls \-FxA'): `a' shows all
 files (even if they start with a `.'), `A' shows all files but `.' and
 `..', and `x' sorts across instead of down.  If the second word of
-\fBlistflags\fR is set, it is used as the path to `ls(1)'.
+\fBlistflags\fR is set, it is used as the path to `\fIls\fR(1)'.
 .TP 8
 .B listjobs \fR(+)
 If set, all jobs are listed when a job is suspended.  If set to `long',
 the listing is in long format.
 .TP 8
 .B listlinks \fR(+)
-If set, the \fIls\-F\fR builtin command shows the type of file to which
+If set, the \fBls\-F\fR builtin command shows the type of file to which
 each symbolic link points.
 .TP 8
 .B listmax \fR(+)
-The maximum number of items which the \fIlist-choices\fR editor command
+The maximum number of items which the \fBlist-choices\fR editor command
 will list without asking first.
 .TP 8
 .B listmaxrows \fR(+)
-The maximum number of rows of items which the \fIlist-choices\fR editor
+The maximum number of rows of items which the \fBlist-choices\fR editor
 command will list without asking first.
 .TP 8
 .B loginsh \fR(+)
@@ -4304,12 +4310,12 @@ The default is to present job completions just before printing a prompt.
 The user's real organization ID.  (Domain/OS only)
 .TP 8
 .B owd \fR(+)
-The old working directory, equivalent to the `\-' used by \fIcd\fR and \fIpushd\fR.
+The old working directory, equivalent to the `\-' used by \fBcd\fR and \fBpushd\fR.
 See also the \fBcwd\fR and \fBdirstack\fR shell variables.
 .TP 8
 .B padhour
 If set, enable the printing of padding '0' for hours, in 24 and 12 hour
-formats.  E.G.: 07:45:42 vs. 7:45:42.
+formats.  E.g., `07:45:42' versus `7:45:42'.
 .TP 8
 .B parseoctal
 To retain compatibily with older versions numeric variables starting with
@@ -4329,7 +4335,7 @@ A shell which is given neither the \fB\-c\fR nor the \fB\-t\fR option
 hashes the contents of the directories in \fBpath\fR after
 reading \fI~/.tcshrc\fR and each time \fBpath\fR is reset.
 If one adds a new command to a directory in \fBpath\fR while the shell
-is active, one may need to do a \fIrehash\fR for the shell to find it.
+is active, one may need to do a \fBrehash\fR for the shell to find it.
 .TP 8
 .B printexitvalue \fR(+)
 If set and an interactive program exits with a non-zero status, the shell
@@ -4364,7 +4370,7 @@ are represented by an ellipsis so the whole becomes `...trailing'.
 is ignored when counting trailing components.
 .TP 4
 %C
-Like %c, but without `~' substitution.
+Like `%c', but without `~' substitution.
 .TP 4
 %h, %!, !
 The current history event number.
@@ -4397,10 +4403,10 @@ The `precise' time of day in 12-hour AM/PM format, with seconds.
 Like `%p', but in 24-hour format (but see the \fBampm\fR shell variable).
 .TP 4
 \e\fIc\fR
-\fIc\fR is parsed as in \fIbindkey\fR.
+\fIc\fR is parsed as in \fBbindkey\fR.
 .TP 4
 ^\fIc\fR
-\fIc\fR is parsed as in \fIbindkey\fR.
+\fIc\fR is parsed as in \fBbindkey\fR.
 .TP 4
 %%
 A single `%'.
@@ -4479,7 +4485,7 @@ Set by default to `%# ' in interactive shells.
 .RE
 .TP 8
 .B prompt2 \fR(+)
-The string with which to prompt in \fIwhile\fR and \fIforeach\fR loops and
+The string with which to prompt in \fBwhile\fR and \fBforeach\fR loops and
 after lines ending in `\e'.
 The same format sequences may be used as in \fBprompt\fR (q.v.);
 note the variable meaning of `%R'.
@@ -4497,10 +4503,10 @@ If set (to a two-character string), the `%#' formatting sequence in the
 normal users and the second character for the superuser.
 .TP 8
 .B pushdtohome \fR(+)
-If set, \fIpushd\fR without arguments does `pushd ~', like \fIcd\fR.
+If set, \fBpushd\fR without arguments does `pushd ~', like \fBcd\fR.
 .TP 8
 .B pushdsilent \fR(+)
-If set, \fIpushd\fR and \fIpopd\fR do not print the directory stack.
+If set, \fBpushd\fR and \fBpopd\fR do not print the directory stack.
 .TP 8
 .B recexact \fR(+)
 If set, completion completes on an exact match even if a longer match is
@@ -4533,7 +4539,7 @@ If set, the shell does `history \-S' before exiting.
 If the first word is set to a number, at most that many lines are saved.
 (The number should be less than or equal to the number \fBhistory\fR entries;
 if it is set to greater than the number of \fBhistory\fR settings, only
-\fBhistory\fR entries will be saved)
+\fBhistory\fR entries will be saved.)
 If the second word is set to `merge', the history list is merged with
 the existing history file instead of replacing it (if there is one) and
 sorted by time stamp and the most recent events are retained.
@@ -4542,7 +4548,7 @@ If the second word of \fBsavehist\fR is `merge' and the third word is set to
 that would possibly like to merge history at exactly the same time. (+)
 .TP 8
 .B sched \fR(+)
-The format in which the \fIsched\fR builtin command prints scheduled events;
+The format in which the \fBsched\fR builtin command prints scheduled events;
 if not given, `%h\et%T\et%R\en' is used.
 The format sequences are described above under \fBprompt\fR;
 note the variable meaning of `%R'.
@@ -4589,7 +4595,7 @@ this is a bug.
 .PP
 If set to `ignore', the shell tries to construct a current directory
 relative to the current directory before the link was crossed.
-This means that \fIcd\fRing through a symbolic link and then `cd ..'ing
+This means that \fBcd\fRing through a symbolic link and then `cd ..'ing
 returns one to the original directory.  This affects only builtin commands
 and filename completion.
 .PP
@@ -4600,7 +4606,7 @@ such as those embedded in command options.  Expansion may be prevented by
 quoting.  While this setting is usually the most convenient, it is sometimes
 misleading and sometimes confusing when it fails to recognize an argument
 which should be expanded.  A compromise is to use `ignore' and use the
-editor command \fInormalize-path\fR (bound by default to ^X-n) when necessary.
+editor command \fBnormalize-path\fR (bound by default to ^X-n) when necessary.
 .PP
 Some examples are in order.  First, let's set up some play directories:
 .IP "" 4
@@ -4667,7 +4673,7 @@ and here's the behavior with \fBsymlinks\fR set to `expand'.
 \&..
 .PP
 Note that `expand' expansion 1) works just like `ignore' for builtins
-like \fIcd\fR, 2) is prevented by quoting, and 3) happens before
+like \fBcd\fR, 2) is prevented by quoting, and 3) happens before
 filenames are passed to non-builtin commands.
 .RE
 .TP 8
@@ -4681,10 +4687,10 @@ The terminal type.  Usually set in \fI~/.login\fR as described under
 \fBStartup and shutdown\fR.
 .TP 8
 .B time
-If set to a number, then the \fItime\fR builtin (q.v.) executes automatically
+If set to a number, then the \fBtime\fR builtin (q.v.) executes automatically
 after each command which takes more than that many CPU seconds.
 If there is a second word, it is used as a format string for the output
-of the \fItime\fR builtin.  (u) The following sequences may be used in the
+of the \fBtime\fR builtin.  (u) The following sequences may be used in the
 format string:
 .PP
 .RS +8
@@ -4786,7 +4792,7 @@ Note that the CPU percentage can be higher than 100% on multi-processors.
 .RE
 .TP 8
 .B tperiod \fR(+)
-The period, in minutes, between executions of the \fIperiodic\fR special alias.
+The period, in minutes, between executions of the \fBperiodic\fR special alias.
 .TP 8
 .B tty \fR(+)
 The name of the tty, or empty if not attached to one.
@@ -4842,8 +4848,8 @@ dtr
 Login shells drop DTR when exiting
 .TP 6
 bye
-\fIbye\fR is a synonym for \fIlogout\fR and \fIlog\fR
-is an alternate name for \fIwatchlog\fR
+\fBbye\fR is a synonym for \fBlogout\fR and \fBlog\fR
+is an alternate name for \fBwatchlog\fR
 .TP 6
 al
 \fBautologout\fR is enabled; default
@@ -4859,7 +4865,7 @@ hb
 The `#!<program> <args>' convention is emulated when executing shell scripts
 .TP 6
 ng
-The \fInewgrp\fR builtin is available
+The \fBnewgrp\fR builtin is available
 .TP 6
 rh
 The shell attempts to set the \fBREMOTEHOST\fR environment variable
@@ -4876,18 +4882,18 @@ in the local version.
 .TP 8
 .B vimode \fR(+)
 .RS +8
-If unset, various key bindings change behavior to be more \fBemacs\fR(1)\-style:
+If unset, various key bindings change behavior to be more \fIemacs\fR(1)\-style:
 word boundaries are determined by \fBwordchars\fR versus other characters.
 .PP
-If set, various key bindings change behavior to be more \fBvi\fR(1)\-style:
+If set, various key bindings change behavior to be more \fIvi\fR(1)\-style:
 word boundaries are determined by \fBwordchars\fR versus whitespace
 versus other characters;
 cursor behavior depends upon current vi mode (command, delete, insert, replace).
 .PP
-This variable is unset by \fIbindkey\fR \fB-e\fR and
-set by \fIbindkey\fR \fB-v\fR.
+This variable is unset by \fBbindkey\fR \fB-e\fR and
+set by \fBbindkey\fR \fB-v\fR.
 .B vimode
-may be explicitly set or unset by the user after those \fIbindkey\fR
+may be explicitly set or unset by the user after those \fBbindkey\fR
 operations if required.
 .RE
 .TP 8
@@ -4905,7 +4911,7 @@ For example,
 .IP "" 4
 set watch = (george ttyd1 any console $user any)
 .PP
-reports activity of the user `george' on ttyd1, any user on the console, and
+reports activity of the user `george' on `ttyd1', any user on the console, and
 oneself (or a trespasser) on any terminal.
 .PP
 Logins and logouts are checked every 10 minutes by default, but the first
@@ -4914,9 +4920,9 @@ For example,
 .IP "" 4
 set watch = (1 any any)
 .PP
-reports any login/logout once every minute.  For the impatient, the \fIlog\fR
+reports any login/logout once every minute.  For the impatient, the \fBlog\fR
 builtin command triggers a \fBwatch\fR report at any time.  All current logins
-are reported (as with the \fIlog\fR builtin) when \fBwatch\fR is first set.
+are reported (as with the \fBlog\fR builtin) when \fBwatch\fR is first set.
 .PP
 The \fBwho\fR shell variable controls the format of \fBwatch\fR reports.
 .RE
@@ -4954,7 +4960,7 @@ which don't store the remote hostname.
 .TP 8
 .B wordchars \fR(+)
 A list of non-alphanumeric characters to be considered part of a word by the
-\fIforward-word\fR, \fIbackward-word\fR etc., editor commands.
+\fBforward-word\fR, \fBbackward-word\fR etc., editor commands.
 If unset, the default value is determined based on the state of \fBvimode\fR:
 if \fBvimode\fR is unset, `*?_\-.[]~=' is used as the default;
 if \fBvimode\fR is set, `_' is used as the default.
@@ -4972,7 +4978,7 @@ If set, the shell does not set \fBautologout\fR (q.v.).
 .TP 8
 .B EDITOR
 The pathname to a default editor.
-Used by the \fIrun-fg-editor\fR editor command if the
+Used by the \fBrun-fg-editor\fR editor command if the
 the \fBeditors\fR shell variable is unset.
 See also the \fBVISUAL\fR environment variable.
 .TP 8
@@ -4992,7 +4998,7 @@ is running, as determined at compile time.  This variable is obsolete and
 will be removed in a future version.
 .TP 8
 .B HPATH \fR(+)
-A colon-separated list of directories in which the \fIrun-help\fR editor
+A colon-separated list of directories in which the \fBrun-help\fR editor
 command looks for command documentation.
 .TP 8
 .B LANG
@@ -5007,7 +5013,7 @@ See \fBNative Language System support\fR.
 The number of lines in the terminal.  See \fBTerminal management\fR.
 .TP 8
 .B LS_COLORS
-The format of this variable is reminiscent of the \fBtermcap(5)\fR
+The format of this variable is reminiscent of the \fItermcap\fR(5)
 file format; a colon-separated list of expressions of the form
 "\fIxx=string\fR", where "\fIxx\fR" is a two-character variable name.  The
 variables with their associated defaults are:
@@ -5079,10 +5085,10 @@ and \fB?\fR for Delete.  In addition, the \fB^[\fR escape character
 can be used to override the default interpretation of \fB^[\fR,
 \fB^\fR, \fB:\fR and \fB=\fR.
 .PP
-Each file will be written as \fB<lc>\fR \fB<color-code>\fR
-\fB<rc>\fR \fB<filename>\fR \fB<ec>\fR.  If the \fB<ec>\fR
-code is undefined, the sequence \fB<lc>\fR \fB<no>
-\fB<rc>\fR will be used instead.  This is generally more convenient
+Each file will be written as `\fB<lc>\fR \fB<color-code>\fR
+\fB<rc>\fR \fB<filename>\fR \fB<ec>\fR'.  If the \fB<ec>\fR
+code is undefined, the sequence `\fB<lc>\fR \fB<no>
+\fB<rc>\fR' will be used instead.  This is generally more convenient
 to use, but less general.  The left, right and end codes are
 provided so you don't have to type common parts over and over
 again and to support weird terminals; you will generally not
@@ -5174,7 +5180,7 @@ the file color the same as the color of the link target.
 The machine type (microprocessor class or machine model), as determined at compile time.
 .TP 8
 .B NOREBIND \fR(+)
-If set, printable characters are not rebound to \fIself-insert-command\fR.
+If set, printable characters are not rebound to \fBself-insert-command\fR.
 See \fBNative Language System support\fR.
 .TP 8
 .B OSTYPE \fR(+)
@@ -5213,7 +5219,7 @@ The vendor, as determined at compile time.
 .TP 8
 .B VISUAL
 The pathname to a default full-screen editor.
-Used by the \fIrun-fg-editor\fR editor command if the
+Used by the \fBrun-fg-editor\fR editor command if the
 the \fBeditors\fR shell variable is unset.
 See also the \fBEDITOR\fR environment variable.
 .SH FILES
@@ -5239,8 +5245,8 @@ Read by every shell after \fI/etc/csh.cshrc\fR or its equivalent.
 .I ~/.cshrc
 Read by every shell, if \fI~/.tcshrc\fR doesn't exist,
 after \fI/etc/csh.cshrc\fR or its equivalent.
-This manual uses `\fI~/.tcshrc\fR' to mean `\fI~/.tcshrc\fR or,
-if \fI~/.tcshrc\fR is not found, \fI~/.cshrc\fR'.
+This manual uses `\fI~/.tcshrc\fR' to mean ``\fI~/.tcshrc\fR or,
+if \fI~/.tcshrc\fR is not found, \fI~/.cshrc\fR''.
 .TP 16
 .I ~/.history
 Read by login shells after \fI~/.tcshrc\fR
@@ -5288,33 +5294,39 @@ or \fIvi\fR(1)\-style key bindings.
 See \fBThe command-line editor\fR and \fBEditor commands\fR.
 .PP
 Programmable, interactive word completion and listing.
-See \fBCompletion and listing\fR and the \fIcomplete\fR and \fIuncomplete\fR
+See \fBCompletion and listing\fR and the \fBcomplete\fR and \fBuncomplete\fR
 builtin commands.
 .PP
 \fBSpelling correction\fR (q.v.) of filenames, commands and variables.
 .PP
 \fBEditor commands\fR (q.v.) which perform other useful functions in the middle of
-typed commands, including documentation lookup (\fIrun-help\fR),
-quick editor restarting (\fIrun-fg-editor\fR) and
-command resolution (\fIwhich-command\fR).
+typed commands, including documentation lookup (\fBrun-help\fR),
+quick editor restarting (\fBrun-fg-editor\fR) and
+command resolution (\fBwhich-command\fR).
 .PP
 An enhanced history mechanism.  Events in the history list are time-stamped.
-See also the \fIhistory\fR command and its associated shell variables,
+See also the \fBhistory\fR command and its associated shell variables,
 the previously undocumented `#' event specifier and new modifiers
 under \fBHistory substitution\fR,
-the \fI*-history\fR, \fIhistory-search-*\fR, \fIi-search-*\fR, \fIvi-search-*\fR and
-\fItoggle-literal-history\fR editor commands
+the \fBdown-history\fR, \fBexpand-history\fR,
+\fBhistory-search-backward\fR, \fBhistory-search-forward\fR,
+\fBi-search-back\fR, \fBi-search-fwd\fR,
+\fBtoggle-literal-history\fR,
+\fBvi-search-back\fR, \fBvi-search-fwd\fR,
+and
+\fBup-history\fR
+editor commands
 and the \fBhistlit\fR shell variable.
 .PP
 Enhanced directory parsing and directory stack handling.
-See the \fIcd\fR, \fIpushd\fR, \fIpopd\fR and \fIdirs\fR commands and their associated
+See the \fBcd\fR, \fBpushd\fR, \fBpopd\fR and \fBdirs\fR commands and their associated
 shell variables, the description of \fBDirectory stack substitution\fR,
 the \fBdirstack\fR, \fBowd\fR and \fBsymlinks\fR shell variables and
-the \fInormalize-command\fR and \fInormalize-path\fR editor commands.
+the \fBnormalize-command\fR and \fBnormalize-path\fR editor commands.
 .PP
 Negation in glob-patterns.  See \fBFilename substitution\fR.
 .PP
-New \fBFile inquiry operators\fR (q.v.) and a \fIfiletest\fR
+New \fBFile inquiry operators\fR (q.v.) and a \fBfiletest\fR
 builtin which uses them.
 .PP
 A variety of \fBAutomatic, periodic and timed events\fR (q.v.) including
@@ -5329,8 +5341,8 @@ and system-dependent file locations (see \fBFILES\fR).
 .PP
 Extensive terminal-management capabilities.  See \fBTerminal management\fR.
 .PP
-New builtin commands including \fIbuiltins\fR, \fIhup\fR, \fIls\-F\fR,
-\fInewgrp\fR, \fIprintenv\fR, \fIwhich\fR and \fIwhere\fR (q.v.).
+New builtin commands including \fBbuiltins\fR, \fBhup\fR, \fBls\-F\fR,
+\fBnewgrp\fR, \fBprintenv\fR, \fBwhich\fR and \fBwhere\fR (q.v.).
 .PP
 New variables that make useful information easily available to the shell.
 See the \fBgid\fR, \fBloginsh\fR, \fBoid\fR, \fBshlvl\fR, \fBtcsh\fR,
@@ -5353,7 +5365,7 @@ Shell builtin functions are not stoppable/restartable.  Command sequences
 of the form `a ; b ; c' are also not handled gracefully when stopping is
 attempted.  If you suspend `b', the shell will then immediately execute
 `c'.  This is especially noticeable if this expansion results from an
-\fIalias\fR.  It suffices to place the sequence of commands in ()'s to force it
+\fBalias\fR.  It suffices to place the sequence of commands in ()'s to force it
 to a subshell, i.e., `( a ; b ; c )'.
 .PP
 Control over tty output after processes are started is primitive; perhaps
@@ -5368,7 +5380,7 @@ Control structures should be parsed rather than being recognized as
 built-in commands.  This would allow control commands to be placed anywhere,
 to be combined with `|', and to be used with `&' and `;' metasyntax.
 .PP
-\fIforeach\fR doesn't ignore here documents when looking for its \fIend\fR.
+\fBforeach\fR doesn't ignore here documents when looking for its \fBend\fR.
 .PP
 It should be possible to use the `:' modifiers on the output of command
 substitutions.
@@ -5381,15 +5393,15 @@ if the terminal cannot move the cursor up (i.e., terminal type `dumb').
 Glob-patterns which do not use `?', `*' or `[]' or which use `{}' or `~'
 are not negated correctly.
 .PP
-The single-command form of \fIif\fR does output redirection even if
+The single-command form of \fBif\fR does output redirection even if
 the expression is false and the command is not executed.
 .PP
-\fIls\-F\fR includes file identification characters when sorting filenames
+\fBls\-F\fR includes file identification characters when sorting filenames
 and does not handle control characters in filenames well.  It cannot be
 interrupted.
 .PP
 Command substitution supports multiple commands and conditions, but not
-cycles or backward \fIgoto\fRs.
+cycles or backward \fBgoto\fRs.
 .PP
 Report bugs at https://bugs.astron.com/, preferably with fixes.  If you want to
 help maintain and test tcsh, add yourself to the mailing list in
@@ -5429,7 +5441,7 @@ limited to 1/6th the number of characters allowed in an argument list.
 Command substitutions may substitute no more characters than are allowed in
 an argument list.
 .PP
-To detect looping, the shell restricts the number of \fIalias\fR
+To detect looping, the shell restricts the number of \fBalias\fR
 substitutions on a single line to 20.
 .SH "SEE ALSO"
 csh(1), emacs(1), ls(1), newgrp(1), sh(1), setpath(1), stty(1), su(1),
@@ -5464,7 +5476,7 @@ Special aliases, directory stack extraction stuff, login/logout watch,
 scheduled events, and the idea of the new prompt format
 .TP 2
 Rayan Zachariassen, University of Toronto, 1984
-\fIls\-F\fR and \fIwhich\fR builtins and numerous bug fixes, modifications
+\fBls\-F\fR and \fBwhich\fR builtins and numerous bug fixes, modifications
 and speedups
 .TP 2
 Chris Kingsley, Caltech
@@ -5484,7 +5496,7 @@ Daniel Long, NNSC, 1988
 \fBwordchars\fR
 .TP 2
 Patrick Wolfe, Kuck and Associates, Inc., 1988
-\fIvi\fR mode cleanup
+\fBvi\fR mode cleanup
 .TP 2
 David C Lawrence, Rensselaer Polytechnic Institute, 1989
 \fBautolist\fR and ambiguous completion listing
@@ -5508,7 +5520,7 @@ Per Hedeland, Ellemtel, Sweden, 1990-
 Various bugfixes, improvements and manual updates
 .TP 2
 Hans J. Albertsson (Sun Sweden)
-\fBampm\fR, \fIsettc\fR and \fItelltc\fR
+\fBampm\fR, \fBsettc\fR and \fBtelltc\fR
 .TP 2
 Michael Bloom
 Interrupt handling fixes
@@ -5527,7 +5539,7 @@ Dan Oscarsson, LTH Sweden, 1990
 NLS support and simulated NLS support for non NLS sites, fixes
 .TP 2
 Johan Widen, SICS Sweden, 1990
-\fBshlvl\fR, Mach support, \fIcorrect-line\fR, 8-bit printing
+\fBshlvl\fR, Mach support, \fBcorrect-line\fR, 8-bit printing
 .TP 2
 Matt Day, Sanyo Icon, 1990
 POSIX termio support, SysV limit fixes
@@ -5546,17 +5558,17 @@ David Dawes, Sydney U. Australia, Physics Dept., 1991
 SVR4 job control fixes
 .TP 2
 Jose Sousa, Interactive Systems Corp., 1991
-Extended \fIvi\fR fixes and \fIvi\fR delete command
+Extended \fBvi\fR fixes and \fBvi\fR delete command
 .TP 2
 Marc Horowitz, MIT, 1991
-ANSIfication fixes, new exec hashing code, imake fixes, \fIwhere\fR
+ANSIfication fixes, new exec hashing code, imake fixes, \fBwhere\fR
 .TP 2
 Bruce Sterling Woodcock, sterling@netcom.com, 1991-1995
 ETA and Pyramid port, Makefile and lint fixes, \fBignoreeof\fR=n addition, and
 various other portability changes and bug fixes
 .TP 2
 Jeff Fink, 1992
-\fIcomplete-word-fwd\fR and \fIcomplete-word-back\fR
+\fBcomplete-word-fwd\fR and \fBcomplete-word-back\fR
 .TP 2
 Harry C. Pulley, 1992
 Coherent port

--- a/tcsh.man.new
+++ b/tcsh.man.new
@@ -5731,30 +5731,25 @@ Controllable
 types currently include (if supported by the OS):
 .Bl -tag -width 12n -offset indent
 .
+.It Ic concurrency
+Maximum number of threads for this process.
+.
+.It Ic coredumpsize
+Size of the largest core dump that will be created.
+.
 .It Ic cputime
 Maximum number of cpu-seconds to be used by each process.
-.
-.It Ic filesize
-Largest single file which can be created.
 .
 .It Ic datasize
 Maximum growth of the data+stack region via
 .Xr sbrk 2
 beyond the end of the program text.
 .
-.It Ic stacksize
-Maximum size of the automatically-extended stack region.
+.It Ic descriptors No or Ic openfiles
+Maximum number of open files for this process.
 .
-.It Ic coredumpsize
-Size of the largest core dump that will be created.
-.
-.It Ic memoryuse
-Maximum amount of physical memory a process
-may have allocated to it at a given time.
-.
-.It Ic vmemoryuse
-Maximum amount of virtual memory a process
-may have allocated to it at a given time (address space).
+.It Ic filesize
+Largest single file which can be created.
 .
 .It Ic heapsize
 Maximum amount of memory a process
@@ -5762,46 +5757,11 @@ may allocate per
 .Xr brk 2
 system call.
 .
-.It Ic descriptors No or Ic openfiles
-Maximum number of open files for this process.
-.
-.It Ic pseudoterminals
-Maximum number of pseudo-terminals for this user.
-.
 .It Ic kqueues
 Maximum number of kqueues allocated for this process.
 .
-.It Ic concurrency
-Maximum number of threads for this process.
-.
-.It Ic memorylocked
-Maximum size which a process may lock into memory using
-.Xr mlock 2 .
-.
-.It Ic maxproc
-Maximum number of simultaneous processes for this user id.
-.
-.It Ic maxthread
-Maximum number of simultaneous threads (lightweight processes) for this
-user id.
-.
-.It Ic threads
-Maximum number of threads for this process.
-.
-.It Ic sbsize
-Maximum size of socket buffer usage for this user.
-.
-.It Ic swapsize
-Maximum amount of swap space reserved or used for this user.
-.
 .It Ic maxlocks
 Maximum number of locks for this user.
-.
-.It Ic posixlocks
-Maximum number of POSIX advisory locks for this user.
-.
-.It Ic maxsignal
-Maximum number of pending signals for this user.
 .
 .It Ic maxmessage
 Maximum number of bytes in POSIX mqueues for this user.
@@ -5810,11 +5770,52 @@ Maximum number of bytes in POSIX mqueues for this user.
 Maximum nice priority the user is allowed to raise mapped from [19...-20]
 to [0...39] for this user.
 .
+.It Ic maxproc
+Maximum number of simultaneous processes for this user id.
+.
 .It Ic maxrtprio
 Maximum realtime priority for this user.
 .
 .It Ic maxrttime
 Timeout for RT tasks in microseconds for this user.
+.
+.It Ic maxsignal
+Maximum number of pending signals for this user.
+.
+.It Ic maxthread
+Maximum number of simultaneous threads (lightweight processes) for this
+user id.
+.
+.It Ic memorylocked
+Maximum size which a process may lock into memory using
+.Xr mlock 2 .
+.
+.It Ic memoryuse
+Maximum amount of physical memory a process
+may have allocated to it at a given time.
+.
+.It Ic posixlocks
+Maximum number of POSIX advisory locks for this user.
+.
+.It Ic pseudoterminals
+Maximum number of pseudo-terminals for this user.
+.
+.It Ic sbsize
+Maximum size of socket buffer usage for this user.
+.
+.It Ic stacksize
+Maximum size of the automatically-extended stack region.
+.
+.It Ic swapsize
+Maximum amount of swap space reserved or used for this user.
+.
+.It Ic threads
+Maximum number of threads for this process.
+.
+.It Ic vmemoryuse
+Maximum amount of virtual memory a process
+may have allocated to it at a given time (address space).
+.
 .El
 .Pp
 .Ar maximum-use

--- a/tcsh.man.new
+++ b/tcsh.man.new
@@ -3208,36 +3208,25 @@ builtin command (q.v.) has its own separate syntax.
 .
 .Ss "Logical, arithmetical and comparison operators"
 These operators are similar to those of C and have the same precedence.
-They include:
 .Pp
-.Bl -tag -width 6n -offset indent -compact
-.It Li "||  &&  |  ^  &  ==  !=  =~  !~  <=  >="
-.It Li "<  > <<  >>  +  \-  *  /  %  !  ~  (  )"
+The operators, in descending precedence, with equivalent precedence per line, are:
+.Pp
+.Bl -column -offset indent -compact "XX" "XX" "XX" "XX"
+.It Li \&( Ta Li \&)
+.It Li \&~
+.It Li \&!
+.It Li * Ta Li / Ta Li %
+.It Li + Ta Li \-
+.It Li << Ta Li >>
+.It Li <= Ta Li >= Ta Li < Ta Li >
+.It Li == Ta Li \&!= Ta Li =~ Ta Li \&!~
+.It Li &
+.It Li ^
+.It Li |
+.It Li &&
+.It Li ||
 .El
 .Pp
-Here the precedence increases to the right,
-.Ql ==
-.Ql \&!=
-.Ql =~
-and
-.Ql \&!~ ,
-.Ql <=
-.Ql >=
-.Ql <
-and
-.Ql > ,
-.Ql <<
-and
-.Ql >> ,
-.Ql +
-and
-.Ql \- ,
-.Ql *
-.Ql /
-and
-.Ql %
-being, in
-groups, at the same level.
 The
 .Ql ==
 .Ql \&!=
@@ -3273,11 +3262,11 @@ no two components of an expression can appear in the same word; except
 when adjacent to components of expressions which are syntactically
 significant to the parser
 .Po
-.Ql \&&
-.Ql |
-.Ql <
-.Ql >
-.Ql \&(
+.Ql \&& ,
+.Ql | ,
+.Ql < ,
+.Ql > ,
+.Ql \&( ,
 .Ql \&)
 .Pc
 they should be

--- a/tcsh.man.new
+++ b/tcsh.man.new
@@ -37,19 +37,16 @@
 .\" - Include the tilde when naming dot files. .Pa ~/.login , not .Pa .login
 .\"
 .\" - Refer to external commands in man page format, e.g., .Xr csh 1
-.\" However, tcsh is .Nm , because this is the tcsh man page (and
-.\" see the next note anyway).
+.\"   However, tcsh is .Nm , because this is the tcsh man page (and
+.\"   see the next note anyway).
 .\"
-.\" - Say .Sq the shell , not .Sq tcsh ,
-.\" unless distinguishing between tcsh and csh.
+.\" - Say `the shell', not `tcsh', unless distinguishing between tcsh and csh.
 .\"
-.\" - Say .Sq shell variable / .Sq environment variable instead of
-.\" .Sq variable and .Sq builtin command / .Sq editor command instead of
-.\" .Sq builtin or .Sq command
+.\" - Say `shell variable'/`environment variable' instead of `variable'
+.\"   and `builtin command'/`editor command' instead of `builtin' or `command'
 .\"   unless the distinction is absolutely clear from context.
 .\"
-.\" - Use the simple present tense.
-.\" .Sq The shell uses , not .Sq The shell will use
+.\" - Use the simple present tense. `The shell uses', not `The shell will use'.
 .\"
 .\" - IMPORTANT: Cross-reference as much as possible. Commands, variables,
 .\"   etc. in the reference section should be mentioned in the appropriate
@@ -59,27 +56,25 @@
 .\"   new features in NEW FEATURES and referenced external commands in SEE
 .\"   ALSO.
 .\"
-.\" - tcsh.man2html depends heavily on the specific nroff commands used in the
-.\"   man page when the script was written. Please stick closely to the style
-.\"   used here if you can. In particular, please don't use nroff commands
-.\"   which aren't already used herein.
-.\"
 .\" UPDATE NEXT LINE FOR RELEASE
 .Dd May 12, 2022
 .Dt TCSH 1
 .\" UPDATE NEXT LINE FOR RELEASE
 .Os Astron 6.24.01
+.
 .Sh NAME
 .Nm tcsh
 .Nd C shell with file name completion and command line editing
+.
 .Sh SYNOPSIS
 .Nm
 .Op Fl bcdefFimnqstvVxX
-.Op Fl Dname Ns Op =value
-.Op Ar arg ...
+.Op Fl D Ns Ar name Ns Op Ns = Ns Ar value
+.Op Ar arg
+\&...
 .Nm
 .Fl l
-.Ek
+.
 .Sh DESCRIPTION
 .Nm
 is an enhanced but completely compatible version of the Berkeley
@@ -88,9 +83,9 @@ UNIX C shell,
 It is a command language interpreter usable both as an interactive login
 shell and a shell script command processor.
 It includes a command-line editor (see
-.Sx The command-line editor )
+.Sx The command-line editor ) ,
 programmable word completion (see
-.Sx Completion and listing )
+.Sx Completion and listing ) ,
 spelling correction (see
 .Sx Spelling correction ) ,
 a history mechanism (see
@@ -109,17 +104,18 @@ Throughout this manual, features of
 not found in most
 .Xr csh 1
 implementations
-(specifically, the 4.4BSD one)
+(specifically, the 4.4BSD
+.Xr csh 1 )
 are labeled with
 .Sq (+) ,
 and features which are present in
 .Xr csh 1
 but not usually documented are labeled with
 .Sq (u) .
-.Bl -tag
+.
 .Ss Argument list processing
 If the first argument (argument 0) to the shell is
-.Sq \-
+.Ql \-
 then it is a login shell.
 A login shell can be also specified by invoking the shell with
 the
@@ -128,6 +124,7 @@ flag as the only argument.
 .Pp
 The rest of the flag arguments are interpreted as follows:
 .Bl -tag -width indent
+.
 .It Fl b
 Forces a
 .Dq break
@@ -137,49 +134,59 @@ The remaining arguments will not be interpreted as shell options.
 This may be used to pass options to a shell script without confusion
 or possible subterfuge.
 The shell will not run a set-user ID script without this option.
+.
 .It Fl c
 Commands are read from the following argument (which must be present, and
 must be a single argument),
 stored in the
-.Va command
+.Ic command
 shell variable for reference, and executed.
 Any remaining arguments are placed in the
-.Va argv
+.Ic argv
 shell variable.
+.
 .It Fl d
 The shell loads the directory stack from
 .Pa ~/.cshdirs
 as described under
 .Sx Startup and shutdown ,
 whether or not it is a login shell. (+)
-.It Fl Dname Ns Op =value
+.
+.It Fl D Ns Ar name Ns Op Ns = Ns Ar value
 Sets the environment variable
-.Va name
-.Dv value .
+.Ar name
+to
+.Ar value .
 (Domain/OS only) (+)
+.
 .It Fl e
 The shell exits if any invoked command terminates abnormally or
 yields a non-zero exit status.
+.
 .It Fl f
 The shell does not load any resource or startup files, or perform any
 command hashing, and thus starts faster.
+.
 .It Fl F
 The shell uses
 .Xr fork 2
 instead of
 .Xr vfork 2
 to spawn processes. (+)
+.
 .It Fl i
 The shell is interactive and prompts for its top-level input, even if
 it appears to not be a terminal.
 Shells are interactive without this option if
 their inputs and outputs are terminals.
+.
 .It Fl l
 The shell is a login shell.
 Applicable only if
 .Fl l
 is the only
 flag specified.
+.
 .It Fl m
 The shell loads
 .Pa ~/.tcshrc
@@ -189,37 +196,45 @@ Newer versions of
 can pass
 .Fl m
 to the shell. (+)
+.
 .It Fl n
 The shell parses commands but does not execute them.
 This aids in debugging shell scripts.
+.
 .It Fl q
 The shell accepts SIGQUIT (see
 .Sx Signal handling )
 and behaves when it is used under a debugger.
 Job control is disabled. (u)
+.
 .It Fl s
 Command input is taken from the standard input.
+.
 .It Fl t
 The shell reads and executes a single line of input.
 A
-.Sq \e
+.Ql \e
 may be used to
 escape the newline at the end of this line and continue onto another line.
+.
 .It Fl v
 Sets the
-.Va verbose
+.Ic verbose
 shell variable, so that
 command input is echoed after history substitution.
+.
 .It Fl x
 Sets the
-.Va echo
+.Ic echo
 shell variable, so that commands are echoed
 immediately before execution.
+.
 .It Fl V
 Sets the
-.Va verbose
+.Ic verbose
 shell variable even before executing
 .Pa ~/.tcshrc .
+.
 .It Fl X
 Is to
 .Fl x
@@ -227,13 +242,14 @@ as
 .Fl V
 is to
 .Fl v .
-.TP 4
+.
 .It Fl \-help
 Print a help message on the standard output and exit. (+)
+.
 .It Fl \-version
 Print the version/platform/compilation options on the standard output and exit.
 This information is also contained in the
-.Va version
+.Ic version
 shell variable. (+)
 .El
 .Pp
@@ -249,20 +265,21 @@ commands, or
 to be executed.
 The shell opens this file and saves its name for possible
 resubstitution by
-.Sq $0 .
+.Ql $0 .
 Because many systems use either the standard
 version 6 or version 7 shells whose shell scripts are not compatible
 with this shell, the shell uses such a
-.Sq standard
+.Dq standard
 shell to execute a script
 whose first character is not a
-.Sq # ,
+.Ql # ,
 i.e., that does not start with a
 comment.
 .Pp
 Remaining arguments are placed in the
-.Va argv
+.Ic argv
 shell variable.
+.
 .Ss Startup and shutdown
 A login shell begins by executing commands from the system files
 .Pa /etc/csh.cshrc
@@ -277,16 +294,16 @@ or, if
 .Pa ~/.tcshrc
 is not found,
 .Pa ~/.cshrc ,
-then
+then the contents of
 .Pa ~/.history
 (or the value of the
-.Va histfile
-shell variable), then
+.Ic histfile
+shell variable) are loaded into memory, then
 .Pa ~/.login ,
 and finally
 .Pa ~/.cshdirs
 (or the value of the
-.Va dirsfile
+.Ic dirsfile
 shell variable) (+).
 The shell may read
 .Pa /etc/csh.login
@@ -302,7 +319,7 @@ and
 .Pa ~/.history ,
 if so compiled;
 see the
-.Va version
+.Ic version
 shell variable. (+)
 .Pp
 Non-login shells read only
@@ -330,16 +347,17 @@ and
 can have only a
 .Pa ~/.cshrc
 which checks for the existence of the
-.Va tcsh
+.Ic tcsh
 shell variable (q.v.) before using
-.Nm \-
-specific commands,
+.Nm Ns
+\-specific commands,
 or can have both a
 .Pa ~/.cshrc
 and a
 .Pa ~/.tcshrc
 which
-.Ic sources
+.Ic source Ns
+s
 (see the builtin command)
 .Pa ~/.cshrc .
 The rest of this manual uses
@@ -354,7 +372,7 @@ is not found,
 .Pp
 In the normal case, the shell begins reading commands from the terminal,
 prompting with
-.Sq >\~ .
+.Sq Li >\ \& .
 (Processing of arguments and the use of the shell to
 process files containing command scripts are described later.)
 The shell repeatedly reads a line of command input, breaks it into words,
@@ -364,26 +382,26 @@ in the line.
 One can log out by typing
 .Sq ^D
 on an empty line,
-.Sq logout
+.Ic logout
 or
-.Sq login
+.Ic login
 or
 via the shell's autologout mechanism (see the
-.Va autologout
+.Ic autologout
 shell variable).
 When a login shell terminates it sets the
-.Va logout
+.Ic logout
 shell variable to
-.Sq normal
+.Ql normal
 or
-.Sq automatic
+.Ql automatic
 as appropriate, then executes commands from the files
 .Pa /etc/csh.logout
 and
 .Pa ~/.logout .
 The shell may drop DTR on logout
 if so compiled; see the
-.Va version
+.Ic version
 shell variable.
 .Pp
 The names of the system login and logout files vary from system to system for
@@ -391,9 +409,10 @@ compatibility with different
 .Xr csh 1
 variants; see
 .Sx FILES .
+.
 .Ss Editing
 We first describe
-.Sx The command-line editor
+.Sx The command-line editor .
 The
 .Sx Completion and listing
 and
@@ -404,33 +423,34 @@ Finally,
 .Sx Editor commands
 lists and describes
 the editor commands specific to the shell and their default bindings.
+.
 .Ss The command-line editor (+)
 Command-line input can be edited using key sequences much like those used in
 .Xr emacs 1
 or
 .Xr vi 1 .
 The editor is active only when the
-.Va edit
+.Ic edit
 shell variable is set, which it is by default in interactive shells.
 The
 .Ic bindkey
 builtin can display and change key bindings.
-.Xr emacs 1
-style key bindings are used by default
+.Xr emacs 1 Ns
+\-style key bindings are used by default
 (unless the shell was compiled otherwise; see the
-.Va version
+.Ic version
 shell variable),
 but
 .Ic bindkey
 can change the key bindings to
-.Xr vi 1
-style bindings en masse.
+.Xr vi 1 Ns
+\-style bindings en masse.
 .Pp
 The shell always binds the arrow keys (as defined in the
-.Va TERMCAP
+.Ev TERMCAP
 environment variable) to:
 .Pp
-.Bl -tag -width right -compact -offset indent
+.Bl -tag -width right -offset indent -compact
 .It down
 .Ic down-history
 .It up
@@ -443,7 +463,7 @@ environment variable) to:
 .Pp
 unless doing so would alter another single-character binding.
 One can set the arrow key escape sequences to the empty string with
-.Va settc
+.Ic settc
 to prevent these bindings.
 The ANSI/VT100 sequences for arrow keys are always bound.
 .Pp
@@ -462,9 +482,9 @@ commands with a short description of each.
 Certain key bindings have different behavior depending if
 .Xr emacs 1
 or
-.Xr vi 1
-style bindings are being used; see
-.Va vimode
+.Xr vi 1 Ns
+\-style bindings are being used; see
+.Ic vimode
 for more information.
 .Pp
 Note that editor commands do not have the same notion of a
@@ -472,15 +492,15 @@ Note that editor commands do not have the same notion of a
 as does the shell.
 The editor delimits words with any non-alphanumeric characters not in
 the shell variable
-.Va wordchars ,
+.Ic wordchars ,
 while the shell recognizes only whitespace
 and some of the characters with special meanings to it, listed under
 .Sx Lexical structure .
+.
 .Ss Completion and listing (+)
 The shell is often able to complete words when given a unique abbreviation.
 Type part of a word (for example
-.Ic ls
-.Pa /usr/lost )
+.Ql ls /usr/lost )
 and hit the tab key to run the
 .Ic complete-word
 editor command.
@@ -490,13 +510,13 @@ to
 .Pa /usr/lost+found/ ,
 replacing the incomplete word with the complete word in the input buffer.
 (Note the terminal
-.Sq / ;
+.Sq Pa / ;
 completion adds a
-.Sq /
+.Ql /
 to the end of completed directories and a space to the end of other completed
 words, to speed typing and provide a visual indicator of successful completion.
 The
-.Va addsuffix
+.Ic addsuffix
 shell variable can be unset to prevent this.)
 If no match is found (perhaps
 .Pa /usr/lost+found
@@ -506,7 +526,7 @@ If the word is already complete (perhaps there is a
 on your
 system, or perhaps you were thinking too far ahead and typed the whole thing)
 a
-.Sq /
+.Ql /
 or space is added to the end if it isn't already there.
 .Pp
 Completion works anywhere in the line, not at just the end; completed
@@ -517,43 +537,43 @@ to be deleted.
 .Pp
 Commands and variables can be completed in much the same way.
 For example, typing
-.Sq em[tab]
+.Ql em[tab]
 would complete
-.Sq em
+.Ql em
 to
-.Sq emacs
+.Ql emacs
 if
-.Pa emacs
+.Ql emacs
 were the only command on your system beginning with
-.Sq em .
+.Ql em .
 Completion can find a command in any directory in
-.Pa path
+.Ic path
 or if given a full pathname.
 Typing
-.Sq echo $ar[tab]
+.Ql echo $ar[tab]
 would complete
-.Sq $ar
+.Ql $ar
 to
-.Sq $argv
+.Ql $argv
 if no other variable began with
-.Sq ar .
+.Ql ar .
 .Pp
 The shell parses the input buffer to determine whether the word you want to
 complete should be completed as a filename, command or variable.
 The first word in the buffer and the first word following
-.Sq \&; ,
-.Sq | ,
-.Sq |& ,
-.Sq &&
+.Ql \&; ,
+.Ql | ,
+.Ql |& ,
+.Ql && ,
 or
-.Sq ||
+.Ql ||
 is considered to be a command.
 A word beginning with
-.Sq $
+.Ql $
 is considered to be a variable.
 Anything else is a filename.
 An empty line is
-.Sq completed
+.Dq completed
 as a filename.
 .Pp
 You can list the possible completions of a word at any time by typing
@@ -572,7 +592,7 @@ lbin/       lib/        local/      lost+found/
 .Ed
 .Pp
 If the
-.Va autolist
+.Ic autolist
 shell variable is set, the shell lists the remaining
 choices (if any) whenever completion fails:
 .Bd -literal -offset indent
@@ -582,20 +602,20 @@ libtermcap.a@ libtermlib.a@
 > nm /usr/lib/libterm
 .Ed
 .Pp
-If
-.Va autolist
+If the
+.Ic autolist
 shell variable is set to
-.Sq ambiguous ,
+.Ql ambiguous ,
 choices are listed only when
 completion fails and adds no new characters to the word being completed.
 .Pp
 A filename to be completed can contain variables, your own or others' home
 directories abbreviated with
-.Sq ~
+.Ql ~
 (see
 .Sx Filename substitution )
 and directory stack entries abbreviated with
-.Sq =
+.Ql =
 (see
 .Sx Directory stack substitution ) .
 For example,
@@ -605,6 +625,7 @@ kahn    kas     kellogg
 > ls ~ke[tab]
 > ls ~kellogg/
 .Ed
+.Pp
 or
 .Bd -literal -offset indent
 > set local = /usr/local
@@ -621,8 +642,8 @@ editor command.
 .Ic delete-char-or-list-or-eof
 lists at only the end of the line;
 in the middle of a line it deletes the character under the cursor and
-on an empty line it logs one out or, if then
-.Va ignoreeof
+on an empty line it logs one out or, if the
+.Ic ignoreeof
 variable is set, does nothing.
 .Sq M-^D ,
 bound to the editor command
@@ -650,7 +671,7 @@ the list of possible completions, replacing the current word with the next or
 previous word in the list.
 .Pp
 The shell variable
-.Va fignore
+.Ic fignore
 can be set to a list of suffixes to be ignored by completion.
 Consider the following:
 .Bd -literal -offset indent
@@ -665,32 +686,34 @@ main.c   main.c~  main.o
 > emacs main.c
 .Ed
 .Pp
-.Sq main.c~
+.Ql main.c~
 and
-.Sq main.o
+.Ql main.o
 are ignored by completion (but not listing),
 because they end in suffixes in
-.Va fignore .
+.Ic fignore .
 Note that a
-.Sq \e
+.Ql \e
 was needed in front of
-.Sq ~
+.Ql ~
 to prevent it from being expanded to
-.Va home
+.Ic home
 as described under
 .Sx Filename substitution .
-.Va fignore
+.Ic fignore
 is ignored if only one completion is possible.
 .Pp
 If the
-.Va complete
+.Ic complete
 shell variable is set to
-.Sq enhance ,
+.Ql enhance ,
 completion 1) ignores case and 2) considers periods, hyphens and underscores
-.Sq ( \&. ,
-.Sq \&-
+.Po
+.Ql \&. ,
+.Ql \- ,
 and
-.Sq _ )
+.Ql _
+.Pc
 to be word separators and hyphens and underscores to be equivalent.
 If you had the following files
 .Bd -literal -offset indent
@@ -699,22 +722,22 @@ comp.lang.c++    comp.std.c
 .Ed
 .Pp
 and typed
-.Sq mail \-f c.l.c[tab] ,
+.Ql mail \-f c.l.c[tab] ,
 it would be completed to
-.Sq mail \-f comp.lang.c ,
+.Ql mail \-f comp.lang.c ,
 and
 .Sq ^D
 would list
-.Sq comp.lang.c
+.Ql comp.lang.c
 and
-.Sq comp.lang.c++ .
-.Sq mail \-f c..c++[^D]
+.Ql comp.lang.c++ .
+.Ql mail \-f c..c++[^D]
 would list
-.Sq comp.lang.c++
+.Ql comp.lang.c++
 and
-.Sq comp.std.c++ .
+.Ql comp.std.c++ .
 Typing
-.Sq rm a\-\-file[^D]
+.Ql rm a\-\-file[^D]
 in the following directory
 .Bd -literal -offset indent
 A_silly_file    a-hyphenated-file    another_silly_file
@@ -726,32 +749,32 @@ Periods, however, are not equivalent to
 hyphens or underscores.
 .Pp
 If the
-.Va complete
+.Ic complete
 shell variable is set to
-.Sq Enhance ,
+.Ql Enhance ,
 completion
 ignores case and differences between a hyphen and an underscore word
 separator only when the user types a lowercase character or a hyphen.
 Entering an uppercase character or an underscore will not match the
 corresponding lowercase character or hyphen word separator.
 Typing
-.Sq rm a\-\-file[^D]
+.Ql rm a\-\-file[^D]
 in the directory of the previous example would
 still list all three files, but typing
-.Sq rm A\-\-file
+.Ql rm A\-\-file
 would match only
-.Sq A_silly_file
+.Ql A_silly_file
 and typing
-.Sq rm a__file[^D]
+.Ql rm a__file[^D]
 would match just
-.Sq A_silly_file
+.Ql A_silly_file
 and
-.Sq another_silly_file
+.Ql another_silly_file
 because the user explicitly used an uppercase
 or an underscore character.
 .Pp
 Completion and listing are affected by several other shell variables:
-.Va recexact
+.Ic recexact
 can be set to complete on the shortest possible unique
 match, even if more typing might result in a longer match:
 .Bd -literal -offset indent
@@ -762,55 +785,55 @@ fodder   foo      food     foonly
 .Ed
 .Pp
 just beeps, because
-.Sq fo
+.Ql fo
 could expand to
-.Sq fod
+.Ql fod
 or
-.Sq foo ,
+.Ql foo ,
 but if we type another
-.Sq o ,
+.Ql o ,
 .Bd -literal -offset indent
 > rm foo[tab]
 > rm foo
 .Ed
 .Pp
 the completion completes on
-.Sq foo ,
+.Ql foo ,
 even though
-.Sq food
+.Ql food
 and
-.Sq foonly
+.Ql foonly
 also match.
-.Va autoexpand
+.Ic autoexpand
 can be set to run the
 .Ic expand-history
 editor command
 before each completion attempt,
-.Va autocorrect
+.Ic autocorrect
 can be set to
 spelling-correct the word to be completed (see
 .Sx Spelling correction )
 before each completion attempt and
-.Va correct
+.Ic correct
 can be set to complete commands automatically after one hits
-.Sq return .
-.Va matchbeep
+return.
+.Ic matchbeep
 can be set to make completion beep or not beep in a variety
 of situations, and
-.Va nobeep
+.Ic nobeep
 can be set to never beep at all.
-.Va nostat
+.Ic nostat
 can be set to a list of directories and/or patterns that
 match directories to prevent the completion mechanism from
-.Xr stat 2
+.Xr stat 2 Ns
 ing
 those directories.
-.Va listmax
+.Ic listmax
 and
-.Va listmaxrows
+.Ic listmaxrows
 can be set to limit the number of items
 and rows (respectively) that are listed without asking first.
-.Va recognize_only_executables
+.Ic recognize_only_executables
 can be set to make the shell list only
 executables when listing commands, but it is quite slow.
 .Pp
@@ -826,24 +849,29 @@ and
 .Ic expand-glob
 editor commands perform
 equivalent functions for glob-patterns.
+.
 .Ss Spelling correction (+)
 The shell can sometimes correct the spelling of filenames, commands and
 variable names as well as completing and listing them.
 .Pp
 Individual words can be spelling-corrected with the
 .Ic spell-word
-editor command (usually bound to M-s and M-S)
+editor command (usually bound to
+.Sq M-s
+and
+.Sq M-S )
 and the entire input buffer with
 .Ic spell-line
-(usually bound to M-$).
+(usually bound to
+.Sq M-$ ) .
 The
-.Va correct
+.Ic correct
 shell variable can be set to
-.Dv cmd
+.Ql cmd
 to correct the command name or
-.Dv all
+.Ql all
 to correct the entire line each time return is typed, and
-.Va autocorrect
+.Ic autocorrect
 can be set to correct the word to be completed
 before each completion attempt.
 .Pp
@@ -857,11 +885,11 @@ CORRECT>ls /usr/bin (y|n|e|a)?
 .Ed
 .Pp
 One can answer
-.Sq y
+.Ql y
 or space to execute the corrected line,
-.Sq e
+.Ql e
 to leave the uncorrected command in the input buffer,
-.Sq a
+.Ql a
 to abort the command as if
 .Sq ^C
 had been hit, and
@@ -881,6 +909,7 @@ not register a misspelling.
 Like completion, spelling correction works anywhere in the line,
 pushing the rest of the line to the right and possibly leaving
 extra characters to the right of the cursor.
+.
 .Ss Editor commands (+)
 .Ic bindkey
 lists key bindings and
@@ -895,59 +924,70 @@ for descriptions of each editor's key bindings.
 .Pp
 The character or characters to which each command is bound by default is
 given in parentheses.
-.Sq ^character
+.Sq ^ Ns Ar character
 means a control character and
-.Sq M-character
+.Sq M- Ns Ar character
 a meta character, typed as
-.Sq escape-character
+.Sq escape- Ns Ar character
 on terminals without a meta key.
 Case counts, but commands that are bound
 to letters by default are bound to both lower- and uppercase letters for
 convenience.
 .Bl -tag -width indent
-.It Ic backward-char Ar (^B, left)
+.
+.It Ic backward-char No (^B, left)
 Move back a character.
 Cursor behavior modified by
-.Va vimode
-.It Ic backward-delete-word Ar (M-^H, M-^?)
-Cut from beginning of current word to cursor \- saved in cut buffer.
+.Ic vimode .
+.
+.It Ic backward-delete-word No (M-^H, M-^?)
+Cut from beginning of current word to cursor - saved in cut buffer.
 Word boundary behavior modified by
-.Va vimode
-.It Ic backward-word Ar (M-b, M-B)
+.Ic vimode .
+.
+.It Ic backward-word No (M-b, M-B)
 Move to beginning of current word.
 Word boundary and cursor behavior modified by
-.Va vimode
-.It Ic beginning-of-line Ar (^A, home)
+.Ic vimode .
+.
+.It Ic beginning-of-line No (^A, home)
 Move to beginning of line.
 Cursor behavior modified by
-.Va vimode
-.It Ic capitalize-word Ar (M-c, M-C)
+.Ic vimode .
+.
+.It Ic capitalize-word No (M-c, M-C)
 Capitalize the characters from cursor to end of current word.
 Word boundary behavior modified by
-.Va vimode
-.It Ic complete-word Ar (tab)
+.Ic vimode .
+.
+.It Ic complete-word No (tab)
 Completes a word as described under
-.Sx Completion and listing
-.It Ic complete-word-back Ar (not bound)
+.Sx Completion and listing .
+.
+.It Ic complete-word-back No (not bound)
 Like
 .Ic complete-word-fwd ,
 but steps up from the end of the list.
-.It Ic complete-word-fwd Ar (not bound)
+.
+.It Ic complete-word-fwd No (not bound)
 Replaces the current word with the first word in the list of possible
 completions.
 May be repeated to step down through the list.
 At the end of the list, beeps and reverts to the incomplete word.
-.It Ic complete-word-raw Ar (^X-tab)
+.
+.It Ic complete-word-raw No (^X-tab)
 Like
 .Ic complete-word ,
 but ignores user-defined completions.
-.It Ic copy-prev-word Ar (M-^_)
+.
+.It Ic copy-prev-word No (M-^_)
 Copies the previous word in the current line into the input buffer.
 See also
-.Ic insert-last-word
+.Ic insert-last-word .
 Word boundary behavior modified by
-.Va vimode
-.It Ic dabbrev-expand Ar (M-/)
+.Ic vimode .
+.
+.It Ic dabbrev-expand No (M-/)
 Expands the current word to the most recent preceding one for which
 the current is a leading substring, wrapping around the history list
 (once) if necessary.
@@ -958,23 +998,26 @@ changes to the next previous word etc., skipping identical matches
 much like
 .Ic history-search-backward
 does.
-.It Ic delete-char Ar (not bound)
+.
+.It Ic delete-char No (not bound)
 Deletes the character under the cursor.
 See also
-.Ic delete-char-or-list-or-eof
+.Ic delete-char-or-list-or-eof .
 Cursor behavior modified by
-.Va vimode
-.It Ic delete-char-or-eof Ar (not bound)
+.Ic vimode .
+.
+.It Ic delete-char-or-eof No (not bound)
 Does
 .Ic delete-char
 if there is a character under the cursor or
 .Ic end-of-file
 on an empty line.
 See also
-.Ic delete-char-or-list-or-eof
+.Ic delete-char-or-list-or-eof .
 Cursor behavior modified by
-.Va vimode
-.It Ic delete-char-or-list Ar (not bound)
+.Ic vimode .
+.
+.It Ic delete-char-or-list No (not bound)
 Does
 .Ic delete-char
 if there is a character under the cursor
@@ -982,8 +1025,9 @@ or
 .Ic list-choices
 at the end of the line.
 See also
-.Ic delete-char-or-list-or-eof
-.It Ic delete-char-or-list-or-eof Ar (^D)
+.Ic delete-char-or-list-or-eof .
+.
+.It Ic delete-char-or-list-or-eof No (^D)
 Does
 .Ic delete-char
 if there is a character under the cursor,
@@ -993,74 +1037,86 @@ at the end of the line or
 on an empty line.
 See also those three commands, each of which does only a single action, and
 .Ic delete-char-or-eof ,
-.Ic delete-char-or-list
+.Ic delete-char-or-list ,
 and
 .Ic list-or-eof ,
 each of which does a different two out of the three.
-.It Ic delete-word Ar (M-d, M-D)
-Cut from cursor to end of current word \- save in cut buffer.
+.
+.It Ic delete-word No (M-d, M-D)
+Cut from cursor to end of current word - save in cut buffer.
 Word boundary behavior modified by
-.Va vimode
-.It Ic down-history Ar (down-arrow, ^N)
+.Ic vimode .
+.
+.It Ic down-history No (down-arrow, ^N)
 Like
 .Ic up-history ,
 but steps down, stopping at the original input line.
-.It Ic downcase-word Ar (M-l, M-L)
+.
+.It Ic downcase-word No (M-l, M-L)
 Lowercase the characters from cursor to end of current word.
 Word boundary behavior modified by
-.Va vimode
-.It Ic end-of-file Ar (not bound)
+.Ic vimode .
+.
+.It Ic end-of-file No (not bound)
 Signals an end of file, causing the shell to exit unless the
-.Va ignoreeof
+.Ic ignoreeof
 shell variable (q.v.) is set to prevent this.
 See also
-.Ic delete-char-or-list-or-eof
-.It Ic end-of-line Ar (^E, end)
+.Ic delete-char-or-list-or-eof .
+.
+.It Ic end-of-line No (^E, end)
 Move cursor to end of line.
 Cursor behavior modified by
-.Va vimode
-.It Ic expand-history Ar (M-space)
+.Ic vimode .
+.
+.It Ic expand-history No (M-space)
 Expands history substitutions in the current word.
 See
-.Sx History substitution
+.Sx History substitution .
 See also
 .Ic magic-space ,
-.Ic toggle-literal-history
+.Ic toggle-literal-history ,
 and the
-.Va autoexpand
+.Ic autoexpand
 shell variable.
-.It Ic expand-glob Ar (^X-*)
+.
+.It Ic expand-glob No (^X-*)
 Expands the glob-pattern to the left of the cursor.
 See
-.Sx Filename substitution
-.It Ic expand-line Ar (not bound)
+.Sx Filename substitution .
+.
+.It Ic expand-line No (not bound)
 Like
 .Ic expand-history ,
 but expands history substitutions in each word in the input buffer.
-.It Ic expand-variables Ar (^X-$)
+.
+.It Ic expand-variables No (^X-$)
 Expands the variable to the left of the cursor.
 See
-.Sx Variable substitution
-.It Ic forward-char Ar (^F, right)
+.Sx Variable substitution .
+.
+.It Ic forward-char No (^F, right)
 Move forward one character.
 Cursor behavior modified by
-.Va vimode
-.It Ic forward-word Ar (M-f, M-F)
+.Ic vimode .
+.
+.It Ic forward-word No (M-f, M-F)
 Move forward to end of current word.
 Word boundary and cursor behavior modified by
-.Va vimode
-.It Ic history-search-backward Ar (M-p, M-P)
+.Ic vimode .
+.
+.It Ic history-search-backward No (M-p, M-P)
 Searches backwards through the history list for a command beginning with
 the current contents of the input buffer up to the cursor and copies it
 into the input buffer.
 The search string may be a glob-pattern (see
 .Sx Filename substitution )
 containing
-.Sq * ,
-.Sq \&?  ,
-.Sq []
+.Ql * ,
+.Ql \&? ,
+.Ql [] ,
 or
-.Sq {}
+.Ql {} .
 .Ic up-history
 and
 .Ic down-history
@@ -1070,18 +1126,20 @@ Emacs mode only.
 See also
 .Ic history-search-forward
 and
-.Ic i-search-back
-.It Ic history-search-forward Ar (M-n, M-N)
+.Ic i-search-back .
+.
+.It Ic history-search-forward No (M-n, M-N)
 Like
 .Ic history-search-backward ,
 but searches forward.
-.It Ic i-search-back Ar (not bound)
+.
+.It Ic i-search-back No (not bound)
 Searches backward like
 .Ic history-search-backward ,
 copies the first match
 into the input buffer with the cursor positioned at the end of the pattern,
 and prompts with
-.Sq bck:
+.Sq Li bck:\ \&
 and the first match.
 Additional characters may be
 typed to extend the search,
@@ -1119,48 +1177,55 @@ causes the current line to be executed.
 See also
 .Ic i-search-fwd
 and
-.Ic history-search-backward
+.Ic history-search-backward .
 Word boundary behavior modified by
-.Va vimode
-.It Ic i-search-fwd Ar (not bound)
+.Ic vimode .
+.
+.It Ic i-search-fwd No (not bound)
 Like
 .Ic i-search-back ,
 but searches forward.
 Word boundary behavior modified by
-.Va vimode
-.It Ic insert-last-word Ar (M-_)
+.Ic vimode .
+.
+.It Ic insert-last-word No (M-_)
 Inserts the last word of the previous input line
-.Sq ( \&!$ )
+.Pq Ql \&!$
 into the input buffer.
 See also
-.Ic copy-prev-word
-.It Ic list-choices Ar (M-^D)
+.Ic copy-prev-word .
+.
+.It Ic list-choices No (M-^D)
 Lists completion possibilities as described under
-.Sx Completion and listing
+.Sx Completion and listing .
 See also
 .Ic delete-char-or-list-or-eof
 and
-.Ic list-choices-raw
-.It Ic list-choices-raw Ar (^X-^D)
+.Ic list-choices-raw .
+.
+.It Ic list-choices-raw No (^X-^D)
 Like
 .Ic list-choices ,
 but ignores user-defined completions.
-.It Ic list-glob Ar (^X-g, ^X-G)
+.
+.It Ic list-glob No (^X-g, ^X-G)
 Lists (via the
 .Ic ls\-F
 builtin) matches to the glob-pattern
 (see
 .Sx Filename substitution )
 to the left of the cursor.
-.It Ic list-or-eof Ar (not bound)
+.
+.It Ic list-or-eof No (not bound)
 Does
 .Ic list-choices
 or
 .Ic end-of-file
 on an empty line.
 See also
-.Ic delete-char-or-list-or-eof
-.It Ic magic-space Ar (not bound)
+.Ic delete-char-or-list-or-eof .
+.
+.It Ic magic-space No (not bound)
 Expands history substitutions in the current line,
 like
 .Ic expand-history ,
@@ -1168,48 +1233,53 @@ and inserts a space.
 .Ic magic-space
 is designed to be bound to the space bar,
 but is not bound by default.
-.It Ic normalize-command Ar (^X-?)
-Searches for the current word in PATH and, if it is found, replaces it with
+.
+.It Ic normalize-command No (^X-?)
+Searches for the current word in
+.Ev PATH
+and, if it is found, replaces it with
 the full path to the executable.
 Special characters are quoted.
 Aliases are
 expanded and quoted but commands within aliases are not.
 This command is
 useful with commands that take commands as arguments, e.g.,
-.Sq dbx
+.Ql dbx
 and
-.Sq sh \-x
-.It Ic normalize-path Ar (^X-n, ^X-N)
+.Ql sh \-x .
+.
+.It Ic normalize-path No (^X-n, ^X-N)
 Expands the current word as described under the
-.Sq expand
+.Ql expand
 setting
 of the
-.Va symlinks
+.Ic symlinks
 shell variable.
-.It Ic overwrite-mode Ar (unbound)
+.
+.It Ic overwrite-mode No (unbound)
 Toggles between input and overwrite modes.
-.It Ic run-fg-editor Ar (M-^Z)
+.
+.It Ic run-fg-editor No (M-^Z)
 Saves the current input line and
 looks for a stopped job where the file name portion of its first word
 is found in the
-.Va editors
+.Ic editors
 shell variable.
 If
-.Va editors
+.Ic editors
 is not set, then the file name portion of the
-.Va EDITOR
+.Ev EDITOR
 environment variable
-.Sq ( ed
+.Ql ( ed
 if unset)
 and the
-.Va VISUAL
+.Ev VISUAL
 environment variable
-Sq ( vi
+.Ql ( vi
 if unset)
 will be used.
 If such a job is found, it is restarted as if
-.Sq fg %
-.Ic job
+.Ql fg % Ns Ar job
 had been typed.
 This is used to toggle back and forth between an editor and
 the shell easily.
@@ -1217,45 +1287,49 @@ Some people bind this command to
 .Sq ^Z
 so they
 can do this even more easily.
-.It Ic run-help Ar (M-h, M-H)
+.
+.It Ic run-help No (M-h, M-H)
 Searches for documentation on the current command, using the same notion of
-.Sq current command
+.Dq current command
 as the completion routines, and prints it.
 There is no way
 to use a pager;
 .Ic run-help
 is designed for short help files.
 If the special alias
-.Va helpcommand
+.Ic helpcommand
 is defined, it is run with the
 command name as a sole argument.
 Else,
 documentation should be in a file named
-.Sq command.help ,
-.Sq command.1 ,
-.Sq command.6 ,
-.Sq command.8 ,
+.Pa command.help ,
+.Pa command.1 ,
+.Pa command.6 ,
+.Pa command.8 ,
 or
-.Sq command ,
+.Pa command ,
 which should be in one
 of the directories listed in the
-.Va HPATH
+.Ev HPATH
 environment variable.
 If there is more than one help file only the first is printed.
-.It Ic self-insert-command Ar (text characters)
-In insert mode (the default), inserts the typed character into the input line after the character under the cursor.
+.
+.It Ic self-insert-command No (text characters)
+In insert mode (the default), inserts the typed character into
+the input line after the character under the cursor.
 In overwrite mode, replaces the character under the cursor with the typed character.
 The input mode is normally preserved between lines, but the
-.Va inputmode
+.Ic inputmode
 shell variable can be set to
-.Dv insert
+.Ql insert
 or
-.Dv overwrite
+.Ql overwrite
 to put the
 editor in that mode at the beginning of each line.
 See also
-.Ic overwrite-mode
-.It Ic sequence-lead-in Ar (arrow prefix, meta prefix, ^X)
+.Ic overwrite-mode .
+.
+.It Ic sequence-lead-in No (arrow prefix, meta prefix, ^X)
 Indicates that the following characters are part of a
 multi-key sequence.
 Binding a command to a multi-key sequence really creates
@@ -1269,61 +1343,70 @@ bound to
 are effectively bound to
 .Ic undefined-key
 unless bound to another command.
-.It Ic spell-line Ar (M-$)
+.
+.It Ic spell-line No (M-$)
 Attempts to correct the spelling of each word in the input buffer, like
 .Ic spell-word ,
 but ignores words whose first character is one of
-.Sq \- ,
-.Sq \ ! ,
-.Sq ^
+.Ql \- ,
+.Ql \&! ,
+.Ql ^ ,
 or
-.Sq % ,
+.Ql % ,
 or which contain
-.Sq \e ,
-.Sq *
+.Ql \e ,
+.Ql * ,
 or
-.Sq \&? ,
+.Ql \&? ,
 to avoid problems with switches, substitutions and the like.
 See
-.Sx Spelling correction
-.It Ic spell-word Ar (M-s, M-S)
+.Sx Spelling correction .
+.
+.It Ic spell-word No (M-s, M-S)
 Attempts to correct the spelling of the current word as described under
-.Sx Spelling correction
+.Sx Spelling correction .
 Checks each component of a word which appears to be a pathname.
-.It Ic toggle-literal-history Ar (M-r, M-R)
+.
+.It Ic toggle-literal-history No (M-r, M-R)
 Expands or
-.Sq unexpands
+unexpands
 history substitutions in the input buffer.
 See also
 .Ic expand-history
 and the
-.Va autoexpand
+.Ic autoexpand
 shell variable.
-.It Ic undefined-key Ar (any unbound key)
+.
+.It Ic undefined-key No (any unbound key)
 Beeps.
-.It Ic up-history Ar (up-arrow, ^P)
+.
+.It Ic up-history No (up-arrow, ^P)
 Copies the previous entry in the history list into the input buffer.
 If
-.Va histlit
+.Ic histlit
 is set, uses the literal form of the entry.
 May be repeated to step up through the history list, stopping at the top.
-.It Ic upcase-word Ar (M-u, M-U)
+.
+.It Ic upcase-word No (M-u, M-U)
 Uppercase the characters from cursor to end of current word.
 Word boundary behavior modified by
-.Va vimode
-.It Ic vi-beginning-of-next-word Ar (not bound)
+.Ic vimode .
+.
+.It Ic vi-beginning-of-next-word No (not bound)
 Vi goto the beginning of next word.
 Word boundary and cursor behavior modified by
-.Va vimode
-.It Ic vi-eword Ar (not bound)
+.Ic vimode .
+.
+.It Ic vi-eword No (not bound)
 Vi move to the end of the current word.
 Word boundary behavior modified by
-.Va vimode
-.It Ic vi-search-back Ar (?)
+.Ic vimode .
+.
+.It Ic vi-search-back No (?)
 Prompts with
-.Sq \&?
+.Sq Li \&?
 for a search string (which may be a glob-pattern, as with
-.Ic history-search-backward ),
+.Ic history-search-backward ) ,
 searches for it and copies it into the input buffer.
 The bell rings if no match is found.
 Hitting return ends the search and leaves the last match in the input
@@ -1331,16 +1414,19 @@ buffer.
 Hitting escape ends the search and executes the match.
 .Ic vi
 mode only.
-.It Ic vi-search-fwd Ar (/)
+.
+.It Ic vi-search-fwd No (/)
 Like
 .Ic vi-search-back ,
 but searches forward.
-.It Ic which-command Ar (M-?)
+.
+.It Ic which-command No (M-?)
 Does a
 .Ic which
 (see the description of the builtin command) on the
 first word of the input buffer.
-.It Ic yank-pop Ar (M-y)
+.
+.It Ic yank-pop No (M-y)
 When executed immediately after a
 .Ic yank
 or another
@@ -1354,50 +1440,51 @@ command. Repeating
 will cycle through the
 killring any number of times.
 .El
+.
 .Ss Lexical structure
 The shell splits input lines into words at blanks and tabs.
 The special
 characters
-.Sq \&& ,
-.Sq | ,
-.Sq \&; ,
-.Sq < ,
-.Sq > ,
-.Sq \&( ,
+.Ql \&& ,
+.Ql | ,
+.Ql \&; ,
+.Ql < ,
+.Ql > ,
+.Ql \&( ,
 and
-.Sq \&)
+.Ql \&) ,
 and the doubled characters
-.Sq && ,
-.Sq || ,
-.Sq <<
+.Ql && ,
+.Ql || ,
+.Ql << ,
 and
-.Sq >>
+.Ql >>
 are always separate words, whether or not they are
 surrounded by whitespace.
 .Pp
 When the shell's input is not a terminal, the character
-.Sq #
+.Ql #
 is taken to begin a
 comment.
 Each
-.Sq #
+.Ql #
 and the rest of the input line on which it appears is
 discarded before further parsing.
 .Pp
 A special character (including a blank or tab) may be prevented from having
 its special meaning, and possibly made part of another word, by preceding it
 with a backslash
-.Sq ( \e )
+.Pq Ql \e
 or enclosing it in single
-.Sq ( \&' ) ,
-, double
-.Sq ( \&" )
+.Pq Ql \&' ,
+double
+.Pq Ql \&" ,
 or
 backward
-.Sq ( \&` )
+.Pq Ql \&`
 quotes.
 When not otherwise quoted a newline preceded by a
-.Sq \e
+.Ql \e
 is equivalent to a blank, but inside quotes this sequence results in a
 newline.
 .Pp
@@ -1408,20 +1495,20 @@ Furthermore, all
 can be prevented by enclosing the strings (or parts of strings)
 in which they appear with single quotes or by quoting the crucial character(s)
 (e.g.,
-.Sq $
+.Ql $
 or
-.Sq \&`
+.Ql \&`
 for
 .Sx Variable substitution
 or
 .Sx Command substitution
 respectively)
 with
-.Sq \e
+.Ql \e .
 .Sx ( Alias substitution
 is no exception: quoting in any way any
 character of a word for which an
-.Va alias
+.Ic alias
 has been defined prevents
 substitution of the alias.
 The usual way of quoting an alias is to precede it
@@ -1449,7 +1536,8 @@ Backward quotes are special: they signal
 .Pp
 C-style escape sequences can be used in single quoted strings by
 preceding the leading quote with
-.Sq $ .  (+)
+.Ql $ .
+(+)
 See
 .Sx Escape sequences
 for
@@ -1464,80 +1552,89 @@ those parts of the string which need quoting, using different types of quoting
 to do so if appropriate.
 .Pp
 The
-.Va backslash_quote
+.Ic backslash_quote
 shell variable (q.v.) can be set to make backslashes
 always quote
-.Sq \e ,
-.Sq \&' ,
+.Ql \e ,
+.Ql \&' ,
 and
-.Sq \&"
-(+) This may make complex quoting tasks
+.Ql \&"
+(+). This may make complex quoting tasks
 easier, but it can cause syntax errors in
 .Xr csh 1
 scripts.
+.
 .Ss Escape sequences (+)
 The following escape sequences are always recognized inside a string
-constructed using `$''', and optionally by the \fIecho\fR builtin command as
-controlled by the \fBecho_style\fR shell variable.
-.Bl -tag -width XXXXXXXX -compact -offset indent
-.It \ea
+constructed using
+.Ql $'' ,
+and optionally by the
+.Ic echo
+builtin command as
+controlled by the
+.Ic echo_style
+shell variable.
+.Pp
+.Bl -tag -width 12n -offset indent -compact
+.It Li \ea
 Bell
-.It \eb
+.It Li \eb
 Backspace
-.It \ec\fIc
+.It Li \ec Ns Ar c
 The control character denoted by
-.Va ^c
+.Ql ^ Ns Ar c
 in
 .Xr stty 1 .
 If
-.Va c
+.Ar c
 is a backslash, it must be doubled.
-.It \ee
+.It Li \ee
 Escape
-.It \ef
+.It Li \ef
 Form feed
-.It \en
+.It Li \en
 Newline
-.It \er
+.It Li \er
 Carriage return
-.It \et
+.It Li \et
 Horizontal tab
-.It \ev
+.It Li \ev
 Vertical tab
-.It \e\e
+.It Li \e\e
 Literal backslash
-.It \e\&'
+.It Li \e\&'
 Literal single quote
-.It \e\&"
+.It Li \e\&"
 Literal double quote
-.It \e\fInnn
+.It Li \e Ns Ar nnn
 The character corresponding to the octal number
-.Va nnn
-.It \ex\fInn
+.Ar nnn
+.It Li \ex Ns Ar nn
 The character corresponding to the hexadecimal number
-.Va nn
+.Ar nn
 (1\-2 hexadecimal digits)
-.It \ex{\fInnnnnnnn\fB}
+.It Li \ex{ Ns Ar nnnnnnnn Ns Li }
 The character corresponding to the hexadecimal number
-.Va nnnnnnnn
+.Ar nnnnnnnn
 (1\-8 hexadecimal digits)
-.It \eu\fInnnn
+.It Li \eu Ns Ar nnnn
 The Unicode code point
-.Va nnnn
+.Ar nnnn
 (1\-4 hexadecimal digits)
-.It \eU\fInnnnnnnn
+.It Li \eU Ns Ar nnnnnnnn
 The Unicode code point
-.Va nnnnnnnn
+.Ar nnnnnnnn
 (1\-8 hexadecimal digits).
 .El
 .Pp
 The implementations of
-.Ar \ex ,
-.Ar \eu ,
+.Ql \ex ,
+.Ql \eu ,
 and
-.Ar \eU
+.Ql \eU
 in other shells may take a varying number of digits.  It is often safest
 to use leading zeros to provide the maximum expected number of digits.
+.
 .Ss Substitutions
 We now describe the various transformations the shell performs on the input in
 the order in which they occur.
@@ -1546,46 +1643,47 @@ and the commands and variables which affect them.
 Remember that substitutions
 can be prevented by quoting as described under
 .Sx Lexical structure .
+.
 .Ss History substitution
 Each command, or
-.Sq event ,
+.Dq event ,
 input from the terminal is saved in the history list.
 The previous command is always saved, and the
-.Va history
+.Ic history
 shell
 variable can be set to a number to save that many commands.
 The
-.Va histdup
+.Ic histdup
 shell variable can be set to not save duplicate events or consecutive duplicate
 events.
 .Pp
 Saved commands are numbered sequentially from 1 and stamped with the time.
 It is not usually necessary to use event numbers, but the current event number
 can be made part of the prompt by placing an
-.Sq \&!
+.Ql \&!
 in the
-.Va prompt
+.Ic prompt
 shell variable.
 .Pp
 By default history entries are displayed by printing each parsed token
 separated by space; thus the redirection operator
-.Sq >\&&\&!
+.Ql >\&&\&!
 will be displayed as
-.Sq >\0\&&\0\&! .
+.Ql >\0\&&\0\&! .
 The shell actually saves history in expanded and literal (unexpanded) forms.
 If the
-.Va histlit
+.Ic histlit
 shell variable is set, commands that display and store
 history use the literal form.
 .Pp
 The
-.Va history
+.Ic history
 builtin command can print, store in a file, restore
 and clear the history list at any time,
 and the
-.Va savehist
+.Ic savehist
 and
-.Va histfile
+.Ic histfile
 shell variables can be set to
 store the history list automatically on logout and restore it on login.
 .Pp
@@ -1595,72 +1693,79 @@ command in the current command, or fix spelling mistakes in the previous
 command with little typing and a high degree of confidence.
 .Pp
 History substitutions begin with the character
-.Sq \&!
+.Ql \&! .
 They may begin anywhere in
 the input stream, but they do not nest.
 The
-.Sq \&!
+.Ql \&!
 may be preceded by a
-.Sq \e
+.Ql \e
 to
 prevent its special meaning; for convenience, a
-.Sq \&!
+.Ql \&!
 is passed unchanged when it
 is followed by a blank, tab, newline,
-.Sq =
+.Ql =
 or
-.Sq \&(
+.Ql \&( .
 History substitutions also
 occur when an input line begins with
-.Sq ^
+.Ql ^ .
 This special abbreviation will be
 described later.
-The characters used to signal history substitution 
-.Sq ( \&!
+The characters used to signal history substitution
+.Po
+.Ql \&!
 and
-.Sq ^ )
+.Ql ^
+.Pc
 can be changed by setting the
-.Va histchars
+.Ic histchars
 shell variable.
 Any input
 line which contains a history substitution is printed before it is executed.
 .Pp
 A history substitution may have an
-.Sq event specification ,
+.Dq event specification ,
 which indicates the event from which words are to be taken, a
-.Sq word designator ,
+.Dq word designator ,
 which selects particular words from the chosen event, and/or a
-.Sq modifier ,
+.Dq modifier ,
 which manipulates the selected words.
 .Pp
 An event specification can be
 .Pp
-.Bl -tag -width XXXX -offset indent -compact
+.Bl -tag -width 5n -offset indent -compact
+.
 .It Ar n
 A number, referring to a particular event
-.It Ar \-n
+.
+.It Li \- Ns Ar n
 An offset, referring to the event
 .Ar n
 before the current event
-.It Ar #
+.
+.It Li #
 The current event.
 This should be used carefully in
 .Xr csh 1 ,
 where there is no check for recursion.
 .Nm
-allows 10 levels of recursion.
-(+)
-.It Ar \&!
+allows 10 levels of recursion. (+)
+.
+.It Li \&!
 The previous event (equivalent to
-.Sq \-1 )
+.Ql \-1 )
+.
 .It Ar s
 The most recent event whose first word begins with the string
-.Va s
-.It Ar ?s?
+.Ar s
+.
+.It Li ? Ns Ar s Ns Li ?
 The most recent event which contains the string
-.Va s
+.Ar s .
 The second
-.Sq \&?
+.Ql \&?
 can be omitted if it is immediately followed by a newline.
 .El
 .Pp
@@ -1674,262 +1779,287 @@ For example, consider this bit of someone's history list:
 .Pp
 The commands are shown with their event numbers and time stamps.
 The current event, which we haven't typed in yet, is event 13.
-.Sq !11
+.Ql !11
 and
-.Sq !\-2
+.Ql !\-2
 refer to event 11.
-.Sq \&!!
+.Ql \&!!
 refers to the previous event, 12.
-.Sq \&!!
+.Ql \&!!
 can be abbreviated
-.Sq \&!
+.Ql \&!
 if it is
 followed by
-.Sq \&: 
-.Sq ( \&:
-is described below).
-.Sq !n
+.Ql \&:
+.Po
+.Ql \&:
+is described below
+.Pc .
+.Ql !n
 refers to event 9, which begins with
-.Sq n
-.Sq !?old?
+.Ql n .
+.Ql !?old?
 also refers to event 12, which contains
-.Sq old
+.Ql old .
 Without word designators or modifiers history references simply expand to the
 entire event, so we might type
-.Sq !cp
+.Ql !cp
 to redo the copy command or
-.Sq !!|more
+.Ql !!|more
 if the
-.Sq diff
+.Ql diff
 output scrolled off the top of the screen.
 .Pp
 History references may be insulated from the surrounding text with braces if
 necessary.
 For example,
-.Sq !vdoc
+.Ql !vdoc
 would look for a command beginning with
-.Sq vdoc ,
+.Ql vdoc ,
 and, in this example, not find one, but
-.Sq !{v}doc
+.Ql !{v}doc
 would expand
 unambiguously to
-.Sq vi wumpus.mandoc
+.Ql vi wumpus.mandoc .
 Even in braces, history substitutions do not nest.
 .Pp
 (+) While
 .Xr csh 1
 expands, for example,
-.Sq !3d
+.Ql !3d
 to event 3 with the
 letter
-.Sq d
+.Ql d
 appended to it,
 .Nm
 expands it to the last event beginning
 with
-.Sq 3d ;
+.Ql 3d ;
 only completely numeric arguments are treated as event numbers.
 This makes it possible to recall events beginning with numbers.
 To expand
-.Sq !3d
+.Ql !3d
 as in
 .Xr csh 1
 say
-.Sq !{3}d
+.Ql !{3}d .
 .Pp
 To select words from an event we can follow the event specification by a
-.Sq \&:
+.Ql \&:
 and a designator for the desired words.
 The words of an input line are
 numbered from 0, the first (usually command) word being 0, the second word
 (first argument) being 1, etc.
 The basic word designators are:
 .Pp
-.Bl -tag -width XXXX -offset indent -compact
-.It Ar 0
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li 0
 The first (command) word
+.
 .It Ar n
 The
-.Va n
+.Ar n Ns
 th argument
-.It Ar ^
+.
+.It Li ^
 The first argument, equivalent to
-.Sq 1
-.It Ar $
+.Ql 1
+.
+.It Li $
 The last argument
-.It Ar %
-The word matched by an ?
-.Va s
-? search
-.It Ar x\-y
+.
+.It Li %
+The word matched by an
+.Li ? Ns Ar s Ns Li ? No search
+.
+.It Ar x Ns Li \- Ns Ar y
 A range of words
-.It Ar \-y
+.
+.It Li \- Ns Ar y
 Equivalent to
-.Sq 0\-y
-.It Ar *
+.Ql 0\- Ns Ar y
+.
+.It Li *
 Equivalent to
-.Sq ^\-$ ,
+.Ql ^\-$ ,
 but returns nothing if the event contains only 1 word
-.It Ar x*
+.
+.It Ar x Ns Li *
 Equivalent to
-.Sq x\-$
-.It Ar x\-
+.Sq Ar x Ns Li \-$
+.
+.It Ar x Ns Li \-
 Equivalent to
-.Sq x* ,
+.Sq Ar x Ns Li * ,
 but omitting the last word
-.Sq ( $ )
+.Pq Ql $
 .El
 .Pp
 Selected words are inserted into the command line separated by single blanks.
 For example, the
-.Sq diff
+.Ql diff
 command in the previous example might have been
 typed as
-.Sq diff !!:1.old !!:1
+.Ql diff !!:1.old !!:1
 (using
-.Sq \&:1
+.Ql \&:1
 to select the first argument
 from the previous event) or
-.Sq diff !\-2:2 !\-2:1
+.Ql diff !\-2:2 !\-2:1
 to select and swap the
 arguments from the
-.Sq cp
+.Ql cp
 command.
 If we didn't care about the order of the
-`diff' we might have said
-.Sq diff !\-2:1\-2
+.Ql diff
+we might have said
+.Ql diff !\-2:1\-2
 or simply
-.Sq diff !\-2:*
+.Ql diff !\-2:* .
 The
-.Sq cp
+.Ql cp
 command might have been written
-.Sq cp wumpus.man !#:1.old
-, using
-.Sq #
+.Ql cp wumpus.man !#:1.old ,
+using
+.Ql #
 to refer to the current event.
-`!n:\- hurkle.man' would reuse the first two words from the
-.Sq nroff
+.Ql !n:\- hurkle.man
+would reuse the first two words from the
+.Ql nroff
 command
 to say
-.Sq nroff \-man hurkle.man
+.Ql nroff \-man hurkle.man .
 .Pp
 The
-.Sq \&:
+.Ql \&:
 separating the event specification from the word designator can be
 omitted if the argument selector begins with a
-.Sq ^ ,
-.Sq $ ,
-.Sq * ,
-.Sq %
+.Ql ^ ,
+.Ql $ ,
+.Ql * ,
+.Ql % ,
 or
-.Sq \&-
+.Ql \- .
 For example, our
-.Sq diff
+.Ql diff
 command might have been
-.Sq diff !!^.old !!^
+.Ql diff !!^.old !!^
 or,
 equivalently,
-.Sq diff !!$.old !!$
+.Ql diff !!$.old !!$ .
 However, if
-.Sq \&!!
+.Ql \&!!
 is abbreviated
-.Sq \&!
-,
+.Ql \&! ,
 an argument selector beginning with
-.Sq \-
+.Ql \-
 will be interpreted as an event
 specification.
 .Pp
 A history reference may have a word designator but no event specification.
 It then references the previous command.
 Continuing our
-.Sq diff
-example, we could have said simply `diff
-!^.old !^' or, to get the arguments in the opposite order, just
-.Sq diff !*
+.Ql diff
+example, we could have said simply
+.Ql diff !^.old !^
+or, to get the arguments in the opposite order, just
+.Ql diff !* .
 .Pp
 The word or words in a history reference can be edited, or
-.Sq `modified
-',
+.Dq modified ,
 by following it with one or more modifiers, each preceded by a
-.Sq \&: :
+.Ql \&: :
 .Pp
-.Bl -tag -width XXXXXX -offset indent -compact
-.It Ar h
+.Bl -tag -width 6n -offset indent -compact
+.
+.It Li h
 Remove a trailing pathname component, leaving the head.
-.It Ar t
+.
+.It Li t
 Remove all leading pathname components, leaving the tail.
-.It Ar r
+.
+.It Li r
 Remove a filename extension
-.Sq .xxx ,
+.Sq . Ns Ar xxx ,
 leaving the root name.
-.It Ar e
+.
+.It Li e
 Remove all but the extension.
-.It Ar u
+.
+.It Li u
 Uppercase the first lowercase letter.
-.It Ar l
+.
+.It Li l
 Lowercase the first uppercase letter.
-.It Ar s/l/r/
+.
+.It Li s/ Ns Ar l Ns Li / Ns Ar r Ns Li /
 Substitute
 .Ar l
 for
-.Ar r
+.Ar r .
 .Ar l
 is simply a string like
-.Ar r
-, not a regular expression as in
+.Ar r ,
+not a regular expression as in
 the eponymous
 .Xr ed 1
 command.
 Any character may be used as the delimiter in place of
-.Sq / ;
+.Ql / ;
 a
-.Sq \e
+.Ql \e
 can be used to quote the delimiter inside
-.Va l
+.Ar l
 and
-.Va r
+.Ar r
 The character
-.Sq &
+.Ql &
 in the
-.Va r
+.Ar r
 is replaced by
-.Va l ;
-.Sq \e
+.Ar l ;
+.Ql \e
 also quotes
-.Sq &
+.Ql & .
 If
-.Va l
-is empty (
-.Dq \& ) ,
+.Ar l
+is empty
+.Sq ( \& ) ,
 the
-.Va l
+.Ar l
 from a previous substitution or the
-.Va s
+.Ar s
 from a previous search or event number in event specification is used.
 The trailing delimiter may be omitted if it is immediately followed by a
 newline.
-.It Ar \&&
+.
+.It Li \&&
 Repeat the previous substitution.
-.It Ar g
+.
+.It Li g
 Apply the following modifier once to each word.
-.It Ar a (+)
+.
+.It Li a No (+)
 Apply the following modifier as many times as possible to a single word.
-.Sq a
+.Ql a
 and
-.Sq g
+.Ql g
 can be used together to apply a modifier globally.
 With the
-.Sq s
+.Ql s
 modifier, only the patterns contained in the original word are
 substituted, not patterns that contain any substitution result.
-.It Ar p
+.
+.It Li p
 Print the new command line but do not execute it.
-.It Ar q
+.
+.It Li q
 Quote the substituted words, preventing further substitutions.
-.It Ar Q
+.
+.It Li Q
 Same as
-.Ar q
+.Ql q
 but in addition preserve empty variables as a string containing a NUL.
 This is useful to preserve positional arguments for example:
 .Bd -literal -offset indent -compact
@@ -1937,58 +2067,60 @@ This is useful to preserve positional arguments for example:
 > tcsh -f -c 'echo ${#argv}' $args:gQ
 3
 .Ed
-.It Ar x
-Like 
-.Ar q ,
+.
+.It Li x
+Like
+.Ql q ,
 but break into words at blanks, tabs and newlines.
 .El
 .Pp
 Modifiers are applied to only the first modifiable word (unless
-.Sq g
+.Ql g
 is used).
 It is an error for no word to be modifiable.
 .Pp
 For example, the
-.Sq diff
-command might have been written as `diff wumpus.man.old
-!#^:r', using
-.Sq \&:r
+.Ql diff
+command might have been written as
+.Ql diff wumpus.man.old !#^:r ,
+using
+.Ql \&:r
 to remove
-.Sq .old
+.Ql .old
 from the first argument on the same line
 (`!#^').
 We could say
-.Sq echo hello out there
-, then
-.Sq echo !*:u
+.Ql echo hello out there ,
+then
+.Ql echo !*:u
 to capitalize
-`hello',
-.Sq echo !*:au
+.Ql hello ,
+.Ql echo !*:au
 to say it out loud, or
-.Sq echo !*:agu
+.Ql echo !*:agu
 to really shout.
 We might follow
-.Sq mail \-s "I forgot my password" rot
+.Ql mail \-s \&"I forgot my password\&" rot
 with
-.Sq !:s/rot/root
+.Ql !:s/rot/root
 to
 correct the spelling of
-.Sq root
+.Ql root
 (but see
 .Sx Spelling correction
 for a
 different approach).
 .Pp
 There is a special abbreviation for substitutions.
-.Sq ^ ,
+.Ql ^ ,
 when it is the first character on an input line, is equivalent to
-.Sq !:s^
+.Ql !:s^ .
 Thus we might have said
-.Sq ^rot^root
+.Ql ^rot^root
 to make the spelling correction in the
 previous example.
 This is the only history substitution which does not explicitly begin with
-.Sq \&!
+.Ql \&! .
 .Pp
 (+) In
 .Xr csh 1
@@ -2006,7 +2138,7 @@ man wumpus
 In
 .Xr csh 1 ,
 the result would be
-.Sq wumpus.1:r
+.Ql wumpus.1:r .
 A substitution followed by a
 colon may need to be insulated from it with braces:
 .Bd -literal -offset indent
@@ -2025,23 +2157,23 @@ because
 .Nm
 expects another modifier after the second colon
 rather than
-.Sq $
+.Ql $ .
 .Pp
 Finally, history can be accessed through the editor as well as through
 the substitutions just described.
 The
-.Ic up-
+.Ic up-history
 and
 .Ic down-history ,
 .Ic history-search-backward
 and
-.Va -forward ,
+.Ic history-search-forward ,
 .Ic i-search-back
 and
-.Ic -fwd ,
+.Ic i-search-fwd ,
 .Ic vi-search-back
 and
-.Ic -fwd ,
+.Ic vi-search-fwd ,
 .Ic copy-prev-word
 and
 .Ic insert-last-word
@@ -2056,6 +2188,7 @@ and
 .Ic expand-line
 expand history substitutions
 in the current word and in the entire input buffer respectively.
+.
 .Ss Alias substitution
 The shell maintains a list of aliases which can be set, unset and printed by
 the
@@ -2071,37 +2204,38 @@ left-to-right, is checked to see if it has an alias.
 If so, the first word is
 replaced by the alias.
 If the alias contains a history reference, it undergoes
-.Va History substitution
+.Sx History substitution
 (q.v.) as though the original command were the
 previous input line.
 If the alias does not contain a history reference, the
 argument list is left untouched.
 .Pp
 Thus if the alias for
-.Sq ls
+.Ql ls
 were
-.Sq ls \-l
+.Ql ls \-l
 the command
-.Sq ls /usr
-would become `ls
-\-l /usr', the argument list here being undisturbed.
+.Ql ls /usr
+would become
+.Ql ls \-l /usr ,
+the argument list here being undisturbed.
 If the alias for
-.Sq lookup
+.Ql lookup
 were
-.Sq grep !/etc/passwd
+.Ql grep !^ /etc/passwd
 then
-.Sq lookup bill
-would become `grep bill
-/etc/passwd'.
+.Ql lookup bill
+would become
+.Ql grep bill /etc/passwd .
 Aliases can be used to introduce parser metasyntax.
-For
-example,
-.Sq alias print
-pr \e!* | lpr'' defines a
-.Sq `command
-' (`print') which
-.Va pr
-(1)s its arguments to the line printer.
+For example,
+.Sq alias print 'pr \e!* | lpr'
+defines a
+.Dq command
+.Pq Ql print
+which
+.Xr pr 1 Ns s
+its arguments to the line printer.
 .Pp
 Alias substitution is repeated until the first word of the command has no
 alias.
@@ -2111,55 +2245,56 @@ Other loops are detected and
 cause an error.
 .Pp
 Some aliases are referred to by the shell; see
-.Va Special aliases
+.Sx Special aliases .
+.
 .Ss Variable substitution
 The shell maintains a list of variables, each of which has as value a list of
 zero or more words.
 The values of shell variables can be displayed and changed with the
-.Va set
+.Ic set
 and
-.Va unset
+.Ic unset
 commands.
 The system maintains its own list of
-.Sq `environment
-' variables.
+.Dq environment
+variables.
 These can be displayed and changed with
-.Va printenv
-,
-.Va setenv
+.Ic printenv ,
+.Ic setenv ,
 and
-.Va unsetenv
+.Ic unsetenv .
 .Pp
 (+) Variables may be made read-only with
-.Sq set \-r
+.Ql set \-r
 (q.v.).
 Read-only variables may not be modified or unset;
 attempting to do so will cause an error.
 Once made read-only, a variable cannot be made writable,
 so
-.Sq set \-r
+.Ql set \-r
 should be used with caution.
 Environment variables cannot be made read-only.
 .Pp
 Some variables are set by the shell or referred to by it.
 For instance, the
-.Va argv
+.Ic argv
 variable is an image of the shell's argument
 list, and words of this variable's value are referred to in special ways.
 Some of the variables referred to by the shell are toggles;
 the shell does not care what their value is, only whether they are set or not.
 For instance, the
-.Va verbose
+.Ic verbose
 variable is a toggle which causes command
 input to be echoed.
 The
-.Fl v\fR command line option sets this variable.
-.Va Special shell variables
+.Fl v
+command line option sets this variable.
+.Sx Special shell variables
 lists all variables which are referred to by the shell.
 .Pp
 Other operations treat variables numerically.
 The
-.Sq @
+.Sq Ic @
 command permits numeric
 calculations to be performed and the result assigned to a variable.
 Variable
@@ -2170,33 +2305,32 @@ the second and subsequent words of multi-word values are ignored.
 .Pp
 After the input line is aliased and parsed, and before each command is
 executed, variable substitution is performed keyed by
-.Sq $
+.Ql $
 characters.
 This
 expansion can be prevented by preceding the
-.Sq $
+.Ql $
 with a
-.Sq \e
+.Ql \e
 except within
-.Sq "
-s
-where it
-.Va always
+.Ql \&"
+pairs where it
+.Em always
 occurs, and within
-.Sq
-'s where it
-.Va never
+.Ql \&'
+pairs where it
+.Em never
 occurs.
 Strings quoted by
-.Sq \`
+.Ql \`
 are interpreted later (see
 .Sx Command substitution
 below) so
-.Sq $
+.Ql $
 substitution does not occur there until later,
 if at all.
 A
-.Sq $
+.Ql $
 is passed unchanged if followed by a blank, tab, or
 end-of-line.
 .Pp
@@ -2209,19 +2343,19 @@ It is thus possible for the first (command) word
 command name, and the rest of which become arguments.
 .Pp
 Unless enclosed in
-.Sq "
+.Ql \&"
 or given the
-.Sq \&:q
+.Ql \&:q
 modifier the results of variable
 substitution may eventually be command and filename substituted.
 Within
-.Sq "
-, a
+.Ql \&" ,
+a
 variable whose value consists of multiple words expands to a (portion of a)
 single word, with the words of the variable's value separated by blanks.
 When
 the
-.Sq \&:q
+.Ql \&:q
 modifier is applied to a substitution the variable will expand to
 multiple words with each word separated by a blank and quoted to prevent later
 command or filename substitution.
@@ -2231,16 +2365,16 @@ the shell input.
 Except as noted, it is an error to reference a variable which
 is not set.
 .Pp
-.Bl -tag -width XXXXXXXXXX -offset indent -compact
-.PD 0
-.It Ar $name
-.It Ar ${name}
+.Bl -tag -width 10n -offset indent -compact
+.
+.It Li $ Ns Ar name
+.It Li ${ Ns Ar name Ns Li }
 Substitutes the words of the value of variable
-.Va name ,
+.Ar name ,
 each separated
 by a blank.
 Braces insulate
-.Va name
+.Ar name
 from following characters which would
 otherwise be part of it.
 Shell variables have names consisting of
@@ -2248,55 +2382,62 @@ letters and digits starting with a letter.
 The underscore character is
 considered a letter.
 If
-.Va name
+.Ar name
 is not a shell variable, but is set in the
 environment, then that value is returned (but some of the other forms
 given below are not available in this case).
-.It Ar $name[selector]
-.It Ar ${name[selector]}
+.
+.Pp
+.It Li $ Ns Ar name Ns Li [ Ns Ar selector Ns Li ]
+.It Li ${ Ns Ar name Ns Li [ Ns Ar selector Ns Li ]}
 Substitutes only the selected words from the value of
-.Va name
+.Ar name .
 The
-.Va selector
+.Ar selector
 is subjected to
-.Sq $
+.Ql $
 substitution and may consist of
 a single number or two numbers separated by a
-.Sq \&-
+.Ql \- .
 The first word of a variable's value is numbered
-.Sq 1
+.Ql 1 .
 If the first number of a range is omitted it defaults to
-.Sq 1
+.Ql 1 .
 If the last member of a range is omitted it defaults to
-.Sq $#
-.Va name
+.Ql $# Ns Ar name .
 The
-.Va selector
-.Sq *
+.Ar selector
+.Ql *
 selects all words.
 It is not an error for a range to be empty if the
 second argument is omitted or in range.
-.It Ar $0
+.
+.Pp
+.It Li $0
 Substitutes the name of the file from which command input
 is being read.
 An error occurs if the name is not known.
-.It Ar $number
-.It Ar ${number}
+.
+.Pp
+.It Li $ Ns Ar number
+.It Li ${ Ns Ar number Ns Li }
 Equivalent to
-.Sq $argv[number]
-.It Ar $*
+.Ql $argv[ Ns Ar number Ns Li \] .
+.
+.Pp
+.It Li $*
 Equivalent to
-.Sq $argv ,
+.Ql $argv ,
 which is equivalent to
-.Sq $argv[*]
+.Ql $argv[*] .
 .El
 .Pp
 The
-.Sq \&:
+.Ql \&:
 modifiers described under
 .Sx History substitution ,
 except for
-.Sq \&:p ,
+.Ql \&:p ,
 can be applied to the substitutions above.
 More than one may be used.
 (+)
@@ -2307,68 +2448,90 @@ just as with
 within the braces.
 .Pp
 The following substitutions can not be modified with
-.Sq \&:
+.Ql \&:
 modifiers.
 .Pp
-.Bl -tag -width XXXXXXXXXX -offset indent -compact
-.It Ar $?name
-.It Ar ${?name}
+.Bl -tag -width 10n -offset indent -compact
+.
+.It Li $? Ns Ar name
+.It Li ${? Ns Ar name Ns Li }
 Substitutes the string
-.Sq 1
+.Ql 1
 if
-.Va name
+.Ar name
 is set,
-.Sq 0
+.Ql 0
 if it is not.
-.It Ar $?0
+.
+.Pp
+.It Li $?0
 Substitutes
-.Sq 1
+.Ql 1
 if the current input filename is known,
-.Sq 0
+.Ql 0
 if it is not.
 Always
-.Sq 0
+.Ql 0
 in interactive shells.
-.It Ar $#name
-.It Ar ${#name}
-Substitutes the number of words in
-.Va name
-.It Ar $#
-Equivalent to
-.Sq $#argv
-(+)
-.It Ar $%name
-.It Ar ${%name}
-Substitutes the number of characters in
-.Va name
-(+)
+.
 .Pp
-.It Ar $%number
-.It Ar ${%number}
-Substitutes the number of characters in
-.Va $argv[number] .
-(+)
-.It Ar $?
+.It Li $# Ns Ar name
+.It Li ${# Ns Ar name Ns Li }
+Substitutes the number of words in
+.Ar name .
+.
+.Pp
+.It Li $#
 Equivalent to
-.Sq $status
+.Ql $#argv .
 (+)
-.It Ar $$
+.
+.Pp
+.It Li $% Ns Ar name
+.It Li ${% Ns Ar name Ns Li }
+Substitutes the number of characters in
+.Ar name .
+(+)
+.
+.Pp
+.It Li $% Ns Ar number
+.It Li ${% Ns Ar number Ns Li }
+Substitutes the number of characters in
+.Ql $argv[ Ns Ar number Ns Li \] .
+(+)
+.
+.Pp
+.It Li $?
+Equivalent to
+.Ql $status .
+(+)
+.
+.Pp
+.It Li $$
 Substitutes the (decimal) process number of the (parent) shell.
-.It Ar $!
+.
+.Pp
+.It Li $!
 Substitutes the (decimal) process number of the last
 background process started by this shell.
 (+)
-.It Ar $_
+.
+.Pp
+.It Li $_
 Substitutes the command line of the last command executed.
 (+)
-.It Ar $<
+.
+.Pp
+.It Li $<
 Substitutes a line from the standard input, with no further interpretation
 thereafter.
 It can be used to read from the keyboard in a shell script.
 (+) While
 .Xr csh 1
-always quotes $<, as if it were equivalent to
-.Sq $<:q ,
+always quotes
+.Ql $< ,
+as if it were equivalent to
+.Ql $<:q ,
 .Nm
 does not.
 Furthermore, when
@@ -2381,10 +2544,11 @@ does not allow this.
 .El
 .Pp
 The editor command
-.Va expand-variables
-, normally bound to
+.Ic expand-variables ,
+normally bound to
 .Sq ^X-$ ,
 can be used to interactively expand individual variables.
+.
 .Ss "Command, filename and directory stack substitution"
 The remaining substitutions are applied selectively to the arguments
 of builtin commands.
@@ -2392,11 +2556,12 @@ This means that portions of expressions which are not evaluated are
 not subjected to these expansions.
 For commands which are not internal to the
 shell, the command name is substituted separately from the argument list.
-This occurs very late, after input-output redirection is performed, andk
+This occurs very late, after input-output redirection is performed, and
 in a child of the main shell.
+.
 .Ss "Command substitution"
 Command substitution is indicated by a command enclosed in
-.Sq \&`
+.Ql \&` .
 The output
 from such a command is broken into separate words at blanks, tabs and newlines,
 and null words are discarded.
@@ -2405,7 +2570,7 @@ and put in place of the original string.
 .Pp
 Command substitutions inside double
 quotes
-.Sq ( \&" )
+.Pq Ql \&"
 retain blanks and tabs; only newlines force new words.
 The single
 final newline does not force a new word in any case.
@@ -2417,18 +2582,19 @@ By default, the shell since version 6.12 replaces all newline and carriage
 return characters in the command by spaces.
 If this is switched off by
 unsetting
-.Va csubstnonl ,
+.Ic csubstnonl ,
 newlines separate commands as usual.
+.
 .Ss "Filename substitution"
 If a word contains any of the characters
-.Sq * ,
-.Sq \&? ,
-.Sq \&[
+.Ql * ,
+.Ql \&? ,
+.Ql \&[ ,
 or
-.Sq {
+.Ql {
 or begins with
 the character
-.Sq ~
+.Ql ~
 it is a candidate for filename substitution, also known as
 .Dq globbing .
 This word is then regarded as a pattern
@@ -2438,45 +2604,45 @@ replaced with an alphabetically sorted list of file names which match the
 pattern.
 .Pp
 In matching filenames, the character
-.Sq .
+.Ql \&.
 at the beginning of a filename or
 immediately following a
-.Sq / ,
+.Ql / ,
 as well as the character
-.Sq /
+.Ql /
 must be matched
 explicitly (unless either
-.Va globdot
+.Ic globdot
 or
-.Va globstar
-or both are set(+)).
+.Ic globstar
+or both are set (+)).
 The character
-.Sq *
+.Ql *
 matches any string of characters,
 including the null string.
 The character
-.Sq \&?
+.Ql \&?
 matches any single character.
 The sequence
-.Sq [...]
+.Ql [...]
 matches any one of the characters enclosed.
 Within
-.Sq [...]
-, a pair of
+.Ql [...] ,
+a pair of
 characters separated by
-.Sq \&-
+.Ql \-
 matches any character lexically between the two.
 .Pp
 (+) Some glob-patterns can be negated:
 The sequence
-.Sq [^...]
+.Ql [^...]
 matches any single character
-.Va not
+.Em not
 specified by the
 characters and/or ranges of characters in the braces.
 .Pp
 An entire glob-pattern can also be negated with
-.Sq ^ :
+.Ql ^ :
 .Bd -literal -offset indent
 > echo *
 bang crash crunch ouch
@@ -2485,180 +2651,186 @@ bang ouch
 .Ed
 .Pp
 Glob-patterns which do not use
-.Sq \&? ,
-.Sq * , or
-.Sq []
-or which use
-.Sq {}
+.Ql \&? ,
+.Ql * ,
 or
-.Sq ~
+.Ql [] ,
+or which use
+.Ql {}
+or
+.Ql ~
 (below) are not negated correctly.
 .Pp
 The metanotation
-.Sq a{b,c,d}e
+.Ql a{b,c,d}e
 is a shorthand for
-.Sq abe ace ade
+.Ql abe ace ade .
 Left-to-right order is preserved:
-.Sq /usr/source/s1/{oldls,ls}.c
+.Ql /usr/source/s1/{oldls,ls}.c
 expands
 to
-.Sq /usr/source/s1/oldls.c /usr/source/s1/ls.c
+.Ql /usr/source/s1/oldls.c /usr/source/s1/ls.c .
 The results of matches are
 sorted separately at a low level to preserve this order:
-.Sq ../{memo,*box}
+.Ql ../{memo,*box}
 might expand to
-.Sq ../memo ../box ../mbox
+.Ql ../memo ../box ../mbox .
 (Note that
-.Sq memo
+.Ql memo
 was not sorted with the results of matching
-.Sq *box . )
+.Ql *box . )
 It is not an error when this construct expands to files which do not exist,
 but it is possible to get an error from a command to which the expanded list
 is passed.
 This construct may be nested.
 As a special case the words
-.Sq { ,
-.Sq }
+.Ql { ,
+.Ql } ,
 and
-.Sq {}
+.Ql {}
 are passed undisturbed.
 .Pp
 The character
-.Sq ~
+.Ql ~
 at the beginning of a filename refers to home directories.
 Standing alone, i.e.,
-.Sq ~ ,
+.Ql ~ ,
 it expands to the invoker's home directory as
 reflected in the value of the
-.Va home
+.Ic home
 shell variable.
 When followed by a
 name consisting of letters, digits and
-.Sq \&-
+.Ql \-
 characters the shell searches for a
 user with that name and substitutes their home directory; thus
-.Sq ~ken
+.Ql ~ken
 might
 expand to
-.Sq /usr/ken
+.Ql /usr/ken
 and
-.Sq ~ken/chmach
+.Ql ~ken/chmach
 to
-.Sq /usr/ken/chmach
+.Ql /usr/ken/chmach .
 If the character
-.Sq ~
+.Ql ~
 is followed by a character other than a letter or
-.Sq /
+.Ql /
 or appears elsewhere
 than at the beginning of a word, it is left undisturbed.
 A command like
-.Sq setenv MANPATH /usr/share/man:/usr/local/share/man:~/lib/man
+.Ql setenv MANPATH /usr/share/man:/usr/local/share/man:~/lib/man
 does not,
 therefore, do home directory substitution as one might hope.
 .Pp
 It is an error for a glob-pattern containing
-.Sq * ,
-.Sq \&?  ,
-.Sq \&[
+.Ql * ,
+.Ql \&? ,
+.Ql \&[ ,
 or
-.Sq ~ ,
+.Ql ~ ,
 with or
 without
-.Sq ^ ,
+.Ql ^ ,
 not to match any files.
 However, only one pattern in a list of
 glob-patterns must match a file (so that, e.g.,
-.Sq rm *.a *.c *.o
+.Ql rm *.a *.c *.o
 would fail
 only if there were no files in the current directory ending in
-.Sq .a ,
-.Sq .c ,
+.Ql .a ,
+.Ql .c ,
 or
-.Sq .o ) ,
+.Ql .o ) ,
 and if the
-.Va nonomatch
+.Ic nonomatch
 shell variable is set a pattern (or list
 of patterns) which matches nothing is left unchanged rather than causing
 an error.
 .Pp
 The
-.Va globstar
+.Ic globstar
 shell variable can be set to allow
-.Sq **
+.Ql **
 or
-.Sq ***
+.Ql ***
 as
 a file glob pattern that matches any string of characters including
-.Sq / ,
+.Ql / ,
 recursively traversing any existing sub-directories.
 For example,
-.Sq ls **.c
+.Ql ls **.c
 will list all the .c files in the current directory tree.
 If used by itself, it will match zero or more sub-directories
 (e.g.
-.Sq ls /usr/include/**/time.h
+.Ql ls /usr/include/**/time.h
 will list any file named
-.Sq time.h
-in the /usr/include directory tree;
-.Sq ls /usr/include/**time.h
+.Ql time.h
+in the
+.Pa /usr/include
+directory tree;
+.Ql ls /usr/include/**time.h
 will match
-any file in the /usr/include directory tree ending in
-.Sq time.h ;
+any file in the
+.Pa /usr/include
+directory tree ending in
+.Ql time.h ;
 and
-.Sq ls /usr/include/**time**.h
+.Ql ls /usr/include/**time**.h
 will match any .h file with
-.Sq time
+.Ql time
 either
 in a subdirectory name or in the filename itself).
 To prevent problems with recursion, the
-.Sq **
+.Ql **
 glob-pattern will not
 descend into a symbolic link containing a directory.
 To override this,
 use
-.Sq ***
+.Ql ***
 (+)
 .Pp
 The
-.Va noglob
+.Ic noglob
 shell variable can be set to prevent filename substitution,
 and the
-.Va expand-glob
+.Ic expand-glob
 editor command, normally bound to
 .Sq ^X-* ,
 can be
 used to interactively expand individual filename substitutions.
+.
 .Ss "Directory stack substitution (+)"
 The directory stack is a list of directories, numbered from zero, used by the
-.Va pushd ,
-.Va popd
+.Ic pushd ,
+.Ic popd ,
 and
-.Va dirs
+.Ic dirs
 builtin commands (q.v.).
-.Va dirs
+.Ic dirs
 can print, store in a file, restore and clear the directory stack
 at any time, and the
-.Va savedirs
+.Ic savedirs
 and
-.Va dirsfile
+.Ic dirsfile
 shell variables can be set to
 store the directory stack automatically on logout and restore it on login.
 The
-.Va dirstack
+.Ic dirstack
 shell variable can be examined to see the directory stack and
 set to put arbitrary directories into the directory stack.
 .Pp
 The character
-.Sq =
+.Ql =
 followed by one or more digits expands to an entry in
 the directory stack.
 The special case
-.Sq =-
+.Ql =-
 expands to the last directory in
 the stack.
 For example,
 .Bd -literal -offset indent
-> dirs \&-v
+> dirs \-v
 0       /usr/bin
 1       /usr/spool/uucp
 2       /usr/accts/sys
@@ -2671,72 +2843,77 @@ For example,
 .Ed
 .Pp
 The
-.Va noglob
+.Ic noglob
 and
-.Va nonomatch
+.Ic nonomatch
 shell variables and the
-.Va expand-glob
+.Ic expand-glob
 editor command apply to directory stack as well as filename substitutions.
+.
 .Ss "Other substitutions (+)"
 There are several more transformations involving filenames, not strictly
 related to the above but mentioned here for completeness.
-.Va Any
+.Em Any
 filename may be expanded to a full path when the
-.Va symlinks
+.Ic symlinks
 variable (q.v.) is set to
-.Sq expand
+.Ql expand .
 Quoting prevents this expansion, and
 the
-.Va normalize-path
+.Ic normalize-path
 editor command does it on demand.
 The
-.Va normalize-command
-editor command expands commands in PATH into
-full paths on demand.
+.Ic normalize-command
+editor command expands commands in
+.Ev PATH
+into full paths on demand.
 Finally,
-.Va cd
+.Ic cd
 and
-.Va pushd
+.Ic pushd
 interpret
-.Sq \&-
+.Ql \-
 as the old working directory
 (equivalent to the shell variable
-.Va owd ) .
+.Ic owd ) .
 This is not a substitution at all, but an abbreviation recognized by only
 those commands.
 Nonetheless, it too can be prevented by quoting.
+.
 .Ss "Commands"
 The next three sections describe how the shell executes commands and
 deals with their input and output.
+.
 .Ss "Simple commands, pipelines and sequences"
 A simple command is a sequence of words, the first of which specifies the
 command to be executed.
 A series of simple commands joined by
-.Sq |
+.Ql |
 characters
 forms a pipeline.
 The output of each command in a pipeline is connected to the
 input of the next.
 .Pp
 Simple commands and pipelines may be joined into sequences with
-.Sq ; ,
+.Ql \&; ,
 and will
 be executed sequentially.
 Commands and pipelines can also be joined into
 sequences with
-.Sq ||
+.Ql ||
 or
-.Sq && ,
+.Ql && ,
 indicating, as in the C language, that the second
 is to be executed only if the first fails or succeeds respectively.
 .Pp
 A simple command, pipeline or sequence may be placed in parentheses,
-.Sq () ,
+.Ql () ,
 to form a simple command, which may in turn be a component of a pipeline or
 sequence.
 A command, pipeline or sequence can be executed
 without waiting for it to terminate by following it with an
-.Sq \&& .
+.Ql \&& .
+.
 .Ss "Builtin and non-builtin command execution"
 Builtin commands are executed within the shell.
 If any component of a
@@ -2749,7 +2926,7 @@ Parenthesized commands are always executed in a subshell.
 .Ed
 .Pp
 thus prints the
-.Va home
+.Ic home
 directory, leaving you where you were
 (printing this after the home directory), while
 .Bd -literal -offset indent
@@ -2757,18 +2934,18 @@ cd; pwd
 .Ed
 .Pp
 leaves you in the
-.Va home
+.Ic home
 directory.
 Parenthesized commands are most often
 used to prevent
-.Va cd
+.Ic cd
 from affecting the current shell.
 .Pp
 When a command to be executed is found not to be a builtin command the shell
 attempts to execute the command via
 .Xr execve 2 .
 Each word in the variable
-.Va path
+.Ic path
 names a directory in which the shell will look for the
 command.
 If the shell is not given a
@@ -2782,22 +2959,21 @@ command resides there.
 This greatly speeds command location when a large
 number of directories are present in the search path. This hashing mechanism is
 not used:
-.TP 4
-.Bl -enum -width indent
+.Bl -enum -width 2n -offset indent
 .It
 If hashing is turned explicitly off via
-.Va unhash
+.Ic unhash .
 .It
 If the shell was given a
-.Fl f Ar argument
-.It 
+.Fl f Ar argument .
+.It
 For each directory component of
-.Va path
+.Ic path
 which does not begin with a
-.Sq /
+.Ql / .
 .It
 If the command contains a
-.Sq /
+.Ql / .
 .El
 .Pp
 In the above four cases the shell concatenates each component of the path
@@ -2809,127 +2985,130 @@ If the file has execute permissions but is not an executable to the system
 interpreter), then it is assumed to be a file containing shell commands and
 a new shell is spawned to read it.
 The
-.Va shell
+.Ic shell
 special alias may be set
 to specify an interpreter other than the shell itself.
 .Pp
 On systems which do not understand the
-.Sq #!
+.Ql #!
 script interpreter convention
 the shell may be compiled to emulate it; see the
-.Va version
+.Ic version
 shell
 variable.
 If so, the shell checks the first line of the file to
 see if it is of the form
-.Sq #!interpreter arg ...
+.Ql #! Ns Ar interpreter arg Li \&... .
 If it is,
 the shell starts
-.Va interpreter
+.Ar interpreter
 with the given
-.Va arg
+.Ar arg Ns
 s and feeds the
 file to it on standard input.
+.
 .Ss "Input/output"
 The standard input and standard output of a command may be redirected with the
 following syntax:
 .Pp
-.Bl -tag -width XXXXXXXXX -offset indent -compact
-.It Ar < name
+.Bl -tag -width 8n -offset indent -compact
+.
+.It Li < Ar name
 Open file
-.Va name
+.Ar name
 (which is first variable, command and filename
 expanded) as the standard input.
-.It Ar << word
+.
+.Pp
+.It Li << Ar word
 Read the shell input up to a line which is identical to
-.Va word .
-.Va word
+.Ar word .
+.Ar word
 is not subjected to variable, filename or command substitution, and each input
 line is compared to
-.Va word
+.Ar word
 before any substitutions are done on this input
 line.
 Unless a quoting
-.Sq \e ,
-.Sq \&"
-,
-.Sq \&'
+.Ql \e ,
+.Ql \&" ,
+.Ql \&' ,
 or
-.Sq \&`
+.Ql \&`
 appears in
-.Va word
+.Ar word
 variable and
 command substitution is performed on the intervening lines, allowing
-.Sq \e
+.Ql \e
 to
 quote
-.Sq $ ,
-.Sq \e
+.Ql $ ,
+.Ql \e ,
 and
-.Sq \&` .
+.Ql \&` .
 Commands which are substituted have all blanks, tabs,
 and newlines preserved, except for the final newline which is dropped.
 The
 resultant text is placed in an anonymous temporary file which is given to the
 command as standard input.
 .Pp
-.It Ar > name
-.It Ar >! name
-.It Ar >& name
-.It Ar >&! name
+.It Li > Ar name
+.It Li >! Ar name
+.It Li >& Ar name
+.It Li >&! Ar name
 The file
-.Va name
+.Ar name
 is used as standard output.
 If the file does not exist
 then it is created; if the file exists, it is truncated, its previous contents
 being lost.
 .Pp
 If the shell variable
-.Va noclobber
+.Ic noclobber
 is set, then the file must not exist or be a
 character special file (e.g., a terminal or
-.Sq /dev/null )
+.Pa /dev/null )
 or an error results.
 This helps prevent accidental destruction of files.
 In this case the
-.Sq \&!
+.Ql \&!
 forms
 can be used to suppress this check.
 If
-.Va notempty
+.Ql notempty
 is given in
-.Va noclobber ,
-.Sq >
+.Ic noclobber ,
+.Ql >
 is allowed on empty files;
 if
-.Va ask
+.Ql ask
 is set, an interacive confirmation is presented, rather than an
 error.
 .Pp
 The forms involving
-.Sq \&&
+.Ql \&&
 route the diagnostic output into the specified file as
 well as the standard output.
-.Va name
+.Ar name
 is expanded in the same way as
-.Sq <
+.Ql <
 input filenames are.
 .Pp
-.It Ar >> name
-.It Ar >>& name
-.It Ar >>! name
-.It Ar >>&! name
+.It Li >> Ar name
+.It Li >>& Ar name
+.It Li >>! Ar name
+.It Li >>&! Ar name
 Like
-.Sq >
-, but appends output to the end of
-.Va name
+.Ql > ,
+but appends output to the end of
+.Ar name .
 If the shell variable
-.Va noclobber
+.Ic noclobber
 is set, then it is an error for
 the file
-.Va not
+.Em not
 to exist, unless one of the
-.Sq \&!
+.Ql \&!
 forms is given.
 .El
 .Pp
@@ -2939,16 +3118,16 @@ Thus, unlike some previous shells, commands run from a file of shell commands
 have no access to the text of the commands by default; rather they receive the
 original standard input of the shell.
 The
-.Sq <<
+.Ql <<
 mechanism should be used to
 present inline data.
 This permits shell command scripts to function as
 components of pipelines and allows the shell to block read its input.
 Note
 that the default standard input for a command run detached is
-.Va not
+.Em not
 the empty file
-.Va /dev/null ,
+.Pa /dev/null ,
 but the original standard input of the shell.
 If this is a terminal and if the process attempts to read from the terminal,
 then the process will block and the user will be notified (see
@@ -2956,24 +3135,26 @@ then the process will block and the user will be notified (see
 .Pp
 Diagnostic output may be directed through a pipe with the standard output.
 Simply use the form
-.Sq |&
+.Ql |&
 rather than just
-.Sq | .
+.Ql | .
 .Pp
 The shell cannot presently redirect diagnostic output without also redirecting
 standard output, but
-.Sq \&( command > output-file ) >&  error-file
+.Ql \&( Ar command Li > Ar output-file Li ) >& Ar error-file
 is often an acceptable workaround.
 Either
-.Va output-file
+.Ar output-file
 or
-.Va error-file
+.Ar error-file
 may be
-.Sq /dev/tty
+.Pa /dev/tty
 to send output to the terminal.
+.
 .Ss "Features"
 Having described how the shell accepts, parses and executes
 command lines, we now turn to a variety of its useful features.
+.
 .Ss "Control flow"
 The shell contains a number of commands which can be used to regulate the
 flow of control in command files (shell scripts) and (in limited but
@@ -2983,14 +3164,14 @@ shell to reread or skip in its input and, due to the implementation,
 restrict the placement of some of the commands.
 .Pp
 The
-.Va foreach ,
-.Va switch ,
+.Ic foreach ,
+.Ic switch ,
 and
-.Va while
+.Ic while
 statements, as well as the
-.Va if-then-else
+.Ic if \&... then \&... else
 form of the
-.Va if
+.Ic if
 statement, require that the major
 keywords appear in a single simple command on an input line as shown below.
 .Pp
@@ -2998,315 +3179,359 @@ If the shell's input is not seekable, the shell buffers up input whenever
 a loop is being read and performs seeks in this internal buffer to
 accomplish the rereading implied by the loop.
 (To the extent that this allows, backward
-.Va goto
+.Ic goto Ns
 s will succeed on non-seekable inputs.)
+.
 .Ss "Expressions"
 The
-.Va if ,
-.Va while
+.Ic if ,
+.Ic while ,
 and
-.Va exit
+.Ic exit
 builtin commands
 use expressions with a common syntax.
 The expressions can include any
 of the operators described in the next three sections.
 Note that the
-.Va @
+.Ic @
 builtin command (q.v.) has its own separate syntax.
+.
 .Ss "Logical, arithmetical and comparison operators"
 These operators are similar to those of C and have the same precedence.
 They include
-.IP "" 4
-.Bl -tag -width XXXXXX -offset indent -compact
-.It ||  &&  |   &  ==  !=  =~  !~  <=  >=
-.It <  > <<  >>  +  \-  *  /  %  !  ~  (  )
+.Pp
+.Bl -tag -width 6n -offset indent -compact
+.It Li "||  &&  |  ^  &  ==  !=  =~  !~  <=  >="
+.It Li "<  > <<  >>  +  \-  *  /  %  !  ~  (  )"
 .El
 .Pp
 Here the precedence increases to the right,
-.Sq ==
-.Sq \&!=
-.Sq =~
+.Ql ==
+.Ql \&!=
+.Ql =~
 and
-.Sq \&!~ ,
-.Sq <=
-.Sq >=
-.Sq <
+.Ql \&!~ ,
+.Ql <=
+.Ql >=
+.Ql <
 and
-.Sq > ,
-.Sq <<
-.Sq >> ,
-.Sq +
+.Ql > ,
+.Ql <<
 and
-.Sq \&- ,
-.Sq *
-.Sq /
+.Ql >> ,
+.Ql +
 and
-.Sq %
+.Ql \- ,
+.Ql *
+.Ql /
+and
+.Ql %
 being, in
 groups, at the same level.
 The
-.Sq ==
-.Sq \&!=
-.Sq =~
+.Ql ==
+.Ql \&!=
+.Ql =~
 and
-.Sq \&!~
+.Ql \&!~
 operators compare
 their arguments as strings; all others operate on numbers.
 The operators
-.Sq =~
+.Ql =~
 and
-.Sq \&!~
+.Ql \&!~
 are like
-.Sq ==
+.Ql ==
 and
-.Sq \&!=
+.Ql \&!=
 except that the right hand side is a
 glob-pattern (see
 .Sx Filename substitution )
 against which the left hand operand is matched.
 This reduces the need for use of the
-.Va switch
+.Ic switch
 builtin command in shell scripts when all that is really needed is
 pattern matching.
 .Pp
 Null or
 missing arguments are considered
-.Sq 0
+.Ql 0 .
 The results of all expressions are
 strings, which represent decimal numbers.
 It is important to note that
 no two components of an expression can appear in the same word; except
 when adjacent to components of expressions which are syntactically
 significant to the parser
-.Sq ( \&&
-.Sq |
-.Sq <
-.Sq >
-.Sq \&(
-.Sq \&) )
+.Po
+.Ql \&&
+.Ql |
+.Ql <
+.Ql >
+.Ql \&(
+.Ql \&)
+.Pc
 they should be
 surrounded by spaces.
+.
 .Ss "Command exit status"
 Commands can be executed in expressions and their exit status
-returned by enclosing them in braces 
-.Sq ( {} ) .
+returned by enclosing them in braces
+.Pq Ql {} .
 Remember that the braces should
 be separated from the words of the command by spaces.
 Command executions
 succeed, returning true, i.e.,
-.Sq 1 ,
+.Ql 1 ,
 if the command exits with status 0,
 otherwise they fail, returning false, i.e.,
-.Sq 0 .
+.Ql 0 .
 If more detailed status
 information is required then the command should be executed outside of an
 expression and the
-.Va status
+.Ic status
 shell variable examined.
+.
 .Ss "File inquiry operators"
 Some of these operators perform true/false tests on files and related
 objects.
 They are of the form
-.Fl
-.Va op file
-, where
-.Va op
+.Fl Ar op file ,
+where
+.Ar op
 is one of
-.Bl -tag -width XXX -offset indent -compact
-.It Ar r
+.Pp
+.Bl -tag -width 3n -offset indent -compact
+.
+.It Li r
 Read access
-.It Ar w
+.
+.It Li w
 Write access
-.It Ar x
+.
+.It Li x
 Execute access
-.It Ar X
+.
+.It Li X
 Executable in the path or shell builtin, e.g.,
-.Sq \&-X ls
+.Ql \-X ls
 and
-.Sq \&-X ls\&-F
+.Ql \-X ls\-F
 are
 generally true, but
-.Sq \&-X /bin/ls
+.Ql \-X /bin/ls
 is not (+)
-.It Ar e
+.
+.It Li e
 Existence
-.It Ar o
+.
+.It Li o
 Ownership
-.It Ar z
+.
+.It Li z
 Zero size
-.It Ar s
+.
+.It Li s
 Non-zero size (+)
-.It Ar f
+.
+.It Li f
 Plain file
-.It Ar d
+.
+.It Li d
 Directory
-.It Ar l
+.
+.It Li l
 Symbolic link (+) *
-.It Ar b
+.
+.It Li b
 Block special file (+)
-.It Ar c
+.
+.It Li c
 Character special file (+)
-.It Ar p
+.
+.It Li p
 Named pipe (fifo) (+) *
-.It Ar S
+.
+.It Li S
 Socket special file (+) *
-.It Ar u
+.
+.It Li u
 Set-user-ID bit is set (+)
-.It Ar g
+.
+.It Li g
 Set-group-ID bit is set (+)
-.It Ar k
+.
+.It Li k
 Sticky bit is set (+)
-.It Ar t file
+.
+.It Li t
+.Ar file
 (which must be a digit) is an open file descriptor
 for a terminal device (+)
-.It Ar R
+.
+.It Li R
 Has been migrated (Convex only) (+)
-.It Ar L
+.
+.It Li L
 Applies subsequent operators in a multiple-operator test to a symbolic link
 rather than to the file to which the link points (+) *
 .El
 .Pp
-.Va file
+.Ar file
 is command and filename expanded and then tested to
 see if it has the specified relationship to the real user.
 If
-.Va file
+.Ar file
 does not exist or is inaccessible or, for the operators indicated by
 .Sq * ,
 if the specified file type does not exist on the current system,
 then all inquiries return false, i.e.,
-.Sq 0 .
+.Ql 0 .
 .Pp
 These operators may be combined for conciseness:
-.Sq \&-
-.Va xy file
+.Ql \- Ns Ar xy file
 is
 equivalent to
-.Sq \&-x file && \&-y file .
+.Ql \- Ns Ar x file Li && \- Ns Ar y file .
 (+) For example,
-.Sq \&-fx
+.Ql \-fx
 is true
 (returns
-.Sq 1 )
+.Ql 1 )
 for plain executable files, but not for directories.
 .Pp
-.Va L
+.Ql L
 may be used in a multiple-operator test to apply subsequent operators
 to a symbolic link rather than to the file to which the link points.
 For example,
-.Sq \&-lLo
+.Ql \-lLo
 is true for links owned by the invoking user.
-.Va Lr ,
-.Va Lw
+.Ql Lr ,
+.Ql Lw ,
 and
-.Va Lx
+.Ql Lx
 are always true for links and false for
 non-links.
-.Va L
+.Ql L
 has a different meaning when it is the last operator
 in a multiple-operator test; see below.
 .Pp
 It is possible but not useful, and sometimes misleading, to combine operators
 which expect
-.Va file
+.Ar file
 to be a file with operators which do not
 (e.g.,
-.Va X
+.Ql X
 and
-.Va t ) .
+.Ql t ) .
 Following
-.Va L
+.Ql L
 with a non-file operator
 can lead to particularly strange results.
 .Pp
 Other operators return other information, i.e., not just
-.Sq 0
+.Ql 0
 or
-.Sq 1
+.Ql 1 .
 (+)
 They have the same format as before;
-.Va op
+.Ar op
 may be one of
 .Pp
-.Bl -tag -width XXX -offset indent -compact
-.It Ar A
+.Bl -tag -width 6n -offset indent -compact
+.
+.It Li A
 Last file access time, as the number of seconds since the epoch
-.It Ar A:
+.
+.It Li A:
 Like
-.Va Ar A
-, but in timestamp format, e.g.,
+.Ql A ,
+but in timestamp format, e.g.,
 .Sq Fri May 14 16:36:10 1993
-.It Ar M
+.
+.It Li M
 Last file modification time
-.It Ar M:
+.
+.It Li M:
 Like
-.Va M
-, but in timestamp format
-.It Ar C
+.Ql M ,
+but in timestamp format
+.
+.It Li C
 Last inode modification time
-.It Ar C:
+.
+.It Li C:
 Like
-.Va C
-, but in timestamp format
-.It Ar D
+.Ql C ,
+but in timestamp format
+.
+.It Li D
 Device number
-.It Ar I
+.
+.It Li I
 Inode number
-.It Ar F
+.
+.It Li F
 Composite
-.Va f
+.Li f Ns
 ile identifier, in the form
-.Va device :
-.Va inode
-.It Ar L
+.Ar device : Ns
+.Ar inode
+.
+.It Li L
 The name of the file pointed to by a symbolic link
-.It Ar N
+.
+.It Li N
 Number of (hard) links
-.It Ar P
+.
+.It Li P
 Permissions, in octal, without leading zero
-.It Ar P:
+.
+.It Li P:
 Like
-.Va P
-, with leading zero
-.It Ar P<mode>
+.Ql P ,
+with leading zero
+.
+.It Li P Ns Ar mode
 Equivalent to
-.Sq \-P
-.Va file
-&
-.Va mode
-, e.g.,
-.Sq \-P22
-.Va file
+.Ql \-P Ar file Li & Ar mode ,
+e.g.,
+.Ql \-P22 Ar file
 returns
-`22' if
-.Va file
+.Sq 22
+if
+.Ar file
 is writable by group and other,
 .Sq 20
 if by group only,
 and
 .Sq 0
 if by neither
-.It Ar P<mode>:
-Like 
-.Ar BP
-.Va mode
-, with leading zero
-.It Ar U
+.
+.It Li P Ns Ar mode Ns Li \&:
+Like
+.Ql P Ns Ar mode ,
+with leading zero
+.
+.It Li U
 Numeric userid
-.It Ar U:
+.
+.It Li U:
 Username, or the numeric userid if the username is unknown
-.It Ar G
+.
+.It Li G
 Numeric groupid
-.It Ar G:
+.
+.It Li G:
 Groupname, or the numeric groupid if the groupname is unknown
-.It Ar Z
+.
+.It Li Z
 Size, in bytes
 .El
 .Pp
 Only one of these operators may appear in a multiple-operator test, and it
 must be the last.
 Note that
-.Va L
+.Ql L
 has a different meaning at the end of and
 elsewhere in a multiple-operator test.
 Because
@@ -3316,43 +3541,46 @@ for many of these operators, they do not return
 .Sq 0
 when they fail: most
 return
-.Sq \&-1
-, and
-.Va F
+.Sq \-1 ,
+and
+.Ql F
 returns
-.Sq \&:
+.Ql \&: .
 .Pp
 If the shell is compiled with POSIX defined (see the
-.Va version
+.Ic version
 shell
 variable), the result of a file inquiry is based on the permission bits of
 the file and not on the result of the
-.Va access
-(2) system call.
+.Xr access 2
+system call.
 For example, if one tests a file with
-.Fl w\fR whose permissions would
+.Fl w
+whose permissions would
 ordinarily allow writing but which is on a file system mounted read-only,
 the test will succeed in a POSIX shell but fail in a non-POSIX shell.
 .Pp
 File inquiry operators can also be evaluated with the
-.Va filetest
+.Ic filetest
 builtin
 command (q.v.) (+).
+.
 .Ss Jobs
 The shell associates a
-.Va job
+.Ar job
 with each pipeline.
 It keeps a table of
 current jobs, printed by the
-.Va jobs
+.Ic jobs
 command, and assigns them small integer
 numbers.
 When a job is started asynchronously with
-.Sq &
-, the shell prints a
+.Ql & ,
+the shell prints a
 line which looks like
-.IP "" 4
+.Bd -literal -offset indent
 [1] 1234
+.Ed
 .Pp
 indicating that the job which was started asynchronously was job number 1 and
 had one (top-level) process, whose process id was 1234.
@@ -3366,34 +3594,34 @@ indicate that the job has been
 .Sq Suspended
 and print another prompt.
 If the
-.Va listjobs
+.Ic listjobs
 shell variable is set, all jobs will be listed
 like the
-.Va jobs
+.Ic jobs
 builtin command; if it is set to
-.Sq long
+.Ql long
 the listing will
 be in long format, like
-.Sq jobs \&-l
+.Ql jobs \-l .
 You can then manipulate the state of the suspended job.
 You can put it in the
 .Dq background
- with the
-.Va bg
+with the
+.Ic bg
 command or run some other commands and
 eventually bring the job back into the
-.Sq foreground
-' with
-.Va fg
+.Dq foreground
+with
+.Ic fg .
 (See also the
-.Va run-fg-editor
+.Ic run-fg-editor
 editor command.)
 A
 .Sq ^Z
 takes effect immediately and is like an interrupt
 in that pending output and unread input are discarded when it is typed.
 The
-.Va wait
+.Ic wait
 builtin command causes the shell to wait for all background
 jobs to complete.
 .Pp
@@ -3401,99 +3629,99 @@ The
 .Sq ^]
 key sends a delayed suspend signal, which does not generate a STOP
 signal until a program attempts to
-.Va read
-(2) it, to the current job.
+.Xr read 2
+it, to the current job.
 This can usefully be typed ahead when you have prepared some commands for a
 job which you wish to stop after it has read them.
 The
 .Sq ^Y
 key performs this function in
-.Xr csh 1
-; in
-.Nm
-,
-`^Y' is an editing command.
+.Xr csh 1 ;
+in
+.Nm ,
+.Sq ^Y
+is an editing command.
 (+)
 .Pp
 A job being run in the background stops if it tries to read from the
 terminal.
 Background jobs are normally allowed to produce output, but this can
 be disabled by giving the command
-.Sq stty tostop
+.Ql stty tostop .
 If you set this tty option,
 then background jobs will stop when they try to produce output like they do
 when they try to read input.
 .Pp
 There are several ways to refer to jobs in the shell.
 The character
-.Sq %
+.Ql %
 introduces a job name.
 If you wish to refer to job number 1, you can name it
 as
-.Sq %1
+.Ql %1 .
 Just naming a job brings it to the foreground; thus
-.Sq %1
+.Ql %1
 is a synonym
 for
-.Sq fg %1
-, bringing job 1 back into the foreground.
+.Ql fg %1 ,
+bringing job 1 back into the foreground.
 Similarly, saying
-.Sq %1 &
+.Ql %1 &
 resumes job 1 in the background, just like
-.Sq bg %1
+.Ql bg %1 .
 A job can also be named
 by an unambiguous prefix of the string typed in to start it:
-.Sq %ex
+.Ql %ex
 would
 normally restart a suspended
 .Xr ex 1
 job, if there were only one suspended
 job whose name began with the string
-.Sq ex .
+.Ql ex .
 It is also possible to say
-.Va %?string
+.Ql %? Ns Ar string
 to specify a job whose text contains
-.Va string ,
+.Ar string ,
 if there is only one such job.
 .Pp
 The shell maintains a notion of the current and previous jobs.
 In output
 pertaining to jobs, the current job is marked with a
-.Sq +
+.Ql +
 and the previous job
 with a
-.Sq \-
+.Ql \- .
 The abbreviations
-.Sq %+
-,
-.Sq %
-, and (by analogy with the syntax of
+.Ql %+ ,
+.Ql % ,
+and (by analogy with the syntax of
 the
-.Va history
+.Ic history
 mechanism)
-.Sq %%
+.Ql %%
 all refer to the current job, and
-.Sq %\-
+.Ql %\-
 refers
 to the previous job.
 .Pp
 The job control mechanism requires that the
-.Va stty
-(1) option
-.Sq new
+.Xr stty 1
+option
+.Ql new
 be set
 on some systems.
 It is an artifact from a
-.Sq new
+.Dq new
 implementation of the tty
 driver which allows generation of interrupt characters from the keyboard to
 tell jobs to stop.
 See
-.Va stty
-(1) and the
-.Va setty
+.Xr stty 1
+and the
+.Ic setty
 builtin command for
 details on setting options in the new tty driver.
+.
 .Ss "Status reporting"
 The shell learns immediately whenever a process changes state.
 It normally
@@ -3502,18 +3730,18 @@ possible, but only right before it prints a prompt.
 This is done so that it
 does not otherwise disturb your work.
 If, however, you set the shell variable
-.Va notify
-, the shell will notify you immediately of changes of status in
+.Ic notify ,
+the shell will notify you immediately of changes of status in
 background jobs.
-There is also a shell command
-.Va notify
+There is also a builtin command
+.Ic notify
 which marks a
 single process so that its status changes will be immediately reported.
 By
 default
-.Va notify
+.Ic notify
 marks the current process; simply say
-.Sq notify
+.Ql notify
 after
 starting a background job to mark it.
 .Pp
@@ -3521,149 +3749,146 @@ When you try to leave the shell while jobs are stopped, you will be
 warned that
 .Sq There are suspended jobs.
 You may use the
-.Va jobs
+.Ic jobs
 command to
 see what they are.
 If you do this or immediately try to exit again, the shell
 will not warn you a second time, and the suspended jobs will be terminated.
+.
 .Ss "Automatic, periodic and timed events (+)"
 There are various ways to run commands and take other actions automatically
 at various times in the
-.Sq `life cycle
-' of the shell.
+.Dq life cycle
+of the shell.
 They are summarized here,
 and described in detail under the appropriate
-.Va Builtin commands
-,
-.Va Special shell variables
+.Sx Builtin commands ,
+.Sx Special shell variables ,
 and
-.Va Special aliases
+.Sx Special aliases .
 .Pp
 The
-.Va sched
+.Ic sched
 builtin command puts commands in a scheduled-event list,
 to be executed by the shell at a given time.
 .Pp
 The
-.Va beepcmd
-,
-.Va cwdcmd
-,
-.Va periodic
-,
-.Va precmd
-,
-.Va postcmd
-,
+.Ic beepcmd ,
+.Ic cwdcmd ,
+.Ic jobcmd ,
+.Ic periodic ,
+.Ic precmd ,
 and
-.Va jobcmd
-.Va Special aliases
-can be set, respectively, to execute commands when the shell wants
-to ring the bell, when the working directory changes, every
-.Va tperiod
-minutes, before each prompt, before each command gets executed, after each
-command gets executed, and when a job is started or is brought into the
-foreground.
+.Ic postcmd
+.Sx Special aliases
+can be set, respectively, to execute commands:
+when the shell wants to ring the bell,
+when the working directory changes,
+when a job is started or is brought into the foreground,
+every
+.Ic tperiod
+minutes,
+before each prompt,
+and before each command gets executed.
 .Pp
 The
-.Va autologout
+.Ic autologout
 shell variable can be set to log out or lock the shell
 after a given number of minutes of inactivity.
 .Pp
 The
-.Va mail
+.Ic mail
 shell variable can be set to check for new mail periodically.
 .Pp
 The
-.Va printexitvalue
+.Ic printexitvalue
 shell variable can be set to print the exit status
 of commands which exit with a status other than zero.
 .Pp
 The
-.Va rmstar
+.Ic rmstar
 shell variable can be set to ask the user, when
-.Sq rm *
+.Ql rm *
 is
 typed, if that is really what was meant.
 .Pp
 The
-.Va time
+.Ic time
 shell variable can be set to execute the
-.Va time
+.Ic time
 builtin
 command after the completion of any process that takes more than a given
 number of CPU seconds.
 .Pp
 The
-.Va watch
+.Ic watch
 and
-.Va who
+.Ic who
 shell variables can be set to report when
 selected users log in or out, and the
-.Va log
+.Ic log
 builtin command reports
 on those users at any time.
+.
 .Ss "Native Language System support (+)"
 The shell is eight bit clean
 (if so compiled; see the
-.Va version
+.Ic version
 shell variable)
 and thus supports character sets needing this capability.
 NLS support differs depending on whether or not
 the shell was compiled to use the system's NLS (again, see
-.Va version
-).
+.Ic version ) .
 In either case, 7-bit ASCII is the default character code
 (e.g., the classification of which characters are printable) and sorting,
 and changing the
-.Va LANG
+.Ev LANG
 or
-.Va LC_CTYPE
+.Ev LC_CTYPE
 environment variables
 causes a check for possible changes in these respects.
 .Pp
 When using the system's NLS, the
-.Va setlocale
-(3) function is called
+.Xr setlocale 3
+function is called
 to determine appropriate character code/classification and sorting
 (e.g., a 'en_CA.UTF-8' would yield "UTF-8" as a character code).
 This function typically examines the
-.Va LANG
+.Ev LANG
 and
-.Va LC_CTYPE
+.Ev LC_CTYPE
 environment variables; refer to the system documentation for further details.
 When not using the system's NLS, the shell simulates it by assuming that the
 ISO 8859-1 character set is used
 whenever either of the
-.Va LANG
+.Ev LANG
 and
-.Va LC_CTYPE
+.Ev LC_CTYPE
 variables are set, regardless of
 their values.
 Sorting is not affected for the simulated NLS.
 .Pp
 In addition, with both real and simulated NLS, all printable
 characters in the range \e200\-\e377, i.e., those that have
-M-
-.Va char
+.No M- Ns Ar char
 bindings, are automatically rebound to
-.Va self-insert-command
-The corresponding binding for the escape-
-.Va char
+.Ic self-insert-command .
+The corresponding binding for the
+.No escape- Ns Ar char
 sequence, if any, is
 left alone.
 These characters are not rebound if the
-.Va NOREBIND
+.Ev NOREBIND
 environment variable
 is set.
 This may be useful for the simulated NLS or a primitive real NLS
 which assumes full ISO 8859-1.
-Otherwise, all M-
-.Va char
+Otherwise, all
+.No M- Ns Ar char
 bindings in the
 range \e240\-\e377 are effectively undone.
 Explicitly rebinding the relevant keys with
-.Va bindkey
+.Ic bindkey
 is of course still possible.
 .Pp
 Unknown characters (i.e., those that are neither printable nor control
@@ -3676,295 +3901,310 @@ changes of 7/8 bit mode.
 NLS users (or, for that matter, those who want to
 use a meta key) may need to explicitly set
 the tty in 8 bit mode through the appropriate
-.Va stty
-(1)
+.Xr stty 1
 command in, e.g., the
-.Va ~/.login
+.Pa ~/.login
 file.
+.
 .Ss "OS variant support (+)"
 A number of new builtin commands are provided to support features in
 particular operating systems.
 All are described in detail in the
-.Va Builtin commands
+.Sx Builtin commands
 section.
 .Pp
 On systems that support TCF (aix-ibm370, aix-ps2),
-.Va getspath
+.Ic getspath
 and
-.Va setspath
+.Ic setspath
 get and set the system execution path,
-.Va getxvers
+.Ic getxvers
 and
-.Va setxvers
+.Ic setxvers
 get and set the experimental version prefix
 and
-.Va migrate
+.Ic migrate
 migrates processes between sites.
 The
-.Va jobs
+.Ic jobs
 builtin
 prints the site on which each job is executing.
 .Pp
 Under BS2000,
-.Va bs2cmd
+.Ic bs2cmd
 executes commands of the underlying BS2000/OSD
 operating system.
 .Pp
 Under Domain/OS,
-.Va inlib
+.Ic inlib
 adds shared libraries to the current environment,
-.Va rootnode
+.Ic rootnode
 changes the rootnode and
-.Va ver
+.Ic ver
 changes the systype.
 .Pp
 Under Mach,
-.Va setpath
+.Ic setpath
 is equivalent to Mach's
-.Va setpath
-(1).
+.Xr setpath 1 .
 .Pp
 Under Masscomp/RTU and Harris CX/UX,
-.Va universe
+.Ic universe
 sets the universe.
 .Pp
 Under Harris CX/UX,
-.Va ucb
+.Ic ucb
 or
-.Va att
+.Ic att
 runs a command under the specified
 universe.
 .Pp
 Under Convex/OS,
-.Va warp
+.Ic warp
 prints or sets the universe.
 .Pp
 The
-.Va VENDOR
-,
-.Va OSTYPE
+.Ev VENDOR ,
+.Ev OSTYPE ,
 and
-.Va MACHTYPE
+.Ev MACHTYPE
 environment variables
 indicate respectively the vendor, operating system and machine type
 (microprocessor class or machine model) of the
 system on which the shell thinks it is running.
 These are particularly useful when sharing one's home directory between several
 types of machines; one can, for example,
-.IP "" 4
+.Bd -literal -offset indent
 set path = (~/bin.$MACHTYPE /usr/ucb /bin /usr/bin .)
+.Ed
 .Pp
 in one's
-.Va ~/.login
+.Pa ~/.login
 and put executables compiled for each machine in the
 appropriate directory.
 .Pp
 The
-.Va version
+.Ic version
 shell
 variable indicates what options were chosen when the shell was compiled.
 .Pp
 Note also the
-.Va newgrp
+.Ic newgrp
 builtin, the
-.Va afsuser
+.Ic afsuser
 and
-.Va echo_style
+.Ic echo_style
 shell variables and the system-dependent locations of
 the shell's input files (see
-.Va FILES
-).
+.Sx FILES ) .
+.
 .Ss "Signal handling"
 Login shells ignore interrupts when reading the file
-.Va ~/.logout
+.Pa ~/.logout .
 The shell ignores quit signals unless started with
-.Fl q\fR.
+.Fl q .
 Login shells catch the terminate signal, but non-login shells inherit the
 terminate behavior from their parents.
 Other signals have the values which the shell inherited from its parent.
 .Pp
 In shell scripts, the shell's handling of interrupt and terminate signals
 can be controlled with
-.Va onintr
-, and its handling of hangups can be
+.Ic onintr ,
+and its handling of hangups can be
 controlled with
-.Va hup
+.Ic hup
 and
-.Va nohup
+.Ic nohup .
 .Pp
 The shell exits on a hangup (see also the
-.Va logout
+.Ic logout
 shell variable).
 By
 default, the shell's children do too, but the shell does not send them a
 hangup when it exits.
-.Va hup
+.Ic hup
 arranges for the shell to send a hangup to
 a child when it exits, and
-.Va nohup
+.Ic nohup
 sets a child to ignore hangups.
+.
 .Ss "Terminal management (+)"
-The shell uses three different sets of terminal (
-.Dq tty
-) modes:
-`edit', used when editing,
-.Sq quote
-, used when quoting literal characters,
+The shell uses three different sets of terminal
+.Dq ( tty )
+modes:
+.Sq edit ,
+used when editing;
+.Sq quote ,
+used when quoting literal characters;
 and
-.Sq execute
-, used when executing commands.
+.Sq execute ,
+used when executing commands.
 The shell holds some settings in each mode constant, so commands which leave
 the tty in a confused state do not interfere with the shell.
 The shell also matches changes in the speed and padding of the tty.
 The list of tty modes that are kept constant
 can be examined and modified with the
-.Va setty
+.Ic setty
 builtin.
 Note that although the editor uses CBREAK mode (or its equivalent),
 it takes typed-ahead characters anyway.
 .Pp
 The
-.Va echotc
-,
-.Va settc
+.Ic echotc ,
+.Ic settc ,
 and
-.Va telltc
+.Ic telltc
 commands can be used to
 manipulate and debug terminal capabilities from the command line.
 .Pp
 On systems that support SIGWINCH or SIGWINDOW, the shell
 adapts to window resizing automatically and adjusts the environment
 variables
-.Va LINES
+.Ev LINES
 and
-.Va COLUMNS
+.Ev COLUMNS
 if set.
 If the environment
 variable
-.Va TERMCAP
-contains li# and co# fields, the shell adjusts
+.Ev TERMCAP
+contains
+.Ql li#
+and
+.Ql co#
+fields, the shell adjusts
 them to reflect the new window size.
+.
 .Sh REFERENCE
 The next sections of this manual describe all of the available
-.Va Builtin commands
-,
-.Va Special aliases
+.Sx Builtin commands ,
+.Sx Special aliases ,
 and
-.Va Special shell variables
+.Sx Special shell variables .
+.
 .Ss "Builtin commands"
-.Bl -tag -width XXXXXXX -offset indent
-.It Ar %job
+.
+.Bl -tag -width 8n
+.
+.It Ic % Ns Ar job
 A synonym for the
-.Va fg
+.Ic fg
 builtin command.
-.It Ar %job \&&
+.
+.It Ic % Ns Ar job Cm \&&
 A synonym for the
-.Va bg
+.Ic bg
 builtin command.
-.It Ar \&:
+.
+.It Ic \&:
 Does nothing, successfully.
+.
+.El
 .Pp
-.It Ar @
-.It Ar @ name = expr
-.It Ar @ name[index] = expr
-.It Ar @ name++|--
-.It Ar @name[index]++|--
+.Bl -tag -width 8n -compact
+.
+.It Ic @
+.It Ic @ Ar name Cm = Ar expr
+.It Ic @ Ar name Ns Cm \&[ Ns Ar index Ns Cm \&] = Ar expr
+.It Ic @ Ar name Ns Cm ++|--
+.It Ic @ Ar name Ns Cm \&[ Ns Ar index Ns Cm \&]++|--
 The first form prints the values of all shell variables.
 .Pp
 The second form assigns the value of
-.Va expr
+.Ar expr
 to
-.Va name
+.Ar name .
 The third form assigns the value of
-.Va expr
+.Ar expr
 to the
-.Va index
-'th
+.Ar index Ns
+\&'th
 component of
-.Va name
-; both
-.Va name
+.Ar name ;
+both
+.Ar name
 and its
-.Va index
-'th component
+.Ar index Ns
+\&'th component
 must already exist.
 .Pp
-.Va expr
+.Ar expr
 may contain the operators
-.Sq *
-,
-.Sq +
-, etc., as in C.
+.Ql * ,
+.Ql + ,
+etc., as in C.
 If
-.Va expr
+.Ar expr
 contains
-.Sq <
-,
-.Sq >
-,
-.Sq &
+.Ql < ,
+.Ql > ,
+.Ql & ,
 or
-.Sq
+.Ql \&|
 then at least that part of
-.Va expr
+.Ar expr
 must be placed within
-.Sq ()
+.Ql () .
 Note that the syntax of
-.Va expr
+.Ar expr
 has nothing to do with that described
 under
-.Va Expressions
+.Sx Expressions .
 .Pp
-The fourth and fifth forms increment (
-.Sq ++ )
-or decrement 
-.Sq ( -- )
-.Va name
+The fourth and fifth forms increment
+.Pq Sq Cm ++
+or decrement
+.Pq Sq Cm --
+.Ar name
 or its
-.Va index
-'th component.
+.Ar index Ns
+\&'th component.
 .Pp
 The space between
-.Sq @
+.Sq Ic @
 and
-.Va name
+.Ar name
 is required.
 The spaces between
-.Va name
+.Ar name
 and
-.Sq =
+.Sq Cm =
 and between
-.Sq =
+.Sq Cm =
 and
-.Va expr
+.Ar expr
 are optional.
 Components of
-.Va expr
+.Ar expr
 must be separated by spaces.
-.It Ar alias [name [wordlist]]
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic alias Op Ar name Op Ar wordlist
 Without arguments, prints all aliases.
 With
-.Va name
-, prints the alias for name.
+.Ar name ,
+prints the alias for name.
 With
-.Va name
+.Ar name
 and
-.Va wordlist
-, assigns
-.Va wordlist
+.Ar wordlist ,
+assigns
+.Ar wordlist
 as the alias of
-.Va name
-.Va wordlist
+.Ar name .
+.Ar wordlist
 is command and filename substituted.
-.Va name
+.Ar name
 may not be
-.Sq alias
+.Sq Ic alias
 or
-.Sq unalias
+.Sq Ic unalias .
 See also the
-.Va unalias
+.Ic unalias
 builtin command.
-.It Ar alloc
+.
+.It Ic alloc
 Shows the amount of dynamic memory acquired, broken down into used and free
 memory.
 With an argument shows the number of free and used blocks in each size
@@ -3972,481 +4212,521 @@ category.
 The categories start at size 8 and double at each step.
 This command's output may vary across system types, because systems other
 than the VAX may use a different memory allocator.
-.It Ar bg [%job...]
+.
+.It Ic bg Op Cm % Ns Ar job No \&...
 Puts the specified jobs (or, without arguments, the current job)
 into the background, continuing each if it is stopped.
-.Va job
+.Ar job
 may be a number, a string,
-.Sq \&, ,
-.Sq % ,
-.Sq + ,
+.Ql \& ,
+.Ql % ,
+.Ql + ,
 or
-.Sq \&-
-as described
-under
-.Va Jobs .
-.It Ar bindkey Oo Fl l Ns | Ns Fl d Ns | Ns Fl e Ns | Ns Fl v Ns | Ns Fl u Oc (+)
-.It Ar bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl r Oc Oo Fl Fl Oc Ar key (+)
-.It Ar bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl c Ns | Ns Fl s Oc Oo Fl Fl Oc Ar key command (+)
-.\" .It Ar macro can't take too many words, so I used \fB in the previous tags
+.Ql \-
+as described under
+.Sx Jobs .
+.
+.El
+.Pp
+.Bl -tag -width 8n -compact
+.
+.It Ic bindkey Oo Fl l Ns | Ns Fl d Ns | Ns Fl e Ns | Ns Fl v Ns | Ns Fl u Oc No (+)
+.It Ic bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl r Oc Oo Fl \- Oc Ar key No (+)
+.It Ic bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl c Ns | Ns Fl s Oc Oo Fl \- Oc Ar key command No (+)
 Without options, the first form lists all bound keys and the editor command to which each is bound,
 the second form lists the editor command to which
-.Va key
+.Ar key
 is bound and
 the third form binds the editor command
-.Va command
+.Ar command
 to
-.Va key
+.Ar key .
 Options include:
 .Pp
-.Bl -tag -width XXX -compact
+.Bl -tag -width 5n -offset indent -compact
+.
 .It Fl l
 Lists all editor commands and a short description of each.
+.
 .It Fl d
 Binds all keys to the standard bindings for the default editor,
 as per
-.Va -e
+.Fl e
 and
-.Va -v
+.Fl v
 below.
+.
 .It Fl e
 Binds all keys to
-.Va emacs
-(1)\-style bindings.
+.Xr emacs 1 Ns
+\-style bindings.
 Unsets
-.Va vimode
+.Ic vimode .
+.
 .It Fl v
 Binds all keys to
-.Va vi
-(1)\-style bindings.
+.Xr vi 1 Ns
+\-style bindings.
 Sets
-.Va vimode
+.Ic vimode .
+.
 .It Fl a
 Lists or changes key-bindings in the alternative key map.
 This is the key map used in
-.Va vimode
+.Ic vimode
 command mode.
+.
 .It Fl b
-.Va key
+.Ar key
 is interpreted as
-a control character written ^
-.Va character
+a control character written
+.No ^ Ns Ar character
 (e.g.,
-.Sq ^A
-) or
-C-
-.Va character
-(e.g.,
-.Sq C-A
-),
-a meta character written M-
-.Va character
-(e.g.,
-.Sq M-A
-),
-a function key written F-
-.Va string
-(e.g.,
-.Sq F-string
-),
-or an extended prefix key written X-
-.Va character
-(e.g.,
-.Sq X-A
-).
-.It Fl k
-.Va key
-is interpreted as a symbolic arrow key name, which may be one of
-`down',
-.Sq up
-,
-.Sq left
+.Sq ^A )
 or
-.Sq right
+.No C- Ns Ar character
+(e.g.,
+.Sq C-A ) ,
+a meta character written
+.No M- Ns Ar character
+(e.g.,
+.Sq M-A ) ,
+a function key written
+.No F- Ns Ar string
+(e.g.,
+.Sq F-string ) ,
+or an extended prefix key written
+.No X- Ns Ar character
+(e.g.,
+.Sq X-A ) .
+.
+.It Fl k
+.Ar key
+is interpreted as a symbolic arrow key name, which may be one of
+.Sq down ,
+.Sq up ,
+.Sq left ,
+or
+.Sq right .
+.
 .It Fl r
 Removes
-.Va key
-'s binding.
+.Ar key Ns
+\&'s binding.
 Be careful:
-.Sq bindkey \-r
+.Ql bindkey \-r
 does
-.Va not
+.Em not
 bind
-.Va key
+.Ar key
 to
-.Va self-insert-command
+.Ic self-insert-command
 (q.v.), it unbinds
-.Va key
+.Ar key
 completely.
+.
 .It Fl c
-.Va command
+.Ar command
 is interpreted as a builtin or external command instead of an
 editor command.
+.
 .It Fl s
-.Va command
-is taken as a literal string and treated as terminal input
-when
-.Va key
+.Ar command
+is taken as a literal string and treated as terminal input when
+.Ar key
 is typed.
 Bound keys in
-.Va command
+.Ar command
 are themselves
 reinterpreted, and this continues for ten levels of interpretation.
-.It Fl \&-
+.
+.It Fl \-
 Forces a break from option processing, so the next word is taken as
-.Va key
-even if it begins with '\&-'.
-.It Fl u 
-(or any invalid option)
+.Ar key
+even if it begins with
+.Ql \- .
+.
+.It Fl u
+(or any invalid option).
 Prints a usage message.
 .El
 .Pp
-.Va key
+.Ar key
 may be a single character or a string.
 If a command is bound to a string, the first character of the string is bound to
-.Va sequence-lead-in
+.Ic sequence-lead-in
 and the entire string is bound to the command.
 .Pp
 Control characters in
-.Va key
+.Ar key
 can be literal (they can be typed by preceding
 them with the editor command
-.Va quoted-insert
-, normally bound to
-.Sq ^V
-) or
+.Ic quoted-insert ,
+normally bound to
+.Sq ^V )
+or
 written caret-character style, e.g.,
-.Sq ^A
+.Sq ^A .
 Delete is written
 .Sq ^?
 (caret-question mark).
-.Va key
+.Ar key
 and
-.Va command
+.Ar command
 can contain backslashed
 escape sequences (in the style of System V
-.Va echo
-(1)) as follows:
+.Xr echo 1 )
+as follows:
 .Pp
-.Bl -tag -width XXXX -compact -offset indent
-.It \ea
+.Bl -tag -width 5n -offset indent -compact
+.
+.It Li \ea
 Bell
-.It \eb
+.It Li \eb
 Backspace
-.It \ee
+.It Li \ee
 Escape
-.It \ef
+.It Li \ef
 Form feed
-.It \en
+.It Li \en
 Newline
-.It \er
+.It Li \er
 Carriage return
-.It \et
+.It Li \et
 Horizontal tab
-.It \ev
+.It Li \ev
 Vertical tab
-.It \e\fInnn
+.It Li \e Ns Ar nnn
 The ASCII character corresponding to the octal number
-.Va nnn
+.Ar nnn
 .El
 .Pp
-`\e' nullifies the special meaning of the following character, if it has
+.Ql \e
+nullifies the special meaning of the following character, if it has
 any, notably
-.Sq \e
+.Ql \e
 and
-.Sq ^
-.It bs2cmd Va bs2000-command
-(+)
+.Ql ^ .
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic bs2cmd Ar bs2000-command No (+)
 Passes
-.Va bs2000-command
+.Ar bs2000-command
 to the BS2000 command interpreter for
 execution. Only non-interactive commands can be executed, and it is
 not possible to execute any command that would overlay the image
 of the current process, like /EXECUTE or /CALL-PROCEDURE. (BS2000 only)
-.It break
+.
+.It Ic break
 Causes execution to resume after the
-.Va end
+.Ic end
 of the nearest
 enclosing
-.Va foreach
+.Ic foreach
 or
-.Va while
+.Ic while .
 The remaining commands on the
 current line are executed.
 Multi-level breaks are thus
 possible by writing them all on one line.
-.It breaksw
+.
+.It Ic breaksw
 Causes a break from a
-.Va switch
-, resuming after the
-.Va endsw
-
-.It builtins \fR(+)
+.Ic switch ,
+resuming after the
+.Ic endsw .
+.
+.It Ic builtins No (+)
 Prints the names of all builtin commands.
-
-.It bye \fR(+)
+.
+.It Ic bye No (+)
 A synonym for the
-.Va logout
+.Ic logout
 builtin command.
 Available only if the shell was so compiled;
 see the
-.Va version
+.Ic version
 shell variable.
-
-.It case \fIlabel\fB:
+.
+.It Ic case Ar label Ns Cm :
 A label in a
-.Va switch
+.Ic switch
 statement as discussed below.
-
-.It cd \fR[
-.Fl p\fR] [
-.Fl l\fR] [
-.Fl n\fR|
-.Fl v\fR] [\I--\fR] [
-.Va name
-]
+.
+.It Ic cd Xo
+.Op Fl p
+.Op Fl l
+.Op Fl n Ns | Ns Fl v
+.Op Fl \-
+.Op Ar name
+.Xc
 If a directory
-.Va name
+.Ar name
 is given, changes the shell's working directory
 to
-.Va name
+.Ar name .
 If not, changes to
-.Va home
-, unless the
-.Va cdtohome
+.Ic home ,
+unless the
+.Ic cdtohome
 variable is not set, in which case a
-.Va name
+.Ar name
 is required.
 If
-.Va name
+.Ar name
 is
-.Sq \-
+.Ql \-
 it is interpreted as the previous working directory
 (see
-.Va Other substitutions
-).
+.Sx Other substitutions ) .
 (+)
 If
-.Va name
+.Ar name
 is not a subdirectory of the current directory
 (and does not begin with
-.Sq /
-,
-.Sq ./
+.Ql / ,
+.Ql ./
 or
-.Sq ../
-), each component of the variable
-.Va cdpath
+.Ql ../ ) ,
+each component of the variable
+.Ic cdpath
 is checked to see if it has a subdirectory
-.Va name
+.Ar name .
 Finally, if
 all else fails but
-.Va name
+.Ar name
 is a shell variable whose value
 begins with
-.Sq /
-or '.', then this is tried to see if it is a directory, and
-the
-.Fl p\fR option is implied.
-.RS +8
+.Ql /
+or
+.Ql \&. ,
+then this is tried to see if it is a directory, and the
+.Fl p
+option is implied.
 .Pp
 With
-.Fl p\fR, prints the final directory stack, just like
-.Va dirs
+.Fl p ,
+prints the final directory stack, just like
+.Ic dirs .
 The
-.Fl l\fR,
-.Fl n\fR and
-.Fl v\fR flags have the same effect on
-.Va cd
+.Fl l ,
+.Fl n ,
+and
+.Fl v
+flags have the same effect on
+.Ic cd
 as on
-.Va dirs
-, and they imply
-.Fl p\fR.
+.Ic dirs ,
+and they imply
+.Fl p .
 (+)
 Using
-.Fl \-\fR forces a break from option processing so the next word
+.Fl \-
+forces a break from option processing so the next word
 is taken as the directory
-.Va name
-even if it begins with '\-'. (+)
+.Ar name
+even if it begins with
+.Ql \- .
+(+)
 .Pp
 See also the
-.Va implicitcd
+.Ic implicitcd
 and
-.Va cdtohome
+.Ic cdtohome
 shell variables.
-.RE
-
-.It chdir
+.
+.It Ic chdir
 A synonym for the
-.Va cd
+.Ic cd
 builtin command.
-
-.It complete \fR[
-.Va command
-[\fIword\fB/\fIpattern\fB/
-.Va list
-[\fB:
-.Va select
-]
-.Va /
-[[
-.Va suffix
-]
-.Va /
-] ...]] (+)
+.
+.It Ic complete Xo
+.Oo Ar command
+.Oo
+.Sm off
+.Ar word Cm / Ar pattern Cm / Ar list Oo Cm : Ar select Oc Cm / Oo
+.Op Ar suffix
+.Cm /
+.Oc
+.Sm on
+\&...
+.Oc
+.Oc
+(+)
+.Xc
 Without arguments, lists all completions.
 With
-.Va command
-, lists completions for
-.Va command
+.Ar command ,
+lists completions for
+.Ar command .
 With
-.Va command
+.Ar command
 and
-.Va word
+.Ar word
 etc., defines completions.
-.RS +8
 .Pp
-.Va command
+.Ar command
 may be a full command name or a glob-pattern
 (see
-.Va Filename substitution
-).
+.Sx Filename substitution ) .
 It can begin with
-.Sq \-
+.Ql \-
 to indicate that
 completion should be used only when
-.Va command
+.Ic command
 is ambiguous.
 .Pp
-.Va word
+.Ar word
 specifies which word relative to the current word
 is to be completed, and may be one of the following:
 .Pp
-.PD 0
-.RS +4
-.TP 4
-.It c
+.Bl -tag -width 5n -offset indent -compact
+.
+.It Li c
 Current-word completion.
-.Va pattern
+.Ar pattern
 is a glob-pattern which must match the beginning of the current word on
 the command line.
-.Va pattern
+.Ar pattern
 is ignored when completing the current word.
-.TP 4
-.It C
+.
+.It Li C
 Like
-.Va c
-, but includes
-.Va pattern
+.Ql c ,
+but includes
+.Ar pattern
 when completing the current word.
-.TP 4
-.It n
+.
+.It Li n
 Next-word completion.
-.Va pattern
+.Ar pattern
 is a glob-pattern which must match the beginning of the previous word on
 the command line.
-.TP 4
-.It N
+.
+.It Li N
 Like
-.Va n
-, but must match the beginning of the word two before the current word.
-.TP 4
-.It p
+.Ql n ,
+but must match the beginning of the word two before the current word.
+.
+.It Li p
 Position-dependent completion.
-.Va pattern
+.Ar pattern
 is a numeric range, with the same syntax used to index shell
 variables, which must include the current word.
-.PD
-.RE
+.El
 .Pp
-.Va list
-, the list of possible completions, may be one of the following:
+.Ar list ,
+the list of possible completions, may be one of the following:
 .Pp
-.Bl -tag
-.It a
+.Bl -tag -width 5n -offset indent -compact
+.
+.It Li a
 Aliases
-.It b
+.
+.It Li b
 Bindings (editor commands)
-.It c
+.
+.It Li c
 Commands (builtin or external commands)
-.It C
+.
+.It Li C
 External commands which begin with the supplied path prefix
-.It d
+.
+.It Li d
 Directories
-.It D
+.
+.It Li D
 Directories which begin with the supplied path prefix
-.It e
+.
+.It Li e
 Environment variables
-.It f
+.
+.It Li f
 Filenames
-.It F
+.
+.It Li F
 Filenames which begin with the supplied path prefix
-.It g
+.
+.It Li g
 Groupnames
-.It j
+.
+.It Li j
 Jobs
-.It l
+.
+.It Li l
 Limits
-.It n
+.
+.It Li n
 Nothing
-.It s
+.
+.It Li s
 Shell variables
-.It S
+.
+.It Li S
 Signals
-.It t
-Plain (
-.Dq text )
+.
+.It Li t
+Plain
+.Dq ( text )
 files
-.It T
-Plain (
-.Dq text )
+.
+.It Li T
+Plain
+.Dq ( text )
 files which begin with the supplied path prefix
-.It v
+.
+.It Li v
 Any variables
-.It u
+.
+.It Li u
 Usernames
-.It x
+.
+.It Li x
 Like
-.Va n ,
+.Ql n ,
 but prints
-.Va select
+.Ar select
 when
-.Va list-choices
+.Ic list-choices
 is used.
-.It X
+.
+.It Li X
 Completions
-$
-.Va var
+.
+.It Li $ Ns Ar var
 Words from the variable
-.Va var
-(...)
+.Ar var
+.
+.It Li (...)
 Words from the given list
-\`...\`
+.
+.It Li \`...\`
 Words from the output of command
 .El
 .Pp
-.Va select
+.Ar select
 is an optional glob-pattern.
 If given, words from only
-.Va list
+.Ar list
 that match
-.Va select
+.Ar select
 are considered
 and the
-.Va fignore
+.Ic fignore
 shell variable is ignored.
 The last three types of completion may not have a
-.Va select
+.Ar select
 pattern, and
-.Va x
+.Ql x
 uses
-.Va select
-as an explanatory message when
-the
-.Va list-choices
+.Ar select
+as an explanatory message when the
+.Ic list-choices
 editor command is used.
 .Pp
-.Va suffix
+.Ar suffix
 is a single character to be appended to a successful
 completion.
 If null, no character is appended.
@@ -4454,159 +4734,159 @@ If omitted (in which
 case the fourth delimiter can also be omitted), a slash is appended to
 directories and a space to other words.
 .Pp
-.Va command
-invoked from \`...\` version has additional environment
-variable set, the variable name is \%
-.Va COMMAND_LINE
-\% and
+.Ar command
+invoked from
+.Ar list
+.Ql \`...\`
+has the additional environment variable
+.Ev COMMAND_LINE
+set, which
 contains (as its name indicates) contents of the current (already
 typed in) command line. One can examine and use contents of the
-\%
-.Va COMMAND_LINE
-\% variable in her custom script to build more
-sophisticated completions (see completion for svn(1) included in
-this package).
+.Ev COMMAND_LINE
+environment variable in a custom script to build more
+sophisticated completions (see completion for
+.Xr svn 1
+included in this package).
 .Pp
 Now for some examples.
 Some commands take only directories as arguments,
 so there's no point completing plain files.
-.IP "" 4
+.Bd -literal -offset indent
 > complete cd 'p/1/d/'
+.Ed
 .Pp
 completes only the first word following
-.Sq cd
-(`p/1') with a directory.
-.Va p
--type completion can also be used to narrow down command completion:
-.IP "" 4
+.Ql cd
+.Pq Ql p/1
+with a directory.
+.Ql p Ns
+\-type completion can also be used to narrow down command completion:
+.Bd -literal -offset indent
 > co[^D]
-.br
 complete compress
-.br
 > complete \-co* 'p/0/(compress)/'
-.br
 > co[^D]
-.br
 > compress
+.Ed
 .Pp
 This completion completes commands (words in position 0,
-.Sq p/0
-)
+.Ql p/0 )
 which begin with
-.Sq co
+.Ql co
 (thus matching
-.Sq co*
-) to
-.Sq compress
+.Ql co* )
+to
+.Ql compress
 (the only
 word in the list).
 The leading
-.Sq \-
+.Ql \-
 indicates that this completion is to be used with only
 ambiguous commands.
-.IP "" 4
+.Bd -literal -offset indent
 > complete find 'n/\-user/u/'
+.Ed
 .Pp
 is an example of
-.Va n
--type completion.
+.Ql n Ns
+\-type completion.
 Any word following
-.Sq find
+.Ql find
 and
 immediately following
-.Sq \-user
+.Ql \-user
 is completed from the list of users.
-.IP "" 4
+.Bd -literal -offset indent
 > complete cc 'c/\-I/d/'
+.Ed
 .Pp
 demonstrates
-.Va c
--type completion.
+.Ql c Ns
+\-type completion.
 Any word following
-.Sq cc
-and beginning
-with
-.Sq \-I
+.Ql cc
+and beginning with
+.Ql \-I
 is completed as a directory.
-`\-I' is not taken as part of the
+.Ql \-I
+is not taken as part of the
 directory because we used lowercase
-.Va c
+.Ql c .
 .Pp
 Different
-.Va list
-s are useful with different commands.
-.IP "" 4
+.Ar list Ns No s
+are useful with different commands.
+.Bd -literal -offset indent
 > complete alias 'p/1/a/'
-.br
 > complete man 'p/*/c/'
-.br
 > complete set 'p/1/s/'
-.br
 > complete true 'p/1/x:Truth has no options./'
+.Ed
 .Pp
 These complete words following
-.Sq alias
+.Ql alias
 with aliases,
-.Sq man
+.Ql man
 with commands,
 and
-.Sq set
+.Ql set
 with shell variables.
-`true' doesn't have any options, so
-.Va x
+.Ic true
+doesn't have any options, so
+.Ql x
 does nothing when completion
 is attempted and prints
 .Sq Truth has no options.
 when completion choices are listed.
 .Pp
 Note that the
-.Va man
+.Ql man
 example, and several other examples below, could
-just as well have used 'c/*' or 'n/*' as 'p/*'.
+just as well have used
+.Ql 'c/*'
+or
+.Ql 'n/*'
+as
+.Ql 'p/*' .
 .Pp
 Words can be completed from a variable evaluated at completion time,
-.IP "" 4
+.Bd -literal -offset indent
 > complete ftp 'p/1/$hostnames/'
-.br
 > set hostnames = (rtfm.mit.edu tesla.ee.cornell.edu)
-.br
 > ftp [^D]
-.br
 rtfm.mit.edu tesla.ee.cornell.edu
-.br
 > ftp [^C]
-.br
 > set hostnames = (rtfm.mit.edu tesla.ee.cornell.edu uunet.uu.net)
-.br
 > ftp [^D]
-.br
 rtfm.mit.edu tesla.ee.cornell.edu uunet.uu.net
+.Ed
 .Pp
 or from a command run at completion time:
-.IP "" 4
+.Bd -literal -offset indent
 > complete kill 'p/*/\`ps | awk \e{print\e \e$1\e}\`/'
-.br
 > kill \-9 [^D]
-.br
 23113 23377 23380 23406 23429 23529 23530 PID
+.Ed
 .Pp
 Note that the
-.Va complete
+.Ic complete
 command does not itself quote its arguments,
 so the braces, space and
-.Sq $
+.Ql $
 in
-.Sq {print $1}
+.Ql {print $1}
 must be quoted explicitly.
 .Pp
 One command can have multiple completions:
-.IP "" 4
+.Bd -literal -offset indent
 > complete dbx 'p/2/(core)/' 'p/*/c/'
+.Ed
 .Pp
 completes the second argument to
-.Sq dbx
+.Ql dbx
 with the word
-.Sq core
+.Ql core
 and all other
 arguments with commands.
 Note that the positional completion is specified
@@ -4618,284 +4898,281 @@ This is a
 common mistake when defining a completion.
 .Pp
 The
-.Va select
+.Ar select
 pattern is useful when a command takes files with only
 particular forms as arguments.
 For example,
-.IP "" 4
+.Bd -literal -offset indent
 > complete cc 'p/*/f:*.[cao]/'
+.Ed
 .Pp
 completes
-.Sq cc
+.Ql cc
 arguments to files ending in only
-.Sq .c
-,
-.Sq .a
-, or
-.Sq .o
-.Va select
+.Ql .c ,
+.Ql .a ,
+or
+.Ql .o .
+.Ar select
 can also exclude files, using negation of a glob-pattern as
 described under
-.Va Filename substitution
+.Sx Filename substitution .
 One might use
-.IP "" 4
+.Bd -literal -offset indent
 > complete rm 'p/*/f:^*.{c,h,cc,C,tex,1,man,l,y}/'
+.Ed
 .Pp
 to exclude precious source code from
-.Sq rm
+.Ql rm
 completion.
 Of course, one
 could still type excluded names manually or override the completion
 mechanism using the
-.Va complete-word-raw
+.Ic complete-word-raw
 or
-.Va list-choices-raw
+.Ic list-choices-raw
 editor commands (q.v.).
 .Pp
 The
-.Sq C
-,
-.Sq D
-,
-.Sq F
+.Ql C ,
+.Ql D ,
+.Ql F ,
 and
-.Sq T
-
-.Va list
-s are like
-.Sq c
-,
-.Sq d
-,
-.Sq f
+.Ql T
+.Ar list Ns s
+are like
+.Ql c ,
+.Ql d ,
+.Ql f ,
 and
-.Sq t
+.Ql t
 respectively, but they use the
-.Va select
+.Ar select
 argument in a different way: to
 restrict completion to files beginning with a particular path prefix.
 For
 example, the Elm mail program uses
-.Sq =
+.Ql =
 as an abbreviation for one's mail
 directory.
 One might use
-.IP "" 4
+.Bd -literal -offset indent
 > complete elm c@=@F:$HOME/Mail/@
+.Ed
 .Pp
 to complete
-.Sq elm \-f =
+.Ql elm \-f =
 as if it were
-.Sq elm \-f ~/Mail/
-Note that we used
-.Sq @
+.Ql elm \-f ~/Mail/ .
+Note that we used the separator
+.Ql @
 instead of
-.Sq /
+.Ql /
 to avoid confusion with the
-.Va select
+.Ar select
 argument, and we used
-`$HOME' instead of
-.Sq ~
+.Ql $HOME
+instead of
+.Ql ~
 because home directory substitution works at only the
 beginning of a word.
 .Pp
-.Va suffix
+.Ar suffix
 is used to add a nonstandard suffix
 (not space or
-.Sq /
+.Ql /
 for directories) to completed words.
-.IP "" 4
+.Bd -literal -offset indent
 > complete finger 'c/*@/$hostnames/' 'p/1/u/@'
+.Ed
 .Pp
 completes arguments to
-.Sq finger
+.Ql finger
 from the list of users, appends an
-.Sq @
-,
+.Ql @ ,
 and then completes after the
-.Sq @
+.Ql @
 from the
-.Sq hostnames
+.Ql hostnames
 variable.
 Note
 again the order in which the completions are specified.
 .Pp
 Finally, here's a complex example for inspiration:
-.IP "" 4
+.Bd -literal -offset indent
 > complete find \e
-.br
 \&'n/\-name/f/' 'n/\-newer/f/' 'n/\-{,n}cpio/f/' \e
-.br
 \&\'n/\-exec/c/' 'n/\-ok/c/' 'n/\-user/u/' \e
-.br
 \&'n/\-group/g/' 'n/\-fstype/(nfs 4.2)/' \e
-.br
 \&'n/\-type/(b c d f l p s)/' \e
-.br
 \'c/\-/(name newer cpio ncpio exec ok user \e
-.br
 group fstype type atime ctime depth inum \e
-.br
 ls mtime nogroup nouser perm print prune \e
-.br
 size xdev)/' \e
-.br
 \&'p/*/d/'
+.Ed
 .Pp
 This completes words following
-.Sq \-name
-,
-.Sq \-newer
-,
-.Sq \-cpio
+.Ql \-name ,
+.Ql \-newer ,
+.Ql \-cpio ,
 or
-.Sq ncpio
+.Ql ncpio
 (note the pattern which matches both) to files,
 words following
-.Sq \-exec
+.Ql \-exec
 or
-.Sq \-ok
+.Ql \-ok
 to commands, words following
-.Sq user
+.Ql user
 and
-.Sq group
+.Ql group
 to users and groups respectively
 and words following
-.Sq \-fstype
+.Ql \-fstype
 or
-.Sq \-type
+.Ql \-type
 to members of the
 given lists.
 It also completes the switches themselves from the given list
 (note the use of
-.Va c
--type completion)
+.Ql c Ns
+\-type completion)
 and completes anything not otherwise completed to a directory.
 Whew.
 .Pp
 Remember that programmed completions are ignored if the word being completed
 is a tilde substitution (beginning with
-.Sq ~
-) or a variable (beginning with
-.Sq $
-).
+.Ql ~ )
+or a variable (beginning with
+.Ql $ ) .
 See also the
-.Va uncomplete
+.Ic uncomplete
 builtin command.
-.RE
-.TP 8
-.B continue
+.
+.It Ic continue
 Continues execution of the nearest enclosing
-.Va while
+.Ic while
 or
-.Va foreach
+.Ic foreach .
 The rest of the commands on the current line are executed.
-.TP 8
-.B default:
+.
+.It Ic default:
 Labels the default case in a
-.Va switch
+.Ic switch
 statement.
 It should come after all
-.Va case
+.Ic case
 labels.
+.
+.El
 .Pp
-.B dirs \fR[
-.Fl l\fR] [
-.Fl n\fR|
-.Fl v\fR]
-.br
-.B dirs \-S\fR|
-.Fl L \fR[
-.Va filename
-] (+)
-.PD 0
-.TP 8
-.B dirs \-c \fR(+)
+.Bl -tag -width 8n -compact
+.
+.It Ic dirs Xo
+.Op Fl l
+.Op Fl n Ns | Ns Fl v
+.Xc
+.It Ic dirs Xo
+.Fl S Ns | Ns Fl L
+.Op Ar filename
+(+)
+.Xc
+.It Ic dirs Xo
+.Fl c
+(+)
+.Xc
 The first form prints the directory stack.
 The top of the stack is at the
 left and the first directory in the stack is the current directory.
 With
-.Fl l\fR,
-.Sq ~
+.Fl l ,
+.Ql ~
 or
-.Sq ~\fIname\fP
+.Ql ~ Ns Ar name
 in the output is expanded explicitly
 to
-.Va home
-or the pathname of the home directory for user \fIname\fP.
+.Ic home
+or the pathname of the home directory for user
+.Ar name .
 (+)
 With
-.Fl n\fR, entries are wrapped before they reach the edge of the screen.
+.Fl n ,
+entries are wrapped before they reach the edge of the screen.
 (+)
 With
-.Fl v\fR, entries are printed one per line, preceded by their stack positions.
+.Fl v ,
+entries are printed one per line, preceded by their stack positions.
 (+)
 If more than one of
-.Fl n\fR or
-.Fl v\fR is given,
-.Fl v\fR takes precedence.
-.Fl p\fR is accepted but does nothing.
-.PD
-.RS +8
+.Fl n
+or
+.Fl v
+is given,
+.Fl v
+takes precedence.
+.Fl p
+is accepted but does nothing.
 .Pp
 With
-.Fl S\fR, the second form saves the directory stack to
-.Va filename
+.Fl S ,
+the second form saves the directory stack to
+.Ar filename
 as a series of
-.Va cd
+.Ic cd
 and
-.Va pushd
+.Ic pushd
 commands.
 With
-.Fl L\fR, the shell sources
-.Va filename
-, which is presumably
+.Fl L ,
+the shell sources
+.Ar filename ,
+which is presumably
 a directory stack file saved by the
-.Fl S\fR option or the
-.Va savedirs
+.Fl S
+option or the
+.Ic savedirs
 mechanism.
 In either case,
-.Va dirsfile
+.Ic dirsfile
 is used if
-.Va filename
+.Ar filename
 is not given and
-.Va ~/.cshdirs
+.Pa ~/.cshdirs
 is used if
-.Va dirsfile
+.Ic dirsfile
 is unset.
 .Pp
 Note that login shells do the equivalent of
-.Sq dirs \-L
+.Ql dirs \-L
 on startup
 and, if
-.Va savedirs
+.Ic savedirs
 is set,
-.Sq dirs \-S
+.Ql dirs \-S
 before exiting.
 Because only
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 is normally sourced before
-.Va ~/.cshdirs
-,
-.Va dirsfile
+.Pa ~/.cshdirs ,
+.Ic dirsfile
 should be set in
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 rather than
-.Va ~/.login
+.Pa ~/.login .
 .Pp
 The last form clears the directory stack.
-.RE
-.TP 8
-.B echo \fR[
-.Fl n\fR]
-.Va word
-...
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic echo Oo Fl n Oc Ar word No \&...
 Writes each
-.Va word
+.Ar word
 to the shell's standard
 output, separated by spaces and terminated with a newline.
 The
-.Va echo_style
+.Ic echo_style
 shell variable may be set to emulate (or not) the flags and escape
 sequences of the BSD and/or System V versions of
 .Xr echo 1 ;
@@ -4903,74 +5180,85 @@ see
 .Sx Escape sequences
 and
 .Xr echo 1 .
-.TP 8
-.B echotc \fR[
-.Fl sv\fR]
-.Va arg
-... (+)
+.
+.It Ic echotc Oo Fl sv Oc Ar arg No \&... No (+)
 Exercises the terminal capabilities (see
-.Va termcap
-(5)) in
-.Va args
-For example, 'echotc home' sends the cursor to the home position,
-\&'echotc cm 3 10' sends it to column 3 and row 10, and
-\&'echotc ts 0; echo "This is a test."; echotc fs' prints "This is a test."
+.Xr termcap 5 )
+in
+.Ar arg .
+For example,
+.Ql echotc home
+sends the cursor to the home position,
+.Ql echotc cm 3 10
+sends it to column 3 and row 10, and
+.Ql echotc ts 0; echo \&"This is a test.\&"; echotc fs
+prints
+.Sq This is a test.
 in the status line.
-.RS +8
 .Pp
 If
-.Va arg
-is 'baud', 'cols', 'lines', 'meta' or 'tabs', prints the
-value of that capability ("yes" or "no" indicating that the terminal does
+.Ar arg
+is
+.Ql baud ,
+.Ql cols ,
+.Ql lines ,
+.Ql meta ,
+or
+.Ql tabs ,
+prints the
+value of that capability
+.Dq ( yes
+or
+.Dq no
+indicating that the terminal does
 or does not have that capability).
 One might use this to make the output
 from a shell script less verbose on slow terminals, or limit command
 output to the number of lines on the screen:
-.IP "" 4
+.Bd -literal -offset indent
 > set history=\`echotc lines\`
-.br
 > @ history\-\-
+.Ed
 .Pp
 Termcap strings may contain wildcards which will not echo correctly.
 One should use double quotes when setting a shell variable to a terminal
 capability string, as in the following example that places the date in
 the status line:
-.IP "" 4
+.Bd -literal -offset indent
 > set tosl="\`echotc ts 0\`"
-.br
 > set frsl="\`echotc fs\`"
-.br
 > echo \-n "$tosl";date; echo \-n "$frsl"
+.Ed
 .Pp
 With
-.Fl s\fR, nonexistent capabilities return the empty string rather
+.Fl s ,
+nonexistent capabilities return the empty string rather
 than causing an error.
 With
-.Fl v\fR, messages are verbose.
-.RE
+.Fl v ,
+messages are verbose.
 .Pp
-.B else
-.br
-.B end
-.br
-.B endif
-.PD 0
-.TP 8
-.B endsw
+.
+.El
+.Pp
+.Bl -tag -width 8n -compact
+.
+.It Ic else
+.It Ic end
+.It Ic endif
+.It Ic endsw
 See the description of the
-.Va foreach
-,
-.Va if
-,
-.Va switch
-, and
-.Va while
+.Ic foreach ,
+.Ic if ,
+.Ic switch ,
+and
+.Ic while
 statements below.
-.PD
-.TP 8
-.B eval
-.Va arg
-...
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic eval Ar arg No \&...
 Treats the arguments as input to the
 shell and executes the resulting command(s) in the context
 of the current shell.
@@ -4978,359 +5266,367 @@ This is usually used to execute commands
 generated as the result of command or variable substitution,
 because parsing occurs before these substitutions.
 See
-.Va tset
-(1) for a sample use of
-.Va eval
-.TP 8
-.B exec
-.Va command
-Executes the specified command in place of the current shell.
-.TP 8
-.B exit \fR[
-.Va expr
-]
+.Xr tset 1
+for a sample use of
+.Ic eval .
+.
+.It Ic exec Ar command No \&...
+Executes the specified
+.Ar command
+in place of the current shell.
+.
+.It Ic exit Op Ar expr
 The shell exits either with the value of the specified
-.Va expr
+.Ar expr
 (an expression, as described under
-.Va Expressions
-)
+.Sx Expressions )
 or, without
-.Va expr
-, with the value 0.
-.TP 8
-.B fg \fR[\fB%
-.Va job
-...]
+.Ar expr ,
+with the value 0.
+.
+.It Ic fg Op Cm % Ns Ar job No \&...
 Brings the specified jobs (or, without arguments, the current job)
 into the foreground, continuing each if it is stopped.
-.Va job
+.Ar job
 may be a number, a string,
-.Sq
-,
-.Sq %
-,
-.Sq +
+.Ql \& ,
+.Ql % ,
+.Ql + ,
 or
-.Sq \-
-as described
-under
-.Va Jobs
+.Ql \-
+as described under
+.Sx Jobs .
 See also the
-.Va run-fg-editor
+.Ic run-fg-editor
 editor command.
-.TP 8
-.B filetest \-
-.Va op file
-... (+)
+.
+.It Ic filetest \- Ns Ar op file No \&... No (+)
 Applies
-.Va op
+.Ar op
 (which is a file inquiry operator as described under
-.Va File inquiry operators
-) to each
-.Va file
+.Sx File inquiry operators )
+to each
+.Ar file
 and returns the results as a
 space-separated list.
+.
+.El
 .Pp
-.B foreach \fIname \fB(\fIwordlist\fB)
-.br
-\&...
-.PD 0
-.TP 8
-.B end
+.Bl -tag -width 8n -compact
+.
+.It Ic foreach Ar name Cm \&( Ns Ar wordlist Ns Cm \&)
+.It Ic \&...
+.It Ic end
 Successively sets the variable
-.Va name
+.Ar name
 to each member of
-.Va wordlist
+.Ar wordlist
 and executes the sequence of commands between this command
 and the matching
-.Va end
+.Ic end .
 (Both
-.Va foreach
+.Ic foreach
 and
-.Va end
+.Ic end
 must appear alone on separate lines.)  The builtin command
-.Va continue
+.Ic continue
 may be used to continue the loop prematurely and
 the builtin command
-.Va break
+.Ic break
 to terminate it prematurely.
 When this command is read from the terminal, the loop is read once
 prompting with
-.Sq foreach?
+.Sq Li foreach?\ \&
 (or
-.Va prompt2
-) before any statements in
+.Ic prompt2 )
+before any statements in
 the loop are executed.
 If you make a mistake typing in a
 loop at the terminal you can rub it out.
-.PD
-.TP 8
-.B getspath \fR(+)
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic getspath No (+)
 Prints the system execution path.
 (TCF only)
-.TP 8
-.B getxvers \fR(+)
+.
+.It Ic getxvers No (+)
 Prints the experimental version prefix.
 (TCF only)
-.TP 8
-.B glob \fIwordlist
+.
+.It Ic glob Ar word No \&...
 Like
-.Va echo
-, but the
-.Sq -n
+.Ic echo ,
+but the
+.Fl n
 parameter is not recognized and words are
 delimited by null characters in the output.
 Useful for
 programs which wish to use the shell to filename expand a list of words.
-.TP 8
-.B goto \fIword
-.Va word
+.
+.It Ic goto Ar word
+.Ar word
 is filename and command-substituted to
 yield a string of the form
-.Sq label
+.Sq Ar label .
 The shell rewinds its
 input as much as possible, searches for a line of the
 form
-.Sq label:
-, possibly preceded by blanks or tabs, and
+.Sq Ar label Ns No \&: ,
+possibly preceded by blanks or tabs, and
 continues execution after that line.
-.TP 8
-.B hashstat
+.
+.It Ic hashstat
 Prints a statistics line indicating how effective the
 internal hash table has been at locating commands (and avoiding
-.Va exec
-'s).
+.Ic exec Ns
+\&'s).
 An
-.Va exec
+.Ic exec
 is attempted for each component of the
-.Va path
+.Ic path
 where the hash function indicates a possible hit, and
 in each component which does not begin with a
-.Sq /
-.IP
-On machines without
-.Va vfork
-(2), prints only the number and size of
-hash buckets.
+.Ql / .
 .Pp
-.B history \fR[
-.Fl hTr\fR] [
-.Va n
-]
-.br
-.B history \-S\fR|
-.Fl L|
-.Fl M \fR[
-.Va filename
-] (+)
-.PD 0
-.TP 8
-.B history \-c \fR(+)
+On machines without
+.Xr vfork 2 ,
+prints only the number and size of
+hash buckets.
+.
+.El
+.Pp
+.Bl -tag -width 8n -compact
+.
+.It Ic history Xo
+.Op Fl hTr
+.Op Ar n
+.Xc
+.It Ic history Xo
+.Fl S Ns | Ns Fl L Ns | Ns Fl M
+.Op Ar filename
+(+)
+.Xc
+.It Ic history Xo
+.Fl c
+(+)
+.Xc
 The first form prints the history event list.
 If
-.Va n
+.Ar n
 is given only the
-.Va n
+.Ar n
 most recent events are printed or saved.
 With
-.Fl h\fR, the history list is printed without leading numbers.
+.Fl h ,
+the history list is printed without leading numbers.
 If
-.Va -T
+.Fl T
 is specified, timestamps are printed also in comment form.
 (This can be used to
-produce files suitable for loading with 'history \-L' or 'source \-h'.)
+produce files suitable for loading with
+.Ql history \-L
+or
+.Ql source \-h . )
 With
-.Fl r\fR, the order of printing is most recent
+.Fl r ,
+the order of printing is most recent
 first rather than oldest first.
-.PD
-.RS +8
 .Pp
 With
-.Fl S\fR, the second form saves the history list to
-.Va filename
+.Fl S ,
+the second form saves the history list to
+.Ar filename .
 If the first word of the
-.Va savehist
+.Ic savehist
 shell variable is set to a
 number, at most that many lines are saved.
 If the second word of
-.Va savehist
+.Ic savehist
 is set to
-.Sq merge
-, the history list is merged with the
+.Ql merge ,
+the history list is merged with the
 existing history file instead of replacing it (if there is one) and
 sorted by time stamp.
 (+) Merging is intended for an environment like
 the X Window System
 with several shells in simultaneous use.
 If the second word of
-.Va savehist
+.Ic savehist
 is
-.Sq merge
+.Ql merge
 and the third word is set to
-.Sq lock
-, the history file update
+.Ql lock ,
+the history file update
 will be serialized with other shell sessions that would possibly like
 to merge history at exactly the same time.
 .Pp
 With
-.Fl L\fR, the shell appends
-.Va filename
-, which is presumably a
+.Fl L ,
+the shell appends
+.Ar filename ,
+which is presumably a
 history list saved by the
-.Fl S\fR option or the
-.Va savehist
+.Fl S
+option or the
+.Ic savehist
 mechanism,
 to the history list.
-.Fl M\fR is like
-.Fl L\fR, but the contents of
-.Va filename
+.Fl M
+is like
+.Fl L ,
+but the contents of
+.Ar filename
 are merged
 into the history list and sorted by timestamp.
 In either case,
-.Va histfile
+.Ic histfile
 is used if
-.Va filename
+.Ar filename
 is not given and
-.Va ~/.history
+.Pa ~/.history
 is used if
-.Va histfile
+.Ic histfile
 is unset.
-`history \-L' is exactly like 'source \-h' except that it does not require a
+.Ql history \-L
+is exactly like
+.Ql source \-h
+except that it does not require a
 filename.
 .Pp
 Note that login shells do the equivalent of
-.Sq history \-L
+.Ql history \-L
 on startup
 and, if
-.Va savehist
+.Ic savehist
 is set,
-.Sq history \-S
+.Ql history \-S
 before exiting.
 Because only
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 is normally sourced before
-.Va ~/.history
-,
-.Va histfile
+.Pa ~/.history ,
+.Ic histfile
 should be set in
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 rather than
-.Va ~/.login
+.Pa ~/.login .
 .Pp
 If
-.Va histlit
+.Ic histlit
 is set, the first and second forms print and save the literal
 (unexpanded) form of the history list.
 .Pp
 The last form clears the history list.
-.RE
-.TP 8
-.B hup \fR[
-.Va command
-] \fR(+)
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic hup Oo Ar command Oc No (+)
 With
-.Va command
-, runs
-.Va command
+.Ar command ,
+runs
+.Ar command
 such that it will exit on a hangup
 signal and arranges for the shell to send it a hangup signal when the shell
 exits.
 Note that commands may set their own response to hangups, overriding
-.Va hup
+.Ic hup .
 Without an argument, causes the non-interactive shell only to
 exit on a hangup for the remainder of the script.
 See also
-.Va Signal handling
+.Sx Signal handling
 and the
-.Va nohup
+.Ic nohup
 builtin command.
-.TP 8
-.B if (\fIexpr\fB) \fIcommand
+.
+.It Ic if Cm \&( Ns Ar expr Ns Cm \&) Ar command
 If
-.Va expr
+.Ar expr
 (an expression, as described under
-.Va Expressions
-)
+.Sx Expressions )
 evaluates true, then
-.Va command
+.Ar command
 is executed.
 Variable substitution on
-.Va command
+.Ar command
 happens early, at the same time it
 does for the rest of the
-.Va if
+.Ic if
 command.
-.Va command
+.Ar command
 must be a simple command, not an alias, a pipeline, a command list
 or a parenthesized command list, but it may have arguments.
 Input/output redirection occurs even if
-.Va expr
+.Ar expr
 is
 false and
-.Va command
+.Ar command
 is thus
-.Va not
+.Em not
 executed; this is a bug.
+.
+.El
 .Pp
-.B if (\fIexpr\fB) then
-.br
-\&...
-.br
-.B else if (\fIexpr2\fB) then
-.br
-\&...
-.br
-.B else
-.br
-\&...
-.PD 0
-.TP 8
-.B endif
+.Bl -tag -width 8n -compact
+.
+.It Ic if Cm \&( Ns Ar expr Ns Cm \&) then
+.It Ic \&...
+.It Ic else if Cm \&( Ns Ar expr2 Ns Cm \&) then
+.It Ic \&...
+.It Ic else
+.It Ic \&...
+.It Ic endif
 If the specified
-.Va expr
+.Ar expr
 is true then the commands to the
 first
-.Va else
+.Ic else
 are executed; otherwise if
-.Va expr2
+.Ar expr2
 is true then
 the commands to the second
-.Va else
+.Ic else
 are executed, etc.
 Any
 number of
-.Va else-if
+.Ic else if
 pairs are possible; only one
-.Va endif
+.Ic endif
 is
 needed.
 The
-.Va else
+.Ic else
 part is likewise optional.
 (The words
-.Va else
+.Ic else
 and
-.Va endif
+.Ic endif
 must appear at the beginning of input lines;
 the
-.Va if
+.Ic if
 must appear alone on its input line or after an
-.Va else
-.)
-.PD
-.TP 8
-.B inlib
-.Va shared-library
-... (+)
+.Ic else . )
+.
+.El
+.Pp
+.Bl -tag -width 8n -compact
+.
+.It Ic inlib Ar shared-library No \&... No (+)
 Adds each
-.Va shared-library
+.Ar shared-library
 to the current environment.
 There is no way
 to remove a shared library.
 (Domain/OS only)
+.
+.El
 .Pp
-.It Ar jobs Op Fl l
-.It Ar jobs Fl Z Op title (+)
+.Bl -tag -width 8n -compact
+.
+.It Ic jobs Op Fl l
+.It Ic jobs Fl Z Oo Ar title Oc No (+)
 Lists the active jobs.
 With
 .Fl l ,
@@ -5347,74 +5643,63 @@ where available.
 If no
 .Ar title
 is provided, the process title will be cleared.
+.
+.\" adjacant multi-tag items; add a blank
 .Pp
-.PD 0
-.TP 8
-.B kill \fR[
-.Fl s
-.Va signal
-] \fB%
-.Va job
-|
-.Va pid
-...
-.PD 0
-.TP 8
-.B kill \-l
-The first and second forms sends the specified
-.Va signal
+.
+.It Ic kill Xo
+.Op Fl s Ar signal
+.Cm % Ns Ar job Ns | Ns Ar pid No \&...
+.Xc
+.It Ic kill Fl l
+The first form sends the specified
+.Ar signal
 (or, if none
 is given, the TERM (terminate) signal) to the specified jobs or processes.
-.Va job
+.Ar job
 may be a number, a string,
-.Sq
-,
-.Sq %
-,
-.Sq +
+.Ql \& ,
+.Ql % ,
+.Ql + ,
 or
-.Sq \-
-as described
-under
-.Va Jobs
+.Ql \-
+as described under
+.Sx Jobs .
 Signals are either given by number or by name (as given in
-.Va /usr/include/signal.h
-, stripped of the prefix
-.Sq SIG
-).
+.Pa /usr/include/signal.h ,
+stripped of the prefix
+.Sq SIG ) .
 There is no default
-.Va job
-; saying just
-.Sq kill
+.Ar job ;
+saying just
+.Ql kill
 does not send a signal
 to the current job.
 If the signal being sent is TERM (terminate)
 or HUP (hangup), then the job or process is sent a
 CONT (continue) signal as well.
-The third form lists the signal names.
-.PD
-.TP 8
-.B limit \fR[
-.Fl h\fR] [
-.Va resource
-[
-.Va maximum-use
-]]
+The second form lists the signal names.
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic limit Oo Fl h Oc Op Ar resource Op Ar maximum-use
 Limits the consumption by the current process and each
 process it creates to not individually exceed
-.Va maximum-use
+.Ar maximum-use
 on
 the specified
-.Va resource
+.Ar resource .
 If no
-.Va maximum-use
+.Ar maximum-use
 is given, then
 the current limit is printed; if no
-.Va resource
+.Ar resource
 is given, then
 all limitations are given.
 If the
-.Fl h\fR flag is given, the
+.Fl h
+flag is given, the
 hard limits are used instead of the current limits.
 The
 hard limits impose a ceiling on the values of the current
@@ -5422,606 +5707,573 @@ limits.
 Only the super-user may raise the hard limits, but
 a user may lower or raise the current limits within the legal range.
 .Pp
-Controllable resources currently include (if supported by the OS):
-.Bl -tag -width pseudoterminals -compact -offset indent
-.It Va cputime
+Controllable
+.Ar resource
+types currently include (if supported by the OS):
+.Bl -tag -width 12n -offset indent
+.It Ic cputime
 the maximum number of cpu-seconds to be used by each process
-.It Va filesize
+.It Ic filesize
 the largest single file which can be created
-.It Va datasize
-the maximum growth of the data+stack region via sbrk(2) beyond
-the end of the program text
-.It Va stacksize
+.It Ic datasize
+the maximum growth of the data+stack region via
+.Xr sbrk 2
+beyond the end of the program text
+.It Ic stacksize
 the maximum size of the automatically-extended stack region
-.It Va coredumpsize
+.It Ic coredumpsize
 the size of the largest core dump that will be created
-.It Va memoryuse
+.It Ic memoryuse
 the maximum amount of physical memory a process
 may have allocated to it at a given time
-.It Va vmemoryuse
+.It Ic vmemoryuse
 the maximum amount of virtual memory a process
 may have allocated to it at a given time (address space)
-.It Va vmemoryuse
-the maximum amount of virtual memory a process
-may have allocated to it at a given time
-.It Va heapsize
+.It Ic heapsize
 the maximum amount of memory a process
 may allocate per
 .Xr brk 2
 system call
-.It Va descriptors
-or
-.It Va openfiles
+.It Ic descriptors No or Ic openfiles
 the maximum number of open files for this process
-.It Va pseudoterminals
+.It Ic pseudoterminals
 the maximum number of pseudo-terminals for this user
-.It Va kqueues
+.It Ic kqueues
 the maximum number of kqueues allocated for this process
-.It Va concurrency
+.It Ic concurrency
 the maximum number of threads for this process
-.It Va memorylocked
-the maximum size which a process may lock into memory using mlock(2)
-.It Va maxproc
+.It Ic memorylocked
+the maximum size which a process may lock into memory using
+.Xr mlock 2
+.It Ic maxproc
 the maximum number of simultaneous processes for this user id
-.It Va maxthread
+.It Ic maxthread
 the maximum number of simultaneous threads (lightweight processes) for this
 user id
-.It Va threads
+.It Ic threads
 the maximum number of threads for this process
-.It Va sbsize
+.It Ic sbsize
 the maximum size of socket buffer usage for this user
-.It Va swapsize
+.It Ic swapsize
 the maximum amount of swap space reserved or used for this user
-.It Va maxlocks
+.It Ic maxlocks
 the maximum number of locks for this user
-.It Va posixlocks
+.It Ic posixlocks
 the maximum number of POSIX advisory locks for this user
-.It Va maxsignal
+.It Ic maxsignal
 the maximum number of pending signals for this user
-.It Va maxmessage
+.It Ic maxmessage
 the maximum number of bytes in POSIX mqueues for this user
-.It Va maxnice
+.It Ic maxnice
 the maximum nice priority the user is allowed to raise mapped from [19...-20]
 to [0...39] for this user
-.It Va maxrtprio
+.It Ic maxrtprio
 the maximum realtime priority for this user
-.It Va maxrttime
-the timeout for RT tasks in microseconds for this user.
+.It Ic maxrttime
+the timeout for RT tasks in microseconds for this user
 .El
 .Pp
-.Va maximum-use
+.Ar maximum-use
 may be given as a (floating point or
 integer) number followed by a scale factor.
 For all limits
 other than
-.Va cputime
+.Ic cputime
 the default scale is
-.Sq k
+.Ql k
 or
-.Sq kilobytes
+.Ql kilobytes
 (1024 bytes); a scale factor of
-.Sq m
+.Ql m
 or
-.Sq megabytes
+.Ql megabytes
 or
-.Sq g
+.Ql g
 or
-.Sq gigabytes
+.Ql gigabytes
 may also be used.
 For
-.Va cputime
+.Ic cputime
 the default scaling is
-.Sq seconds ,
+.Ql seconds ,
 while
-.Sq m
+.Ql m
 for minutes or
-.Sq h
+.Ql h
 for hours, or a time of the
 form
-.Sq mm:ss
+.Sq Ar mm Ns Li : Ns Ar ss
 giving minutes and seconds may be used.
 .Pp
 If
-.Va maximum-use
+.Ar maximum-use
 is
-.Sq unlimited ,
+.Ql unlimited ,
 then the limitation on the specified
-.Va resource
+.Ar resource
 is removed (this is equivalent to the
-.Va unlimit
+.Ic unlimit
 builtin command).
 .Pp
 For both
-.Va resource
+.Ar resource
 names and scale factors, unambiguous
 prefixes of the names suffice.
-.RE
-.TP 8
-.B log \fR(+)
+.
+.It Ic log No (+)
 Prints the
-.Va watch
+.Ic watch
 shell variable and reports on each user indicated
 in
-.Va watch
+.Ic watch
 who is logged in, regardless of when they last logged in.
 See also
-.Va watchlog
-.TP 8
-.B login
+.Ic watchlog .
+.
+.It Ic login
 Terminates a login shell, replacing it with an instance of
-.Va /bin/login
-. This is one way to log off, included for
+.Pa /bin/login .
+This is one way to log off, included for
 compatibility with
 .Xr sh 1 .
-.TP 8
-.B logout
+.
+.It Ic logout
 Terminates a login shell.
 Especially useful if
-.Va ignoreeof
+.Ic ignoreeof
 is set.
-.TP 8
-.B ls\-F \fR[\-
-.Va switch
-...] [
-.Va file
-...] (+)
+.
+.It Ic ls\-F Xo
+.Op Fl Ar switch No \&...
+.Op Ar file No \&...
+(+)
+.Xc
 Lists files like
-.Sq ls \-F
-, but much faster.
+.Ql ls \-F ,
+but much faster.
 It identifies each type of
 special file in the listing with a special character:
-.Bl -tag -width x -offset indent -compact
-.It Dv /
+.Pp
+.Bl -tag -width 5n -offset indent -compact
+.It Li /
 Directory
-.It Dv *
+.It Li *
 Executable
-.It Dv #
+.It Li #
 Block device
-.It Dv %
+.It Li %
 Character device
-.It Dv |
+.It Li |
 Named pipe (systems with named pipes only)
-.It Dv =
+.It Li =
 Socket (systems with sockets only)
-.It Dv @
+.It Li @
 Symbolic link (systems with symbolic links only)
-.It Dv +
+.It Li +
 Hidden directory (AIX only) or context dependent (HP/UX only)
-.It Dv :
+.It Li :
 Network special (HP/UX only)
 .El
 .Pp
 If the
-.Va listlinks
+.Ic listlinks
 shell variable is set, symbolic links are identified
 in more detail (on only systems that have them, of course):
 .Pp
-.PD 0
-.TP 4
-@
+.Bl -tag -width 5n -offset indent -compact
+.It Li @
 Symbolic link to a non-directory
-.TP 4
->
+.It Li >
 Symbolic link to a directory
-.TP 4
-&
+.It Li &
 Symbolic link to nowhere
-.PD
+.El
 .Pp
-.Va listlinks
-also slows down \fIls\-F\fR and causes partitions holding
+.Ic listlinks
+also slows down
+.Ic ls\-F
+and causes partitions holding
 files pointed to by symbolic links to be mounted.
 .Pp
 If the
-.Va listflags
+.Ic listflags
 shell variable is set to
-.Sq x
-,
-.Sq a
+.Ql x ,
+.Ql a ,
 or
-.Sq A
-, or any
+.Ql A ,
+or any
 combination thereof (e.g.,
-.Sq xA
-), they are used as flags to \fIls\-F\fR,
+.Ql xA ) ,
+they are used as flags to
+.Ic ls\-F ,
 making it act like
-.Sq ls \-xF
-,
-.Sq ls \-Fa
-,
-.Sq ls \-FA
+.Ql ls \-xF ,
+.Ql ls \-Fa ,
+.Ql ls \-FA ,
 or a combination
 (e.g.,
-.Sq ls \-FxA
-).
+.Ql ls \-FxA ) .
 On machines where
-.Sq ls \-C
-is not the default, \fIls\-F\fR acts like
-.Sq ls \-CF
-,
+.Ql ls \-C
+is not the default,
+.Ic ls\-F
+acts like
+.Ql ls \-CF ,
 unless
-.Va listflags
+.Ic listflags
 contains an
-.Sq x
-, in which case it acts like
-.Sq ls \-xF
-\fIls\-F\fR passes its arguments to
-.Va ls
-(1) if it is given any switches,
+.Ql x ,
+in which case it acts like
+.Ql ls \-xF .
+.Ic ls\-F
+passes its arguments to
+.Xr ls 1
+if it is given any switches,
 so
-.Sq alias ls ls\-F
+.Ql alias ls ls\-F
 generally does the right thing.
 .Pp
-The \fBls\-F\fR builtin can list files using different colors depending on the
+The
+.Ic ls\-F
+builtin can list files using different colors depending on the
 filetype or extension.
 See the
-.Va color
+.Ic color
 shell variable and the
-.Va LS_COLORS
+.Ev LS_COLORS
 environment variable.
-.RE
+.El
 .Pp
-.B migrate \fR[
-.Fl
-.Va site
-]
-.Va pid
-|\fB%
-.Va jobid
-... (+)
-.PD 0
-.TP 8
-.B migrate \-
-.Va site
-(+)
+.Bl -tag -width 8n -compact
+.
+.It Ic migrate Xo
+.Op Fl Ar site
+.Ar pid Ns | Ns Cm % Ns Ar jobid No \&... (+)
+.Xc
+.It Ic migrate Fl Ar site No (+)
 The first form migrates the process or job to the site specified or the
 default site determined by the system path.
 The second form is equivalent to
-.Sq migrate \-
-.Va site
-$$
-: it migrates the
+.Ql migrate \- Ns Ar site Li $$ :
+it migrates the
 current process to the specified site.
 Migrating the shell
 itself can cause unexpected behavior, because the shell
 does not like to lose its tty.
 (TCF only)
-.PD
-.TP 8
-.B newgrp \fR[
-.Fl \fR]
-.Va [group]
-(+)
+.El
+.Bl -tag -width 8n
+.
+.It Ic newgrp Oo Cm \- Oc Oo Ar group Oc No (+)
 Equivalent to
-.Sq exec newgrp
-; see
-.Va newgrp
-(1).
+.Ql exec newgrp ;
+see
+.Xr newgrp 1 .
 Available only if the shell was so compiled;
 see the
-.Va version
+.Ic version
 shell variable.
-.TP 8
-.B nice \fR[\fB+
-.Va number
-] [
-.Va command
-]
+.
+.It Ic nice Oo Cm + Ns Ar number Oc Op Ar command
 Sets the scheduling priority for the shell to
-.Va number
-, or, without
-.Va number
-, to 4.
+.Ar number ,
+or, without
+.Ar number ,
+to 4.
 With
-.Va command ,
+.Ar command ,
 runs
-.Va command
+.Ar command
 at the appropriate
 priority.
 The greater the
-.Va number
-, the less cpu
+.Ar number ,
+the less cpu
 the process gets.
 The super-user may specify negative
 priority by using
-.Sq nice \-number ...
+.Ql nice \- Ns Ar number Li \&... .
 Command is always
 executed in a sub-shell, and the restrictions placed on
 commands in simple
-.Va if
+.Ic if
 statements apply.
-.TP 8
-.B nohup \fR[
-.Va command
-]
+.
+.It Ic nohup Op Ar command
 With
-.Va command
-, runs
-.Va command
+.Ar command ,
+runs
+.Ar command
 such that it will ignore hangup signals.
 Note that commands may set their own response to hangups, overriding
-.Va nohup
+.Ic nohup .
 Without an argument, causes the non-interactive shell only to
 ignore hangups for the remainder of the script.
 See also
-.Va Signal handling
+.Sx Signal handling
 and the
-.Va hup
+.Ic hup
 builtin command.
-.TP 8
-.B notify \fR[\fB%
-.Va job
-...]
+.
+.It Ic notify Op Cm % Ns Ar job No \&...
 Causes the shell to notify the user asynchronously when the status of any
-of the specified jobs (or, without %
-.Va job
-, the current job) changes,
+of the specified jobs (or, without
+.Cm % Ns Ar job ,
+the current job) changes,
 instead of waiting until the next prompt as is usual.
-.Va job
+.Ar job
 may be a number, a string,
-.Sq
-,
-.Sq %
-,
-.Sq +
+.Ql \& ,
+.Ql % ,
+.Ql + ,
 or
-.Sq \-
-as described
-under
-.Va Jobs
+.Ql \-
+as described under
+.Sx Jobs .
 See also the
-.Va notify
+.Ic notify
 shell variable.
-.TP 8
-.B onintr \fR[
-.Fl \fR|
-.Va label
-]
+.
+.It Ic onintr Op Cm \- Ns | Ns Ar label
 Controls the action of the shell on interrupts.
 Without arguments,
 restores the default action of the shell on interrupts,
 which is to terminate shell scripts or to return to the
 terminal command input level.
 With
-.Sq \-
-, causes all interrupts to be ignored.
+.Ql \- ,
+causes all interrupts to be ignored.
 With
-.Va label
-, causes the shell to execute a
-.Sq goto
-.Va label
+.Ar label ,
+causes the shell to execute a
+.Ql goto Ar label
 when an interrupt is received or a child process terminates because it was
 interrupted.
-.IP "" 8
-.Va onintr
+.Pp
+.Ic onintr
 is ignored if the shell is running detached and in system
 startup files (see
-.Va FILES
-), where interrupts are disabled anyway.
-.TP 8
-.B popd \fR[
-.Fl p\fR] [
-.Fl l\fR] [
-.Fl n\fR|
-.Fl v\fR] \fR[\fB+
-.Va n
-]
+.Sx FILES ) ,
+where interrupts are disabled anyway.
+.
+.It Ic popd Xo
+.Op Fl p
+.Op Fl l
+.Op Fl n Ns | Ns Fl v
+.Op Cm + Ns Ar n
+.Xc
 Without arguments, pops the directory stack and returns to the new top directory.
 With a number
-.Sq +
-.Va n
-, discards the
-.Va n
-'th entry in the stack.
-.IP "" 8
+.Ql + Ns Ar n ,
+discards the
+.Ar n Ns
+th entry in the stack.
+.Pp
 Finally, all forms of
-.Va popd
+.Ic popd
 print the final directory stack,
 just like
-.Va dirs
+.Ic dirs .
 The
-.Va pushdsilent
+.Ic pushdsilent
 shell variable can be set to
 prevent this and the
-.Fl p\fR flag can be given to override
-.Va pushdsilent
+.Fl p
+flag can be given to override
+.Ic pushdsilent .
 The
-.Fl l\fR,
-.Fl n\fR and
-.Fl v\fR flags have the same effect on
-.Va popd
+.Fl l ,
+.Fl n ,
+and
+.Fl v
+flags have the same effect on
+.Ic popd
 as on
-.Va dirs
+.Ic dirs.
 (+)
-.TP 8
-.B printenv \fR[
-.Va name
-] (+)
+.
+.It Ic printenv Oo Ar name Oc No (+)
 Prints the names and values of all environment variables or,
 with
-.Va name
-, the value of the environment variable
-.Va name
-.TP 8
-.B pushd \fR[
-.Fl p\fR] [
-.Fl l\fR] [
-.Fl n\fR|
-.Fl v\fR] [
-.Va name
-|\fB+
-.Va n
-]
+.Ar name ,
+the value of the environment variable
+.Ar name .
+.
+.It Ic pushd Xo
+.Op Fl p
+.Op Fl l
+.Op Fl n Ns | Ns Fl v
+.Op Ar name Ns | Ns Cm + Ns Ar n
+.Xc
 Without arguments, exchanges the top two elements of the directory stack.
 If
-.Va pushdtohome
+.Ic pushdtohome
 is set,
-.Va pushd
+.Ic pushd
 without arguments does
-.Sq pushd ~
-,
+.Ql pushd ~ ,
 like
-.Va cd
+.Ic cd .
 (+)
 With
-.Va name
-, pushes the current working directory onto the directory
+.Ar name ,
+pushes the current working directory onto the directory
 stack and changes to
-.Va name
+.Ar name .
 If
-.Va name
+.Ar name
 is
-.Sq \-
+.Ql \-
 it is interpreted as the previous working directory
 (see
-.Va Filename substitution
-).
+.Sx Filename substitution ) .
 (+)
 If
-.Va dunique
+.Ic dunique
 is set,
-.Va pushd
+.Ic pushd
 removes any instances of
-.Va name
+.Ar name
 from the stack before pushing it onto the stack.
 (+)
 With a number
-.Sq +
-.Va n
-, rotates the
-.Va n
+.Ql + Ns Ar n ,
+rotates the
+.Ar n Ns
 th element of the
 directory stack around to be the top element and changes to it.
 If
-.Va dextract
+.Ic dextract
 is set, however,
-.Sq pushd +
-.Va n
+.Ql pushd + Ns Ar n
 extracts the
-.Va n
+.Ar n Ns
 th
 directory, pushes it onto the top of the stack and changes to it.
 (+)
-.IP "" 8
+.Pp
 Finally, all forms of
-.Va pushd
+.Ic pushd
 print the final directory stack,
 just like
-.Va dirs
+.Ic dirs .
 The
-.Va pushdsilent
+.Ic pushdsilent
 shell variable can be set to
 prevent this and the
-.Fl p\fR flag can be given to override
-.Va pushdsilent
+.Fl p
+flag can be given to override
+.Ic pushdsilent .
 The
-.Fl l\fR,
-.Fl n\fR and
-.Fl v\fR flags have the same effect on
-.Va pushd
+.Fl l ,
+.Fl n ,
+and
+.Fl v
+flags have the same effect on
+.Ic pushd
 as on
-.Va dirs
+.Ic dirs .
 (+)
-.TP 8
-.B rehash
+.
+.It Ic rehash
 Causes the internal hash table of the contents of the
 directories in the
-.Va path
+.Ic path
 variable to be recomputed.
 This is
 needed if the
-.Va autorehash
+.Ic autorehash
 shell variable is not set and new
 commands are added to directories in
-.Va path
+.Ic path
 while you are logged
 in.
 With
-.Va autorehash
-, a new command will be found
+.Ic autorehash ,
+a new command will be found
 automatically, except in the special case where another command of
 the same name which is located in a different directory already
 exists in the hash table.
 Also flushes the cache of home directories
 built by tilde expansion.
-.TP 8
-.B repeat \fIcount command
+.
+.It Ic repeat Ar count Ar command
 The specified
-.Va command
-,
+.Ar command ,
 which is subject to the same restrictions as the
-.Va command
+.Ar command
 in the one line
-.Va if
+.Ic if
 statement above, is executed
-.Va count
+.Ar count
 times.
 I/O redirections occur exactly once, even if
-.Va count
+.Ar count
 is 0.
-.TP 8
-.B rootnode //
-.Va nodename
-(+)
-Changes the rootnode to //
-.Va nodename
-, so that
-.Sq /
+.
+.It Ic rootnode Cm // Ns Ar nodename No (+)
+Changes the rootnode to
+.Pa // Ns Ar nodename ,
+so that
+.Ql /
 will be interpreted
 as
-.Sq //
-.Va nodename
+.Ql // Ns Ar nodename .
 (Domain/OS only)
+.
+.El
 .Pp
-.B sched \fR(+)
-.br
-.B sched \fR[
-.Va +
-]
-.Va hh:mm command
-\fR(+)
-.PD 0
-.TP 8
-.B sched \-
-.Va n
+.Bl -tag -width 8n -compact
+.
+.It Ic sched No (+)
+.It Ic sched Xo
+.Op Cm + Ns
+.Ar hh Ns Cm : Ns Ar mm
+.Ar command
 (+)
+.Xc
+.It Ic sched Cm \- Ns Ar n No (+)
 The first form prints the scheduled-event list.
 The
-.Va sched
+.Ic sched
 shell variable may be set to define the format in which
 the scheduled-event list is printed.
+.Pp
 The second form adds
-.Va command
+.Ar command
 to the scheduled-event list.
 For example,
-.PD
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > sched 11:00 echo It\e's eleven o\e'clock.
+.Ed
 .Pp
 causes the shell to echo
-.Sq It's eleven o'clock .
+.Sq It's eleven o'clock.
 at 11 AM.
 The time may be in 12-hour AM/PM format
-.IP "" 4
+.Bd -literal -offset indent
 .\" TODO
 > sched 5pm set prompt='[%h] It\e's after 5; go home: >'
+.Ed
 .Pp
 or may be relative to the current time:
-.IP "" 4
+.Bd -literal -offset indent
 > sched +2:15 /usr/lib/uucp/uucico \-r1 \-sother
+.Ed
 .Pp
 A relative time specification may not use AM/PM format.
+.Pp
 The third form removes item
-.Va n
+.Ar n
 from the event list:
 .Bd -literal -offset indent
 > sched
-	1  Wed Apr  4 15:42  /usr/lib/uucp/uucico \-r1 \-sother
-	2  Wed Apr  4 17:00  set prompt=[%h] It's after 5; go home: >
+1  Wed Apr  4 15:42  /usr/lib/uucp/uucico \-r1 \-sother
+2  Wed Apr  4 17:00  set prompt=[%h] It's after 5; go home: >
 > sched \-2
 > sched
-	1  Wed Apr  4 15:42  /usr/lib/uucp/uucico \-r1 \-sother
+1  Wed Apr  4 15:42  /usr/lib/uucp/uucico \-r1 \-sother
 .Ed
 .Pp
 A command in the scheduled-event list is executed just before the first
@@ -6034,1090 +6286,1035 @@ However, normal operation of an already-running command will not
 be interrupted so that a scheduled-event list element may be run.
 .Pp
 This mechanism is similar to, but not the same as, the
-.Va at
-(1)
+.Xr at 1
 command on some Unix systems.
 Its major disadvantage is that it may not run a command at exactly the
 specified time.
 Its major advantage is that because
-.Va sched
+.Ic sched
 runs directly from
 the shell, it has access to shell variables and other structures.
 This provides a mechanism for changing one's working environment
 based on the time of day.
-.RE
+.
+.\" adjacant multi-tag items; add a blank
 .Pp
-.B set
-.br
-.B set
-.Va name
-...
-.br
-.B set
-.Va name
-\fB=
-.Va word
-...
-.br
-.B set [\-r] [\-f|\-l]
-.Va name
-\fB=(\fIwordlist
-.Va )
-... (+)
-.br
-.B set
-.Va name[index]
-\fB=
-.Va word
-...
-.br
-.B set \-r \fR(+)
-.br
-.B set \-r
-.Va name
-... (+)
-.PD 0
-.TP 8
-.B set \-r
-.Va name
-\fB=
-.Va word
-... (+)
+.
+.It Ic set
+.It Ic set Ar name No \&...
+.It Ic set Ar name Ns Cm = Ns Ar word No \&...
+.It Ic set Xo
+.Op Fl r
+.Op Fl f Ns | Ns Fl l
+.Ar name Ns Cm =\&( Ns Ar wordlist Ns Cm \&) No \&...
+(+)
+.Xc
+.It Ic set Ar name Ns Cm [ Ns Ar index Ns Cm ]= Ns Ar word No \&...
+.It Ic set Fl r No (+)
+.It Ic set Fl r Ar name No \&... No (+)
+.It Ic set Fl r Ar name Ns Cm = Ns Ar word No \&... No (+)
 The first form of the command prints the value of all shell variables.
 Variables which contain more than a single word print as a
 parenthesized word list.
 The second form sets
-.Va name
+.Ar name
 to the null string.
 The third form sets
-.Va name
+.Ar name
 to the single
-.Va word
+.Ar word .
 The fourth form sets
-.Va name
+.Ar name
 to the list of words in
-.Va wordlist
+.Ar wordlist .
 In all cases the value is command and filename expanded.
 If
-.Fl r\fR is specified, the value is set read-only.
+.Fl r
+is specified, the value is set read-only.
 If
-.Fl f\fR or
-.Fl l\fR are specified, set only unique words keeping their order.
-.Fl f\fR prefers the first occurrence of a word, and
-.Fl l\fR the last.
+.Fl f
+or
+.Fl l
+are specified, set only unique words keeping their order.
+.Fl f
+prefers the first occurrence of a word, and
+.Fl l
+the last.
 The fifth form sets the
-.Va index
-'th component of
-.Va name
+.Ar index Ns
+\&'th component of
+.Ar name
 to
-.Va word
-;
+.Ar word ;
 this component must already exist.
 The sixth form lists only the names of all shell variables that are read-only.
 The seventh form makes
-.Va name
+.Ar name
 read-only, whether or not it has a value.
 The eighth form is the same as the third form, but
 make
-.Va name
+.Ar name
 read-only at the same time.
-.PD
-.IP "" 8
+.Pp
 These arguments can be repeated to set and/or make read-only multiple variables
 in a single set command.
 Note, however, that variable expansion
 happens for all arguments before any setting occurs.
 Note also that
-.Sq =
+.Ql =
 can
 be adjacent to both
-.Va name
+.Ar name
 and
-.Va word
+.Ar word
 or separated from both by
 whitespace, but cannot be adjacent to only one or the other.
 See also the
-.Va unset
+.Ic unset
 builtin command.
-.TP 8
-.B setenv \fR[
-.Va name
-[
-.Va value
-]]
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic setenv Op Ar name Op Ar value
 Without arguments, prints the names and values of all environment variables.
 Given
-.Va name
-, sets the environment variable
-.Va name
+.Ar name ,
+sets the environment variable
+.Ar name
 to
-.Va value
+.Ar value
 or, without
-.Va value
-, to the null string.
-.TP 8
-.B setpath
-.Va path
-(+)
+.Ar value ,
+to the null string.
+.
+.It Ic setpath Ar path No (+)
 Equivalent to
-.Va setpath
-(1).
+.Xr setpath 1 .
 (Mach only)
-.TP 8
-.B setspath\fR LOCAL|
-.Va site
-|
-.Va cpu
-...
-(+)
+.
+.It Ic setspath Cm LOCAL Ns | Ns Ar site Ns | Ns Ar cpu No \&... No (+)
 Sets the system execution path.
 (TCF only)
-.TP 8
-.B settc
-.Va cap value
-(+)
+.
+.It Ic settc Ar cap value No (+)
 Tells the shell to believe that the terminal capability
-.Va cap
+.Ar cap
 (as defined in
-.Va termcap
-(5)) has the value
-.Va value
+.Xr termcap 5 )
+has the value
+.Ar value .
 No sanity checking is done.
 Concept terminal users may have to
-.Sq settc xn no
+.Ql settc xn no
 to get proper
 wrapping at the rightmost column.
-.TP 8
-.B setty \fR[
-.Fl d\fR|
-.Fl q\fR|
-.Fl x\fR] [
-.Fl a\fR] [[
-.Va +
-|
-.Fl \fR]
-.Va mode
-] (+)
+.
+.It Ic setty Xo
+.Op Fl d Ns | Ns Fl q Ns | Ns Fl x
+.Op Fl a
+.Op Oo Cm + Ns | Ns Cm \- Oc Ns Ar mode
+(+)
+.Xc
 Controls which tty modes (see
-.Va Terminal management
-)
+.Sx Terminal management )
 the shell does not allow to change.
-.Fl d\fR,
-.Fl q\fR or
-.Fl x\fR tells
-.Va setty
+.Fl d ,
+.Fl q ,
+or
+.Fl x
+tells
+.Ic setty
 to act
 on the
-.Sq edit
-,
-.Sq quote
+.Ql edit ,
+.Sq quote ,
 or
 .Sq execute
 set of tty modes respectively; without
-.Fl d\fR,
-.Fl q\fR or
-.Fl x\fR,
+.Fl d ,
+.Fl q ,
+or
+.Fl x ,
 .Sq execute
 is used.
-.IP "" 8
+.Pp
 Without other arguments,
-.Va setty
+.Ic setty
 lists the modes in the chosen set
-which are fixed on (`+mode') or off (`\-mode').
+which are fixed on
+.Pq Sq Cm + Ns Ar mode
+or off
+.Pq Sq Cm - Ns Ar mode .
 The available modes, and thus the display, vary from system to system.
 With
-.Fl a\fR, lists all tty modes in the chosen set
+.Fl a ,
+lists all tty modes in the chosen set
 whether or not they are fixed.
-With \fB+
-.Va mode
-,
-.Fl
-.Va mode
+With
+.Cm + Ns Ar mode ,
+.Cm - Ns Ar mode ,
 or
-.Va mode
-, fixes
-.Va mode
+.Ar mode ,
+fixes
+.Ar mode
 on or off
 or removes control from
-.Va mode
+.Ar mode
 in the chosen set.
 For example,
-.Sq setty +echok echoe
+.Ql setty +echok echoe
 fixes
-.Sq echok
+.Ql echok
 mode on and allows commands
 to turn
-.Sq echoe
+.Ql echoe
 mode on or off, both when the shell is executing commands.
-.TP 8
-.B setxvers\fR [
-.Va string
-] (+)
+.
+.It Ic setxvers Oo Ar string Oc No (+)
 Set the experimental version prefix to
-.Va string
-, or removes it
+.Ar string ,
+or removes it
 if
-.Va string
+.Ar string
 is omitted.
 (TCF only)
-.TP 8
-.B shift \fR[
-.Va variable
-]
+.
+.It Ic shift Op Ar variable
 Without arguments, discards
-.Va argv
-[1] and shifts the members of
-.Va argv
+.Ic argv Ns [1]
+and shifts the members of
+.Ic argv
 to the left.
 It is an error for
-.Va argv
+.Ic argv
 not to be set or to have
 less than one word as value.
 With
-.Va variable
-, performs the
+.Ar variable ,
+performs the
 same function on
-.Va variable
-.TP 8
-.B source \fR[
-.Fl h\fR]
-.Va name
-[
-.Va args
-...]
+.Ar variable .
+.
+.It Ic source Oo Fl h Oc Ar name Op Ar args No \&...
 The shell reads and executes commands from
-.Va name
+.Ar name .
 The commands are not placed on the history list.
 If any
-.Va args
+.Ar args
 are given, they are placed in
-.Va argv
+.Ic argv .
 (+)
-.Va source
+.Ic source
 commands may be nested;
 if they are nested too deeply the shell may run out of file descriptors.
 An error in a
-.Va source
+.Ic source
 at any level terminates all nested
-.Va source
+.Ic source
 commands.
 With
-.Fl h\fR, commands are placed on the history list instead of being
+.Fl h ,
+commands are placed on the history list instead of being
 executed, much like
-.Sq history \-L
-.TP 8
-.B stop \fB%
-.Va job
-|
-.Va pid
-...
+.Ql history \-L .
+.
+.It Ic stop % Ns Ar job Ns | Ns Ar pid No \&...
 Stops the specified jobs or processes which are executing in the background.
-.Va job
+.Ar job
 may be a number, a string,
-.Sq
-,
-.Sq %
-,
-.Sq +
+.Ql \& ,
+.Ql % ,
+.Ql + ,
 or
-.Sq \-
-as described
-under
-.Va Jobs
+.Ql \-
+as described under
+.Sx Jobs .
 There is no default
-.Va job
-; saying just
-.Sq stop
+.Ar job ;
+saying just
+.Ql stop
 does not stop
 the current job.
-.TP 8
-.B suspend
+.
+.It Ic suspend
 Causes the shell to stop in its tracks, much as if it had
 been sent a stop signal with
-.Va ^Z
+.Sq ^Z .
 This is most often used to
 stop shells started by
-.Va su
-(1).
+.Xr su 1 .
+.
+.El
 .Pp
-.B switch (\fIstring\fB)
-.br
-.B case \fIstr1\fB:
-.PD 0
-.IP "" 4
-\&...
-.br
-.B breaksw
-.Pp
-\&...
-.Pp
-.B default:
-.IP "" 4
-\&...
-.br
-.B breaksw
-.TP 8
-.B endsw
+.Bl -tag -width 8n -compact
+.
+.It Ic switch Cm \&( Ns Ar string Ns Cm \&)
+.It Ic case Ar str1 Ns :
+.It Ic \ \ \ \ \&...
+.It Ic \ \ \ \ breaksw
+.It Ic \&...
+.It Ic default:
+.It Ic \ \ \ \ \&...
+.It Ic \ \ \ \ breaksw
+.It Ic endsw
 Each case label is successively matched, against the
 specified
-.Va string
+.Ar string
 which is first command and filename expanded.
 The file metacharacters
-.Sq *
-,
-.Sq \&?
+.Ql * ,
+.Ql \&? ,
 and
-.Sq [...]
+.Ql [...]
 may be used
 in the case labels, which are variable expanded.
 If none
 of the labels match before a
-.Sq default
+.Ic default
 label is found, then
-the execution begins after the default label.
+the execution begins after the
+.Ic default
+label.
 Each case
-label and the default label must appear at the beginning of
+label and the
+.Ic default
+label must appear at the beginning of
 a line.
 The command
-.Va breaksw
+.Ic breaksw
 causes execution to continue
 after the
-.Va endsw
+.Ic endsw .
 Otherwise control may fall through case
 labels and default labels as in C.
 If no label matches and
 there is no default, execution continues after the
-.Va endsw
-.PD
-.TP 8
-.B telltc \fR(+)
+.Ic endsw .
+.
+.El
+.Bl -tag -width 8n
+.
+.It Ic telltc No (+)
 Lists the values of all terminal capabilities (see
-.Va termcap
-(5)).
-.TP 8
-.B termname \fR[
-.Va terminal type
-] \fR(+)
+.Xr termcap 5 ) .
+.
+.It Ic termname Oo Ar termtype Oc No (+)
 Tests if
-.Va terminal type
+.Ar termtype
 (or the current value of
-.Va TERM
+.Ev TERM
 if no
-.Va terminal type
-is given) has an entry in the hosts termcap(5) or
-terminfo(5) database. Prints the terminal type to stdout and returns 0
+.Ar termtype
+is given) has an entry in the hosts
+.Xr termcap 5
+or
+.Xr terminfo 5
+database. Prints the terminal type to stdout and returns 0
 if an entry is present otherwise returns 1.
-.TP 8
-.B time \fR[
-.Va command
-]
+.
+.It Ic time Op Ar command
 Executes
-.Va command
+.Ar command
 (which must be a simple command, not an alias,
 a pipeline, a command list or a parenthesized command list)
 and prints a time summary as described under the
-.Va time
+.Ic time
 variable.
 If necessary, an extra shell is created to print the time statistic when
 the command completes.
 Without
-.Va command
-, prints a time summary for the current shell and its
+.Ar command ,
+prints a time summary for the current shell and its
 children.
-.TP 8
-.B umask \fR[
-.Va value
-]
+..
+.It Ic umask Op Ar value
 Sets the file creation mask to
-.Va value
-, which is given in octal.
+.Ar value ,
+which is given in octal.
 Common values for the mask are
 002, giving all access to the group and read and execute access to others, and
 022, giving read and execute access to the group and others.
 Without
-.Va value
-, prints the current file creation mask.
-.TP 8
-.B unalias
-.Va pattern
-.br
+.Ar value ,
+prints the current file creation mask.
+.
+.It Ic unalias Ar pattern
 Removes all aliases whose names match
-.Va pattern
-`unalias *' thus removes all aliases.
+.Ar pattern .
+.Ql unalias *
+thus removes all aliases.
 It is not an error for nothing to be
-.Va unalias
+.Ic unalias Ns
 ed.
-.TP 8
-.B uncomplete
-.Va pattern
-(+)
+.
+.It Ic uncomplete Ar pattern No (+)
 Removes all completions whose names match
-.Va pattern
-`uncomplete *' thus removes all completions.
+.Ar pattern .
+.Ql uncomplete *
+thus removes all completions.
 It is not an error for nothing to be
-.Va uncomplete
+.Ic uncomplete Ns
 d.
-.TP 8
-.B unhash
+.
+.It Ic unhash
 Disables use of the internal hash table to speed location of
 executed programs.
-.TP 8
-.B universe
-.Va universe
-(+)
+.
+.It Ic universe Ar universe No (+)
 Sets the universe to
-.Va universe
+.Ar universe .
 (Masscomp/RTU only)
-.TP 8
-.B unlimit \fR[
-.Fl hf\fR] [
-.Va resource
-]
+.
+.It Ic unlimit Oo Fl hf Oc Op Ar resource
 Removes the limitation on
-.Va resource
+.Ar resource
 or, if no
-.Va resource
+.Ar resource
 is
 specified, all
-.Va resource
+.Ar resource
 limitations.
 With
-.Fl h\fR, the corresponding hard limits are removed.
+.Fl h ,
+the corresponding hard limits are removed.
 Only the super-user may do this.
 Note that
-.Va unlimit
+.Ic unlimit
 may not exit successful, since most systems
 do not allow
-.Va descriptors
+.Ic descriptors
 to be unlimited.
 With
-.Fl f\fR errors are ignored.
-.TP 8
-.B unset \fIpattern
+.Fl f
+errors are ignored.
+.
+.It Ic unset Ar pattern
 Removes all variables whose names match
-.Va pattern
-, unless they are read-only.
-`unset *' thus removes all variables unless they are read-only;
+.Ar pattern ,
+unless they are read-only.
+.Ql unset *
+thus removes all variables unless they are read-only;
 this is a bad idea.
 It is not an error for nothing to be
-.Va unset
-.TP 8
-.B unsetenv \fIpattern
+.Ic unset .
+.
+.It Ic unsetenv Ar pattern
 Removes all environment variables whose names match
-.Va pattern
-`unsetenv *' thus removes all environment variables;
+.Ar pattern .
+.Ql unsetenv *
+thus removes all environment variables;
 this is a bad idea.
 It is not an error for nothing to be
-.Va unsetenv
+.Ar unsetenv Ns
 ed.
-.TP 8
-.B ver \fR[
-.Va systype
-[
-.Va command
-]] (+)
+.
+.It Ic ver Oo Ar systype Oo Ar command Oc Oc No (+)
 Without arguments, prints
-.Va SYSTYPE
+.Ev SYSTYPE .
 With
-.Va systype
-, sets
-.Va SYSTYPE
+.Ar systype ,
+sets
+.Ev SYSTYPE
 to
-.Va systype
+.Ar systype .
 With
-.Va systype
+.Ar systype
 and
-.Va command
-, executes
-.Va command
+.Ar command ,
+executes
+.Ar command
 under
-.Va systype
-.Va systype
+.Ar systype .
+.Ar systype
 may be
-.Sq bsd4.3
+.Ql bsd4.3
 or
-.Sq sys5.3
+.Ql sys5.3 .
 (Domain/OS only)
-.TP 8
-.B wait
+.
+.It Ic wait
 The shell waits for all background jobs.
 If the shell is interactive, an
 interrupt will disrupt the wait and cause the shell to print the names and job
 numbers of all outstanding jobs.
-.TP 8
-.B warp
-.Va universe
-(+)
+.
+.It Ic warp Ar universe No (+)
 Sets the universe to
-.Va universe
+.Ar universe .
 (Convex/OS only)
-.TP 8
-.B watchlog \fR(+)
+.
+.It Ic watchlog No (+)
 An alternate name for the
-.Va log
+.Ic log
 builtin command (q.v.).
 Available only if the shell was so compiled;
 see the
-.Va version
+.Ic version
 shell variable.
-.TP 8
-.B where
-.Va command
-(+)
+.
+.It Ic where Ar command No (+)
 Reports all known instances of
-.Va command
-, including aliases, builtins and
+.Ar command ,
+including aliases, builtins and
 executables in
-.Va path
-.TP 8
-.B which\fR
-.Va command
-(+)
+.Ic path .
+.
+.It Ic which Ar command No (+)
 Displays the command that will be executed by the shell after substitutions,
-.Va path
+.Ic path
 searching, etc.
 The builtin command is just like
-.Va which
-(1), but it correctly reports
+.Xr which 1 ,
+but it correctly reports
 .Nm
 aliases and builtins and is 10 to 100 times faster.
 See also the
-.Va which-command
+.Ic which-command
 editor command.
+.
+.El
 .Pp
-.B while (\fIexpr
-.Va )
-.br
-\&...
-.PD 0
-.TP 8
-.B end
+.Bl -tag -width 8n -compact
+.Pp
+.
+.It Ic while Cm \&( Ns Ar expr Ns Cm \&)
+.It Ic \&...
+.It Ic end
 Executes the commands between the
-.Va while
+.Ic while
 and the matching
-.Va end
+.Ic end
 while
-.Va expr
+.Ar expr
 (an expression, as described under
-.Va Expressions
-)
+.Sx Expressions )
 evaluates non-zero.
-.Va while
+.Ic while
 and
-.Va end
+.Ic end
 must appear alone on their input lines.
-.Va break
+.Ic break
 and
-.Va continue
+.Ic continue
 may be used to terminate or continue the
 loop prematurely.
 If the input is a terminal, the user is prompted the first time
 through the loop as with
-.Va foreach
-.PD
+.Ic foreach .
+.El
+.
 .Ss "Special aliases (+)"
 If set, each of these aliases executes automatically at the indicated time.
 They are all initially undefined.
-.TP 8
-.B beepcmd
+.Pp
+.Bl -tag -width 8n
+.
+.It Ic beepcmd
 Runs when the shell wants to ring the terminal bell.
-.TP 8
-.B cwdcmd
+.
+.It Ic cwdcmd
 Runs after every change of working directory.
 For example, if the user is
 working on an X window system using
-.Va xterm
-(1) and a re-parenting window
+.Xr xterm 1
+and a re-parenting window
 manager that supports title bars such as
-.Va twm
-(1) and does
-.RS +8
-.IP "" 4
+.Xr twm 1
+and does
+.Bd -literal -offset indent
 > alias cwdcmd  'echo \-n "^[]2;${HOST}:$cwd ^G"'
+.Ed
 .Pp
 then the shell will change the title of the running
-.Va xterm
-(1)
+.Xr xterm 1
 to be the name of the host, a colon, and the full current working directory.
 A fancier way to do that is
-.IP "" 4
+.Bd -literal -offset indent
 > alias cwdcmd 'echo \-n "^[]2;${HOST}:$cwd^G^[]1;${HOST}^G"'
+.Ed
 .Pp
 This will put the hostname and working directory on the title bar but
 only the hostname in the icon manager menu.
 .Pp
 Note that putting a
-.Va cd
-,
-.Va pushd
+.Ic cd ,
+.Ic pushd ,
 or
-.Va popd
+.Ic popd
 in
-.Va cwdcmd
+.Ic cwdcmd
 may cause an infinite loop.
 It is the author's opinion that anyone doing
 so will get what they deserve.
-.RE
-.TP 8
-.B jobcmd
+.
+.It Ic jobcmd
 Runs before each command gets executed, or when the command changes state.
 This is similar to
-.Va postcmd
-, but it does not print builtins.
-.RS +8
-.IP "" 4
+.Ic postcmd ,
+but it does not print builtins.
+.Bd -literal -offset indent
 > alias jobcmd  'echo \-n "^[]2\e;\e!#:q^G"'
+.Ed
 .Pp
 then executing
-.Va vi foo.c
+.Ql vi foo.c
 will put the command string in the xterm title bar.
-.RE
-.TP 8
-.B helpcommand
+.
+.It Ic helpcommand
 Invoked by the
-.Va run-help
+.Ic run-help
 editor command.
 The command name for which help
 is sought is passed as sole argument.
 For example, if one does
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > alias helpcommand '\e!:1 --help'
+.Ed
 .Pp
 then the help display of the command itself will be invoked, using the GNU
 help calling convention.
 Currently there is no easy way to account for various calling conventions (e.g.,
 the customary Unix
-.Sq -h
-), except by using a table of many commands.
-.RE
-.TP 8
-.B periodic
+.Ql -h ) ,
+except by using a table of many commands.
+.
+.It Ic periodic
 Runs every
-.Va tperiod
+.Ic tperiod
 minutes.
 This provides a convenient means for
 checking on common but infrequent changes such as new mail.
 For example,
 if one does
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > set tperiod = 30
-.br
 > alias periodic checknews
+.Ed
 .Pp
 then the
-.Va checknews
-(1) program runs every 30 minutes.
+.Xr checknews 1
+program runs every 30 minutes.
 If
-.Va periodic
+.Ic periodic
 is set but
-.Va tperiod
+.Ic tperiod
 is unset or set to 0,
-.Va periodic
+.Ic periodic
 behaves like
-.Va precmd
-.RE
-.TP 8
-.B precmd
+.Ic precmd .
+.
+.It Ic precmd
 Runs just before each prompt is printed.
 For example, if one does
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > alias precmd date
+.Ed
 .Pp
 then
-.Va date
-(1) runs just before the shell prompts for each command.
+.Xr date 1
+runs just before the shell prompts for each command.
 There are no limits on what
-.Va precmd
+.Ic precmd
 can be set to do, but discretion
 should be used.
-.RE
-.TP 8
-.B postcmd
+.
+.It Ic postcmd
 Runs before each command gets executed.
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > alias postcmd  'echo \-n "^[]2\e;\e!#:q^G"'
+.Ed
 .Pp
 then executing
-.Va vi foo.c
+.Ql vi foo.c
 will put the command string in the xterm title bar.
-.RE
-.TP 8
-.B shell
+.
+.It Ic shell
 Specifies the interpreter for executable scripts which do not themselves
 specify an interpreter.
 The first word should be a full path name to the
 desired interpreter (e.g.,
-.Sq /bin/csh
+.Ql /bin/csh
 or
-.Sq /usr/local/bin/tcsh
-).
+.Ql /usr/local/bin/tcsh ) .
+.
+.El
+.
 .Ss "Special shell variables"
 The variables described in this section have special meaning to the shell.
 .Pp
 The shell sets
-.Va addsuffix ,
-.Va argv ,
-.Va autologout ,
-.Va csubstnonl ,
-.Va command ,
-.Va echo_style ,
-.Va edit ,
-.Va gid ,
-.Va group ,
-.Va home ,
-.Va loginsh ,
-.Va oid ,
-.Va path ,
-.Va prompt ,
-.Va prompt2 ,
-.Va prompt3 ,
-.Va shell ,
-.Va shlvl ,
-.Va tcsh ,
-.Va term ,
-.Va tty ,
-.Va uid ,
-.Va user
+.Ic addsuffix ,
+.Ic argv ,
+.Ic autologout ,
+.Ic csubstnonl ,
+.Ic command ,
+.Ic echo_style ,
+.Ic edit ,
+.Ic gid ,
+.Ic group ,
+.Ic home ,
+.Ic loginsh ,
+.Ic oid ,
+.Ic path ,
+.Ic prompt ,
+.Ic prompt2 ,
+.Ic prompt3 ,
+.Ic shell ,
+.Ic shlvl ,
+.Ic tcsh ,
+.Ic term ,
+.Ic tty ,
+.Ic uid ,
+.Ic user ,
 and
-.Va version
+.Ic version
 at
 startup; they do not change thereafter unless changed by the user.
 The shell updates
-.Va cwd ,
-.Va dirstack ,
-.Va owd
+.Ic cwd ,
+.Ic dirstack ,
+.Ic owd ,
 and
-.Va status
+.Ic status
 when necessary,
 and sets
-.Va logout
+.Ic logout
 on logout.
 .Pp
 The shell synchronizes
-.Va group ,
-.Va home ,
-.Va path ,
-.Va shlvl ,
-.Va term and
-.Va user
+.Ic group ,
+.Ic home ,
+.Ic path ,
+.Ic shlvl ,
+.Ic term ,
+and
+.Ic user
 with the environment variables of the same names:
 whenever the environment variable changes the shell changes the corresponding
 shell variable to match (unless the shell variable is read-only) and vice
 versa.
 Note that although
-.Va cwd
+.Ic cwd
 and
-.Va PWD
+.Ev PWD
 have identical meanings, they
 are not synchronized in this manner, and that the shell automatically
 converts between the different formats of
-.Va path
+.Ic path
 and
-.Va PATH
-.TP 8
-.B addsuffix \fR(+)
+.Ev PATH .
+.
+.Bl -tag -width 8n
+.
+.It Ic addsuffix No (+)
 If set, filename completion adds
-.Sq /
+.Ql /
 to the end of directories and a space
 to the end of normal files when they are matched exactly.
 Set by default.
-.TP 8
-.B afsuser \fR(+)
+.
+.It Ic afsuser No (+)
 If set,
-.Va autologout
-'s autolock feature uses its value instead of
+.Ic autologout Ns
+\&'s autolock feature uses its value instead of
 the local username for kerberos authentication.
-.TP 8
-.B ampm \fR(+)
+.
+.It Ic ampm No (+)
 If set, all times are shown in 12-hour AM/PM format.
-.TP 8
-.B anyerror \fR(+)
+.
+.It Ic anyerror No (+)
 This variable selects what is propagated to the value of the
-.Va status
+.Ic status
 variable. For more information see the description of the
-.Va status
+.Ic status
 variable below.
-.TP 8
-.B argv
+.
+.It Ic argv
 The arguments to the shell.
 Positional parameters are taken from
-.Va argv
-,
+.Ic argv ,
 i.e.,
-.Sq $1
+.Ql $1
 is replaced by
-.Sq $argv[1]
-, etc.
+.Ql $argv[1] ,
+etc.
 Set by default, but usually empty in interactive shells.
-.TP 8
-.B autocorrect \fR(+)
+.
+.It Ic autocorrect No (+)
 If set, the
-.Va spell-word
+.Ic spell-word
 editor command is invoked automatically before
 each completion attempt.
-.TP 8
-.B autoexpand \fR(+)
+.
+.It Ic autoexpand No (+)
 If set, the
-.Va expand-history
+.Ic expand-history
 editor command is invoked automatically
 before each completion attempt. If this is set to
-.Va onlyhistory
-, then
+.Ql onlyhistory ,
+then
 only history will be expanded and a second completion will expand filenames.
-.TP 8
-.B autolist \fR(+)
+.
+.It Ic autolist No (+)
 If set, possibilities are listed after an ambiguous completion.
 If set to
-.Sq ambiguous
-, possibilities are listed only when no new
+.Ql ambiguous ,
+possibilities are listed only when no new
 characters are added by completion.
-.TP 8
-.B autologout \fR(+)
+.
+.It Ic autologout No (+)
 The first word is the number of minutes of inactivity before automatic
 logout.
 The optional second word is the number of minutes of inactivity
 before automatic locking.
 When the shell automatically logs out, it prints
-.Sq auto-logout
-, sets the
+.Sq auto-logout ,
+sets the
 variable
-.Va logout
+.Ic logout
 to
-.Sq automatic
+.Ql automatic
 and exits.
-When the shell automatically locks, the user is required to enter his password
+When the shell automatically locks, the user is required to enter their password
 to continue working.
 Five incorrect attempts result in automatic logout.
 Set to
-.Sq 60
+.Ql 60
 (automatic logout after 60 minutes, and no locking) by default
 in login and superuser shells, but not if the shell thinks it is running
 under a window system (i.e., the
-.Va DISPLAY
+.Ev DISPLAY
 environment variable is set),
 the tty is a pseudo-tty (pty) or the shell was not so compiled (see the
-.Va version
+.Ic version
 shell variable).
 Unset
-.Va autologout or set it to 
-.Dv 0
+.Ic autologout
+or set it to
+.Ql 0
 to disable automatic logout.
 See also the
-.Va afsuser
+.Ic afsuser
 and
-.Va logout
+.Ic logout
 shell variables.
-.TP 8
-.B autorehash \fR(+)
+.
+.It Ic autorehash No (+)
 If set, the internal hash table of the contents of the directories in the
-.Va path
+.Ic path
 variable will be recomputed if a command is not found in the hash
 table.
 In addition, the list of available commands will be rebuilt for each
 command completion or spelling correction attempt if set to
-.Sq complete
+.Ql complete
 or
-`correct' respectively; if set to
-.Sq always
-, this will be done for both
+.Ql correct
+respectively; if set to
+.Ql always ,
+this will be done for both
 cases.
-.TP 8
-.B backslash_quote \fR(+)
+.
+.It Ic backslash_quote No (+)
 .\" TODO
 If set, backslashes (`\e') always quote
-.Sq \e
-,
-.Sq \&' ,
+.Ql \e ,
+.Ql \&' ,
 and
-.Sq \&"
+.Ql \&" .
 This may make
 complex quoting tasks easier, but it can cause syntax errors in
 .Xr csh 1
 scripts.
-.TP 8
-.B catalog
+.
+.It Ic catalog
 The file name of the message catalog.
-If set, tcsh use
+If set,
+.Nm
+uses
 .Sq tcsh.${catalog}
 as a message catalog instead of
 default
-.Sq tcsh
-.TP 8
-.B cdpath
+.Sq tcsh .
+.
+.It Ic cdpath
 A list of directories in which
-.Va cd
+.Ic cd
 should search for
 subdirectories if they aren't found in the current directory.
-.TP 8
-.B cdtohome \fR(+)
+.
+.It Ic cdtohome No (+)
 If not set,
-.Va cd
+.Ic cd
 requires a directory
-.Va name
-, and will not go to the
-.Va home
+.Ar name ,
+and will not go to the
+.Ic home
 directory if it's omitted.
 This is set by default.
-.TP 8
-.B color
-If set, it enables color display for the builtin \fBls\-F\fR and it passes
-.Fl \-color=auto\fR to
-.Va ls
+.
+.It Ic color
+If set, it enables color display for the builtin
+.Ic ls\-F
+and it passes
+.Fl \-color=auto
+to
+.Xr ls 1 .
 Alternatively, it can be set to only
-\fBls\-F\fR or only
-.Va ls
+.Ic ls\-F
+or only
+.Ic ls
 to enable color to only one command.
 Setting
-it to nothing is equivalent to setting it to \fB(ls\-F ls)\fR.
-.TP 8
-.B colorcat
+it to nothing is equivalent to setting it to
+.Ql (ls\-F ls) .
+.
+.It Ic colorcat
 If set, it enables color escape sequence for NLS message files.
 And display colorful NLS messages.
-.TP 8
-.B command \fR(+)
+.
+.It Ic command No (+)
 If set, the command which was passed to the shell with the
-.Va -c
+.Fl c
 flag (q.v.).
-.TP 8
-.B compat_expr \fR(+)
+.
+.It Ic compat_expr No (+)
 If set, the shell will evaluate expressions right to left, like the original
-.Xr csh 1
-.TP 8
-.B complete \fR(+)
+.Xr csh 1 .
+.
+.It Ic complete No (+)
 If set to
-.Sq igncase
-, the completion becomes case insensitive.
+.Ql igncase ,
+the completion becomes case insensitive.
 If set to
-.Sq enhance
-, completion ignores case and considers
+.Ql enhance ,
+completion ignores case and considers
 hyphens and underscores to be equivalent; it will also treat
-periods, hyphens and underscores (`.',
-.Sq \-
+periods, hyphens and underscores
+.Po
+.Ql \&. ,
+.Ql \- ,
 and
-.Sq _
-) as word
+.Ql _
+.Pc
+as word
 separators.
 If set to
-.Sq Enhance
-, completion matches uppercase and underscore
+.Ql Enhance ,
+completion matches uppercase and underscore
 characters explicitly and matches lowercase and hyphens in a
 case-insensitive manner; it will treat periods, hyphens and underscores
 as word separators.
-.TP 8
-.B continue \fR(+)
+.
+.It Ic continue No (+)
 If set to a list of commands, the shell will continue the listed
 commands, instead of starting a new one.
-.TP 8
-.B continue_args \fR(+)
+.
+.It Ic continue_args No (+)
 Same as continue, but the shell will execute:
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 echo \`pwd\` $argv > ~/.<cmd>_pause; %<cmd>
-.RE
-.TP 8
-.B correct \fR(+)
+.Ed
+.
+.It Ic correct No (+)
 If set to
-.Sq cmd
-, commands are automatically spelling-corrected.
+.Ql cmd ,
+commands are automatically spelling-corrected.
 If set to
-.Sq complete
-, commands are automatically completed.
+.Ql complete ,
+commands are automatically completed.
 If set to
-.Sq all
-, the entire command line is corrected.
-.TP 8
-.B csubstnonl \fR(+)
+.Ql all ,
+the entire command line is corrected.
+.
+.It Ic csubstnonl No (+)
 If set, newlines and carriage returns in command substitution are
 replaced by spaces.
 Set by default.
-.TP 8
-.B cwd
+.
+.It Ic cwd
 The full pathname of the current directory.
 See also the
-.Va dirstack
+.Ic dirstack
 and
-.Va owd
+.Ic owd
 shell variables.
-.TP 8
-.B dextract \fR(+)
+.
+.It Ic dextract No (+)
 If set,
-.Sq pushd +
-.Va n
+.Ql pushd + Ns Ar n
 extracts the
-.Va n
+.Ar n Ns
 th directory from the directory
 stack rather than rotating it to the top.
-.TP 8
-.B dirsfile \fR(+)
+.
+.It Ic dirsfile No (+)
 The default location in which
-.Sq dirs \-S
+.Ql dirs \-S
 and
-.Sq dirs \-L
+.Ql dirs \-L
 look for
 a history file.
 If unset,
-.Va ~/.cshdirs
+.Pa ~/.cshdirs
 is used.
 Because only
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 is normally sourced before
-.Va ~/.cshdirs
-,
-.Va dirsfile
+.Pa ~/.cshdirs ,
+.Ic dirsfile
 should be set in
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 rather than
-.Va ~/.login
-.TP 8
-.B dirstack \fR(+)
+.Pa ~/.login .
+.
+.It Ic dirstack No (+)
 An array of all the directories on the directory stack.
-`$dirstack[1]' is the current working directory,
+.Sq $dirstack[1]
+is the current working directory,
 .Sq $dirstack[2]
 the first directory on the stack, etc.
 Note that the current working directory is
 .Sq $dirstack[1]
 but
-.Sq =0
+.Ql =0
 in
 directory stack substitutions, etc.
 One can change the stack arbitrarily by setting
-.Va dirstack
-,
+.Ic dirstack ,
 but the first element (the current working directory) is always correct.
 See also the
-.Va cwd
+.Ic cwd
 and
-.Va owd
+.Ic owd
 shell variables.
-.TP 8
-.B dspmbyte \fR(+)
-Has an effect iff 'dspm' is listed as part of the
-.Va version
+.
+.It Ic dspmbyte No (+)
+Has an effect iff
+.Ql dspm
+is listed as part of the
+.Ic version
 shell variable.
 If set to
-.Sq euc
-, it enables display and editing EUC-kanji(Japanese) code.
+.Ql euc ,
+it enables display and editing EUC-kanji(Japanese) code.
 If set to
-.Sq sjis
-, it enables display and editing Shift-JIS(Japanese) code.
+.Ql sjis ,
+it enables display and editing Shift-JIS(Japanese) code.
 If set to
-.Sq big5
-, it enables display and editing Big5(Chinese) code.
+.Ql big5 ,
+it enables display and editing Big5(Chinese) code.
 If set to
-.Sq utf8
-, it enables display and editing Utf8(Unicode) code.
+.Ql utf8 ,
+it enables display and editing Utf8(Unicode) code.
 If set to the following format, it enables display and editing of original
 multi-byte code format:
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 > set dspmbyte = 0000....(256 bytes)....0000
+.Ed
 .Pp
 The table requires
-.Va just
+.Em just
 256 bytes.
 Each character of 256 characters
 corresponds (from left to right) to the ASCII codes 0x00, 0x01, ... 0xff.
@@ -7126,65 +7323,73 @@ character
 .\" (position in this table?)
 is set to number 0,1,2 and 3.
 Each number has the following meaning:
-.br
-0 ... not used for multi-byte characters.
-.br
-1 ... used for the first byte of a multi-byte character.
-.br
-2 ... used for the second byte of a multi-byte character.
-.br
-3 ... used for both the first byte and second byte of a multi-byte character.
+.Bl -tag -width 3n -offset indent -compact
+.It Li 0
+Not used for multi-byte characters.
+.It Li 1
+Used for the first byte of a multi-byte character.
+.It Li 2
+Used for the second byte of a multi-byte character.
+.It Li 3
+Used for both the first byte and second byte of a multi-byte character.
+.El
 .\" SHK: I tried my best to get the following to be grammatically correct.
-.\" However, I still don't understand what's going on here.
-In the
+.\" However, I still don't understand what's going on here.  In the
 .\" following example, there are three bytes, but the text seems to refer to
-.\" each nybble as a character.
-What's going on here?  It this 3-byte code
+.\" each nybble as a character.  What's going on here?  It this 3-byte code
 .\" in the table?  The text above seems to imply that there are 256
-.\" characters/bytes in the table.
-If I get some more info on this (perhaps
+.\" characters/bytes in the table.  If I get some more info on this (perhaps
 .\" a complete example), I could fix the text to be grammatically correct.
 .\" (steve.kelem@xilinx.com 1999/09/13)
 .Pp
 Example:
-.br
+.Pp
 If set to
-.Sq 001322
-, the first character (means 0x00 of the ASCII code) and
+.Ql 001322 ,
+the first character (means 0x00 of the ASCII code) and
 second character (means 0x01 of ASCII code) are set to
-.Sq 0
+.Ql 0 .
 Then, it is not
 used for multi-byte characters.
-The 3rd character (0x02) is set to '1',
+The 3rd character (0x02) is set to
+.Ql 1 ,
 indicating that it is used for the first byte of a multi-byte character.
-The 4th character(0x03) is set '3'.
+The 4th character (0x03) is set
+.Ql 3 .
 It is used for both the first byte and
 the second byte of a multi-byte character.
 The 5th and 6th characters
-(0x04,0x05) are set to '2', indicating that they are used for the second
+(0x04,0x05) are set to
+.Ql 2 ,
+indicating that they are used for the second
 byte of a multi-byte character.
 .Pp
 The GNU fileutils version of ls cannot display multi-byte
-filenames without the -N ( --literal ) option.
+filenames without the
+.Fl N
+.Pq Fl -literal
+option.
 If you are using
-this version, set the second word of dspmbyte to "ls".
+this version, set the second word of dspmbyte to
+.Ql ls .
 If not, for
-example, "ls-F -l" cannot display multi-byte filenames.
+example,
+.Ql ls-F -l
+cannot display multi-byte filenames.
 .Pp
 Note:
-.br
+.Pp
 This variable can only be used if KANJI and DSPMBYTE has been defined at
 compile time.
-.RE
-.TP 8
-.B dunique \fR(+)
+.
+.It Ic dunique No (+)
 If set,
-.Va pushd
+.Ic pushd
 removes any instances of
-.Va name
+.Ar name
 from the stack before pushing it onto the stack.
-.TP 8
-.B echo
+.
+.It Ic echo
 If set, each command with its arguments is echoed just before it is
 executed.
 For non-builtin commands all expansions occur before
@@ -7192,274 +7397,283 @@ echoing.
 Builtin commands are echoed before command and filename
 substitution, because these substitutions are then done selectively.
 Set by the
-.Fl x\fR command line option.
-.TP 8
-.B echo_style \fR(+)
+.Fl x
+command line option.
+.
+.It Ic echo_style No (+)
 The style of the
-.Va echo
+.Ic echo
 builtin.
 May be set to
 .Pp
-.RS +8
-.PD 0
-.TP 8
-bsd
+.Bl -tag -width 4n -offset indent -compact
+.It Li bsd
 Don't echo a newline if the first argument is
-.Sq \-n ;
+.Fl n ;
 the default for
-.Xr csh 1
-.TP 8
-sysv
+.Xr csh 1 .
+.
+.It Li sysv
 Recognize backslashed escape sequences in echo strings.
-.TP 8
-both
+.
+.It Li both
 Recognize both the
-.Sq \-n
+.Fl n
 flag and backslashed escape sequences; the default
 for
-.Nm
-.TP 8
-none
+.Nm .
+.
+.It Li none
 Recognize neither.
-.PD
+.El
 .Pp
 Set by default to the local system default.
 The BSD and System V
 options are described in the
-.Va echo
-(1) man pages on the appropriate
+.Xr echo 1
+man pages on the appropriate
 systems.
-.RE
-.TP 8
-.B edit \fR(+)
+.
+.It Ic edit No (+)
 If set, the command-line editor is used.
 Set by default in interactive
 shells.
-.TP 8
-.B editors \fR(+)
+.
+.It Ic editors No (+)
 A list of command names for the
-.Va run-fg-editor
+.Ic run-fg-editor
 editor command to match.
 If not set, the
-.Va EDITOR
-(`ed' if unset) and
-.Va VISUAL
-(`vi' if unset)
+.Ev EDITOR
+.Ql ( ed
+if unset) and
+.Ev VISUAL
+.Ql ( vi
+if unset)
 environment variables will be used instead.
-.TP 8
-.B ellipsis \fR(+)
+.
+.It Ic ellipsis No (+)
 If set, the
-.Sq %c
-/`%.' and
-.Sq %C
+.Ql %c ,
+.Ql %. ,
+and
+.Ql \&%C
 prompt sequences (see the
-.Va prompt
-shell variable) indicate skipped directories with an ellipsis (`...')
+.Ic prompt
+shell variable) indicate skipped directories with an ellipsis
+.Pq Ql \&...
 instead of
-.Sq /<skipped>
-.TP 8
-.B euid \fR(+)
+.Ql /< Ns Ar skipped Ns Li > .
+.
+.It Ic euid No (+)
 The user's effective user ID.
-.TP 8
-.B euser \fR(+)
+.
+.It Ic euser No (+)
 The first matching passwd entry name corresponding to the effective user ID.
-.TP 8
-.B fignore \fR(+)
+.
+.It Ic fignore No (+)
 Lists file name suffixes to be ignored by completion.
-.TP 8
-.B filec
+.
+.It Ic filec
 In
-.Nm
-, completion is always used and this variable is ignored
+.Nm ,
+completion is always used and this variable is ignored
 by default. If
-.B edit
+.Ic edit
 is unset, then the traditional
 .Xr csh 1
 completion is used.
 If set in
-.Xr csh 1
-, filename completion is used.
-.TP 8
-.B gid \fR(+)
+.Xr csh 1 ,
+filename completion is used.
+.
+.It Ic gid No (+)
 The user's real group ID.
-.TP 8
-.B globdot \fR(+)
+.
+.It Ic globdot No (+)
 If set, wild-card glob patterns will match files and directories beginning
 with
-.Sq .
+.Ql \&.
 except for
-.Sq .
+.Sq Pa \&.
 and
-.Sq ..
-.TP 8
-.B globstar \fR(+)
+.Sq Pa \&.. .
+.
+.It Ic globstar No (+)
 If set, the
-.Sq **
+.Ql **
 and
-.Sq ***
+.Ql ***
 file glob patterns will match any string of
 characters including
-.Sq /
+.Ql /
 traversing any existing sub-directories.
 (e.g.
-`ls **.c' will list all the .c files in the current directory tree).
+.Ql ls **.c
+will list all the .c files in the current directory tree).
 If used by itself, it will match zero or more sub-directories
 (e.g.
-.Sq ls /usr/include/**/time.h
+.Ql ls /usr/include/**/time.h
 will list any file named
-.Sq time.h
-in the /usr/include directory tree; whereas
-.Sq ls /usr/include/**time.h
-will match any file in the /usr/include directory tree ending in
-.Sq time.h
-).
+.Ql time.h
+in the
+.Pa /usr/include
+directory tree; whereas
+.Ql ls /usr/include/**time.h
+will match any file in the
+.Pa /usr/include
+directory tree ending in
+.Ql time.h ) .
 To prevent problems with recursion, the
-.Sq **
+.Ql **
 glob-pattern will not
 descend into a symbolic link containing a directory.
 To override this,
 use
-.Sq ***
-.TP 8
-.B group \fR(+)
+.Ql *** .
+.
+.It Ic group No (+)
 The user's group name.
-.TP 8
-.B highlight
+.
+.It Ic highlight
 If set, the incremental search match (in
-.Va i-search-back
+.Ic i-search-back
 and
-.Va i-search-fwd
-) and the region between the mark and the cursor are
+.Ic i-search-fwd )
+and the region between the mark and the cursor are
 highlighted in reverse video.
-.IP "" 8
+.Pp
 Highlighting requires more frequent terminal writes, which introduces extra
 overhead. If you care about terminal performance, you may want to leave this
 unset.
-.TP 8
-.B histchars
-A string value determining the characters used in \fBHistory
-substitution\fR (q.v.).
+.
+.It Ic histchars
+A string value determining the characters used in
+.Sx History substitution
+(q.v.).
 The first character of its value is used as
 the history substitution character, replacing the default character
-`!'.
+.Ql \&! .
 The second character of its value replaces the character
-.Sq ^
+.Ql ^
 in
 quick substitutions.
-.TP 8
-.B histdup \fR(+)
+.
+.It Ic histdup No (+)
 Controls handling of duplicate entries in the history list.
 If set to
-`all' only unique history events are entered in the history list.
+.Ql all
+only unique history events are entered in the history list.
 If
 set to
-.Sq prev
+.Ql prev
 and the last history event is the same as the current
 command, then the current command is not entered in the history.
 If
 set to
-.Sq erase
+.Ql erase
 and the same event is found in the history list, that
 old event gets erased and the current one gets inserted.
 Note that the
-`prev' and
-.Sq all
-options renumber history events so there are no gaps.
-.TP 8
-.B histfile \fR(+)
-The default location in which
-.Sq history \-S
+.Ql prev
 and
-.Sq history \-L
+.Ql all
+options renumber history events so there are no gaps.
+.
+.It Ic histfile No (+)
+The default location in which
+.Ql history \-S
+and
+.Ql history \-L
 look for
 a history file.
 If unset,
-.Va ~/.history
+.Pa ~/.history
 is used.
-.Va histfile
+.Ic histfile
 is
 useful when sharing the same home directory between different machines,
 or when saving separate histories on different terminals.
 Because only
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 is normally sourced before
-.Va ~/.history
-,
-.Va histfile
+.Pa ~/.history ,
+.Ic histfile
 should be set in
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 rather than
-.Va ~/.login
-.TP 8
-.B histlit \fR(+)
+.Pa ~/.login .
+.
+.It Ic histlit No (+)
 If set, builtin and editor commands and the
-.Va savehist
+.Ic savehist
 mechanism
 use the literal (unexpanded) form of lines in the history list.
 See
 also the
-.Va toggle-literal-history
+.Ic toggle-literal-history
 editor command.
-.TP 8
-.B history
+.
+.It Ic history
 The first word indicates the number of history events to save.
 The
 optional second word (+) indicates the format in which history is
 printed; if not given,
-.Sq %h\et%T\et%R\en
+.Ql %h\et%T\et%R\en
 is used.
 The format sequences
 are described below under
-.Va prompt
-; note the variable meaning of
-`%R'.
+.Ic prompt ;
+note the variable meaning of
+.Ql \&%R .
 Set to
-.Sq 100
+.Ql 100
 by default.
-.TP 8
-.B home
+.
+.It Ic home
 Initialized to the home directory of the invoker.
 The filename
 expansion of
-.Sq
-.Va ~
+.Ql ~
 refers to this variable.
-.TP 8
-.B ignoreeof
+.
+.It Ic ignoreeof
 If set to the empty string or
-.Sq 0
+.Ql 0
 and the input device is a terminal,
 the
-.Va end-of-file
+.Ic end-of-file
 command (usually generated by the user by typing
-`^D' on an empty line) causes the shell to print `Use "exit" to leave
-tcsh.' instead of exiting.
+.Sq ^D
+on an empty line) causes the shell to print
+.Ql Use \&"exit\&" to leave tcsh.
+instead of exiting.
 This prevents the shell from accidentally
 being killed.
 Historically this setting exited after 26 successive
 EOF's to avoid infinite loops.
 If set to a number
-.Va n
-, the shell
+.Sq Em n ,
+the shell
 ignores
-.Va n - 1
+.Em n
+\- 1
 consecutive
-.Va end-of-file
+.Ic end-of-file Ns
 s and exits on the
-.Va n
+.Em n Ns
 th.
 (+) If unset,
-.Sq 1
+.Ql 1
 is used, i.e., the shell exits on a
 single
-.Sq ^D
-.TP 8
-.B implicitcd \fR(+)
+.Sq ^D .
+.
+.It Ic implicitcd No (+)
 If set, the shell treats a directory name typed as a command as though
 it were a request to change to that directory.
 If set to
-.Va verbose
-,
+.Ic verbose ,
 the change of directory is echoed to the standard output.
 This behavior
 is inhibited in non-interactive shell scripts, or for command strings
@@ -7468,151 +7682,146 @@ Changing directory takes precedence over
 executing a like-named command, but it is done after alias
 substitutions.
 Tilde and variable expansions work as expected.
-.TP 8
-.B inputmode \fR(+)
+.
+.It Ic inputmode No (+)
 If set to
-.Sq insert
+.Ql insert
 or
-.Sq overwrite
-, puts the editor into that input mode
+.Ql overwrite ,
+puts the editor into that input mode
 at the beginning of each line.
-.TP 8
-.B killdup \fR(+)
+.
+.It Ic killdup No (+)
 Controls handling of duplicate entries in the kill ring.
 If set to
-`all' only unique strings are entered in the kill ring.
+.Ql all
+only unique strings are entered in the kill ring.
 If set to
-`prev' and the last killed string is the same as the current killed
+.Ql prev
+and the last killed string is the same as the current killed
 string, then the current string is not entered in the ring.
 If set
 to
-.Sq erase
+.Ql erase
 and the same string is found in the kill ring, the old
 string is erased and the current one is inserted.
-.TP 8
-.B killring \fR(+)
+.
+.It Ic killring No (+)
 Indicates the number of killed strings to keep in memory.
 Set to
-.Sq 30
+.Ql 30
 by default.
 If unset or set to less than
-.Sq 2
-, the shell will only
+.Ql 2 ,
+the shell will only
 keep the most recently killed string.
 Strings are put in the killring by the editor commands that delete
 (kill) strings of text, e.g.
-.Va backward-delete-word
-,
-.Va kill-line
-, etc, as well as the
-.Va copy-region-as-kill
+.Ic backward-delete-word ,
+.Ic kill-line ,
+etc, as well as the
+.Ic copy-region-as-kill
 command.
 The
-.Va yank
+.Ic yank
 editor command will yank the most recently killed string
 into the command-line, while
-.Va yank-pop
+.Ic yank-pop
 (see
-.Va Editor commands
-)
+.Sx Editor commands )
 can be used to yank earlier killed strings.
-.TP 8
-.B listflags \fR(+)
+.
+.It Ic listflags No (+)
 If set to
-.Sq x
-,
-.Sq a
+.Ql x ,
+.Ql a ,
 or
-.Sq A
-, or any combination thereof (e.g.,
-.Sq xA
-), they
-are used as flags to \fIls\-F\fR, making it act like
-.Sq ls \-xF
-, `ls
-\-Fa',
-.Sq ls \-FA
+.Ql A ,
+or any combination thereof (e.g.,
+.Ql xA ) ,
+they are used as flags to
+.Ic ls\-F ,
+making it act like
+.Ql ls \-xF ,
+.Ql ls \-Fa ,
+.Ql ls \-FA ,
 or a combination (e.g.,
-.Sq ls \-FxA
-):
-.Sq a
+.Ql ls \-FxA ) :
+.Ql a
 shows all
 files (even if they start with a
-.Sq .
-),
-.Sq A
+.Ql \&. ) ,
+.Ql A
 shows all files but
-.Sq .
+.Ql \&.
 and
-`..', and
-.Sq x
+.Ql \&.. ,
+and
+.Ql x
 sorts across instead of down.
 If the second word of
-.Va listflags
+.Ic listflags
 is set, it is used as the path to
-.Sq ls(1)
-.TP 8
-.B listjobs \fR(+)
+.Xr ls 1 .
+.
+.It Ic listjobs No (+)
 If set, all jobs are listed when a job is suspended.
 If set to
-.Sq long
-,
+.Ql long ,
 the listing is in long format.
-.TP 8
-.B listlinks \fR(+)
-If set, the \fIls\-F\fR builtin command shows the type of file to which
+.
+.It Ic listlinks No (+)
+If set, the
+.Ic ls\-F
+builtin command shows the type of file to which
 each symbolic link points.
-.TP 8
-.B listmax \fR(+)
+.
+.It Ic listmax No (+)
 The maximum number of items which the
-.Va list-choices
+.Ic list-choices
 editor command
 will list without asking first.
-.TP 8
-.B listmaxrows \fR(+)
+.
+.It Ic listmaxrows No (+)
 The maximum number of rows of items which the
-.Va list-choices
+.Ic list-choices
 editor
 command will list without asking first.
-.TP 8
-.B loginsh \fR(+)
+.
+.It Ic loginsh No (+)
 Set by the shell if it is a login shell.
 Setting or unsetting it
 within a shell has no effect.
 See also
-.Va shlvl
-.TP 8
-.B logout \fR(+)
+.Ic shlvl .
+.
+.It Ic logout No (+)
 Set by the shell to
-.Sq normal
+.Ql normal
 before a normal logout,
-.Sq automatic
+.Ql automatic
 before
 an automatic logout, and
-.Sq hangup
+.Ql hangup
 if the shell was killed by a hangup
 signal (see
-.Va Signal handling
-).
+.Sx Signal handling ) .
 See also the
-.Va autologout
+.Ic autologout
 shell variable.
-.TP 8
-.B mail
+.
+.It Ic mail
 A list of files and directories to check for incoming mail, optionally
 preceded by a numeric word.
 Before each prompt, if 10 minutes have
-passed since the last check, the shell checks each file and says `You
-have new mail.' (or, if
-.Va mail
-contains multiple files, `You have
-new mail in
-.Va name
-.') if the filesize is greater than zero in size
+passed since the last check, the shell checks each file and says
+.Sq You have new mail.
+(or, if
+.Ic mail
+contains multiple files,
+.Sq You have new mail in Ar name Ns \&. )
+if the filesize is greater than zero in size
 and has a modification time greater than its access time.
-.Pp
-.RS +8
-.PD
 .Pp
 If you are in a login shell, then no mail file is reported unless it has
 been modified after the time the shell has started up, to prevent
@@ -7621,21 +7830,18 @@ Most login programs will tell you whether or not
 you have mail when you log in.
 .Pp
 If a file specified in
-.Va mail
+.Ic mail
 is a directory, the shell will count each
-file within that directory as a separate message, and will report `You have
-.Va n
-mails.' or
-.Sq You have
-.Va n
-mails in
-.Va name
+file within that directory as a separate message, and will report
+.Sq You have Ar n No mails.
+or
+.Sq You have Ar n No mails in Ar name Ns No \&.
 as appropriate.
 This functionality is provided primarily for those systems which store mail
 in this manner, such as the Andrew Mail System.
 .Pp
 If the first word of
-.Va mail
+.Ic mail
 is numeric it is taken as a different mail
 checking interval, in seconds.
 .Pp
@@ -7644,407 +7850,402 @@ Under very rare circumstances, the shell may report
 instead
 of
 .Sq You have new mail.
-.RE
-.TP 8
-.B matchbeep \fR(+)
+.
+.It Ic matchbeep No (+)
 If set to
-.Sq never
-, completion never beeps.
+.Ql never ,
+completion never beeps.
 If set to
-.Sq nomatch
-, it beeps only when there is no match.
+.Ql nomatch ,
+it beeps only when there is no match.
 If set to
-.Sq ambiguous
-, it beeps when there are multiple matches.
+.Ql ambiguous ,
+it beeps when there are multiple matches.
 If set to
-.Sq notunique
-, it beeps when there is one exact and other longer matches.
+.Ql notunique ,
+it beeps when there is one exact and other longer matches.
 If unset,
-.Sq ambiguous
+.Ql ambiguous
 is used.
-.TP 8
-.B nobeep \fR(+)
+.
+.It Ic nobeep No (+)
 If set, beeping is completely disabled.
 See also
-.Va visiblebell
-.TP 8
-.B noclobber
+.Ic visiblebell .
+.
+.It Ic noclobber
 If set, restrictions are placed on output redirection to insure that files
 are not accidentally destroyed and that
-.Sq >>
+.Ql >>
 redirections refer to existing
 files, as described in the
-.Va Input/output
+.Sx Input/output
 section.
-.TP 8
-.B noding
+.
+.It Ic noding
 If set, disable the printing of
-.Sq DING!
+.Ql DING!
 in the
-.Va prompt
+.Ic prompt
 time
 specifiers at the change of hour.
-.TP 8
-.B noglob
+.
+.It Ic noglob
 If set,
-.Va Filename substitution
+.Sx Filename substitution
 and
-.Va Directory stack substitution
+.Sx Directory stack substitution
 (q.v.) are inhibited.
 This is most useful in shell scripts which do not deal
 with filenames, or after a list of filenames has been obtained and further
 expansions are not desirable.
-.TP 8
-.B nokanji \fR(+)
+.
+.It Ic nokanji No (+)
 If set and the shell supports Kanji (see the
-.Va version
+.Ic version
 shell variable),
 it is disabled so that the meta key can be used.
-.TP 8
-.B nonomatch
+.
+.It Ic nonomatch
 If set, a
-.Va Filename substitution
+.Sx Filename substitution
 or
-.Va Directory stack substitution
+.Sx Directory stack substitution
 (q.v.) which does not match any
 existing files is left untouched rather than causing an error.
 It is still an error for the substitution to be
 malformed, e.g.,
-.Sq echo [
+.Ql echo [
 still gives an error.
-.TP 8
-.B nostat \fR(+)
+.
+.It Ic nostat No (+)
 A list of directories (or glob-patterns which match directories; see
-.Va Filename substitution
-) that should not be
-.Va stat
-(2)ed during a
+.Sx Filename substitution )
+that should not be
+.Xr stat 2 Ns ed
+during a
 completion operation.
 This is usually used to exclude directories which
 take too much time to
-.Va stat
-(2), for example
-.Va /afs
-.TP 8
-.B notify
+.Xr stat 2 ,
+for example
+.Pa /afs .
+.
+.It Ic notify
 If set, the shell announces job completions asynchronously.
 The default is to present job completions just before printing a prompt.
-.TP 8
-.B oid \fR(+)
+.
+.It Ic oid No (+)
 The user's real organization ID.
 (Domain/OS only)
-.TP 8
-.B owd \fR(+)
+.
+.It Ic owd No (+)
 The old working directory, equivalent to the
-.Sq \-
+.Ql \-
 used by
-.Va cd
+.Ic cd
 and
-.Va pushd
+.Ic pushd .
 See also the
-.Va cwd
+.Ic cwd
 and
-.Va dirstack
+.Ic dirstack
 shell variables.
-.TP 8
-.B padhour
+.
+.It Ic padhour
 If set, enable the printing of padding '0' for hours, in 24 and 12 hour
 formats.
-E.G.: 07:45:42 vs. 7:45:42.
-.TP 8
-.B parseoctal
+E.g.,
+.Sq 07:45:42
+versus
+.Sq 7:45:42 .
+.
+.It Ic parseoctal
 To retain compatibily with older versions numeric variables starting with
 0 are not interpreted as octal. Setting this variable enables proper octal
 parsing.
-.TP 8
-.B path
+.
+.It Ic path
 A list of directories in which to look for executable commands.
 A null word specifies the current directory.
 If there is no
-.Va path
+.Ic path
 variable then only full path names will execute.
-.Va path
+.Ic path
 is set by the shell at startup from the
-.Va PATH
+.Ev PATH
 environment
 variable or, if
-.Va PATH
+.Ev PATH
 does not exist, to a system-dependent default
 something like
-.Sq (/usr/local/bin /usr/bsd /bin /usr/bin .)
+.Ql (/usr/local/bin /usr/bsd /bin /usr/bin .) .
 The shell may put
-.Sq .
+.Ql \&.
 first or last in
-.Va path
+.Ic path
 or omit it entirely
 depending on how it was compiled; see the
-.Va version
+.Ic version
 shell variable.
 A shell which is given neither the
-.Fl c\fR nor the
-.Fl t\fR option
+.Fl c
+nor the
+.Fl t
+option
 hashes the contents of the directories in
-.Va path
+.Ic path
 after
 reading
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 and each time
-.Va path
+.Ic path
 is reset.
 If one adds a new command to a directory in
-.Va path
+.Ic path
 while the shell
 is active, one may need to do a
-.Va rehash
+.Ic rehash
 for the shell to find it.
-.TP 8
-.B printexitvalue \fR(+)
+.
+.It Ic printexitvalue No (+)
 If set and an interactive program exits with a non-zero status, the shell
 prints
-.Sq Exit
-.Va status
-.TP 8
-.B prompt
+.Sq Exit Ar status .
+.
+.It Ic prompt
 The string which is printed before reading each command from the terminal.
-.Va prompt
+.Ic prompt
 may include any of the following formatting sequences (+), which
 are replaced by the given information:
 .Pp
-.RS +8
-.PD 0
-.TP 4
-%/
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li %/
 The current working directory.
-.TP 4
-%~
+.
+.It Li %~
 The current working directory, but with one's home directory
 represented by
-.Sq ~
+.Ql ~
 and other users' home directories represented by
-`~user' as per
-.Va Filename substitution
-`~user' substitution
+.Ql ~ Ns Ar user
+as per
+.Sx Filename substitution .
+.Ql ~ Ns Ar user
+substitution
 happens only if the shell has already used
-.Sq ~
-.Va user
+.Ql ~ Ns Ar user
 in a pathname
 in the current session.
-.TP 4
-%c[[0]
-.Va n
-], %.[[0]
-.Va n
-]
+.
+.It Xo
+.Li %c[[0] Ns Ar n Ns Li ] ,
+.Li %.[[0] Ns Ar n Ns Li ]
+.Xc
 The trailing component of the current working directory, or
-.Va n
+.Ar n
 trailing components if a digit
-.Va n
+.Ar n
 is given.
 If
-.Va n
+.Ar n
 begins with
-.Sq 0
-, the number of skipped components precede
+.Ql 0 ,
+the number of skipped components precede
 the trailing component(s) in the format
-.Sq /<
-.Va skipped
->trailing
+.Ql /< Ns Ar skipped Ns Li >trailing .
 If the
-.Va ellipsis
+.Ic ellipsis
 shell variable is set, skipped components
 are represented by an ellipsis so the whole becomes
-.Sq ...trailing
-`~' substitution is done as in
-.Sq %~
+.Ql \&...trailing .
+.Ql ~
+substitution is done as in
+.Ql %~
 above, but the
-.Sq ~
+.Ql ~
 component
 is ignored when counting trailing components.
-.TP 4
-%C
-Like %c, but without
-.Sq ~
-substitution.
-.TP 4
-%h, %!, !
-The current history event number.
-.TP 4
-%M
-The full hostname.
-.TP 4
-%m
-The hostname up to the first
-.Sq .
-.TP 4
-%S (%s)
-Start (stop) standout mode.
-.TP 4
-%B (%b)
-Start (stop) boldfacing mode.
-.TP 4
-%U (%u)
-Start (stop) underline mode.
-.TP 4
-%t, %@
-The time of day in 12-hour AM/PM format.
-.TP 4
-%T
+.
+.It Li \&%C
 Like
-.Sq %t
-, but in 24-hour format (but see the
-.Va ampm
+.Ql %c ,
+but without
+.Ql ~
+substitution.
+.
+.It Li %h , %! , \&!
+The current history event number.
+.
+.It Li \&%M
+The full hostname.
+.
+.It Li %m
+The hostname up to the first
+.Ql \&. .
+.
+.It Li \&%S Pq Li %s
+Start (stop) standout mode.
+.
+.It Li \&%B Pq Li %b
+Start (stop) boldfacing mode.
+.
+.It Li \&%U (%u)
+Start (stop) underline mode.
+.
+.It Li %t , %@
+The time of day in 12-hour AM/PM format.
+.
+.It Li \&%T
+Like
+.Ql %t ,
+but in 24-hour format (but see the
+.Ic ampm
 shell variable).
-.TP 4
-%p
+.
+.It Li %p
 The
 .Sq precise
 time of day in 12-hour AM/PM format, with seconds.
-.TP 4
-%P
+.
+.It Li \&%P
 Like
-.Sq %p
-, but in 24-hour format (but see the
-.Va ampm
+.Ql %p ,
+but in 24-hour format (but see the
+.Ic ampm
 shell variable).
-.TP 4
-\e
-.Va c
-.Va c
+.
+.It Li \e Ns Ar c
+.Ar c
 is parsed as in
-.Va bindkey
-.TP 4
-^
-.Va c
-.Va c
+.Ic bindkey .
+.
+.It Li ^ Ns Ar c
+.Ar c
 is parsed as in
-.Va bindkey
-.TP 4
-%%
+.Ic bindkey .
+.
+.It Li %%
 A single
-.Sq %
-.TP 4
-%n
+.Ql % .
+.
+.It Li %n
 The user name.
-.TP 4
-%N
+.
+.It Li \&%N
 The effective user name.
-.TP 4
-%j
+.
+.It Li %j
 The number of jobs.
-.TP 4
-%d
+.
+.It Li %d
 The weekday in
 .Sq Day
 format.
-.TP 4
-%D
+.
+.It Li \&%D
 The day in
 .Sq dd
 format.
-.TP 4
-%w
+.
+.It Li %w
 The month in
 .Sq Mon
 format.
-.TP 4
-%W
+.
+.It Li \&%W
 The month in
 .Sq mm
 format.
-.TP 4
-%y
+.
+.It Li %y
 The year in
 .Sq yy
 format.
-.TP 4
-%Y
+.
+.It Li \&%Y
 The year in
 .Sq yyyy
 format.
-.TP 4
-%l
+.
+.It Li %l
 The shell's tty.
-.TP 4
-%L
+.
+.It Li \&%L
 Clears from the end of the prompt to end of the display or the end of the line.
-.TP 4
-%$
+.
+.It Li %$
 Expands the shell or environment variable name immediately after the
-.Sq $
-.TP 4
-%#
-`>' (or the first character of the
-.Va promptchars
+.Ql $ .
+.
+.It Li %#
+.Ql >
+(or the first character of the
+.Ic promptchars
 shell variable)
 for normal users,
-.Sq #
+.Ql #
 (or the second character of
-.Va promptchars
-)
+.Ic promptchars )
 for the superuser.
-.TP 4
-%{
-.Va string
-%}
+.
+.It Li %{ Ns Ar string Ns Li %}
 Includes
-.Va string
+.Ic string
 as a literal escape sequence.
 It should be used only to change terminal attributes and
 should not move the cursor location.
 This
 cannot be the last sequence in
-.Va prompt
-.TP 4
-%?
+.Ic prompt .
+.
+.It Li %?
 The return code of the command executed just before the prompt.
-.TP 4
-%R
+.
+.It Li \&%R
 In
-.Va prompt2
-, the status of the parser.
+.Ic prompt2 ,
+the status of the parser.
 In
-.Va prompt3
-, the corrected string.
+.Ic prompt3 ,
+the corrected string.
 In
-.Va history
-, the history string.
-.PD
+.Ic history ,
+the history string.
+.
+.El
+.
 .Pp
-`%B',
-.Sq %S
-,
-.Sq %U
+.Ql \&%B ,
+.Ql \&%S ,
+.Ql \&%U ,
 and
-.Sq %{
-.Va string
-%}
+.Ql %{ Ns Ar string Ns Li %}
 are available in only
 eight-bit-clean shells; see the
-.Va version
+.Ic version
 shell variable.
 .Pp
 The bold, standout and underline sequences are often used to distinguish a
 superuser shell.
 For example,
-.IP "" 4
-> set prompt = "%m [%h] %B[%@]%b [%/] you rang? "
-.br
-tut [37]
-.Va [2:54pm]
-[/usr/accts/sys] you rang? _
+.Pp
+.\" Using Bl not Bd to allow bold formatting in the second line
+.Bl -tag -offset indent -compact
+.It Li > set prompt = \&"%m [%h] \&%B[%@]%b [%/] you rang? \&"
+.It Li tut [37] Cm [2:54pm] Li [/usr/accts/sys] you rang? _
+.El
 .Pp
 If
-.Sq %t
-,
-.Sq %@
-,
-.Sq %T
-,
-.Sq %p
-, or
-.Sq %P
+.Ql %t ,
+.Ql %@ ,
+.Ql \&%T ,
+.Ql %p ,
+or
+.Ql \&%P
 is used, and
-.Va noding
+.Ic noding
 is not set,
 then print
 .Sq DING!
@@ -8054,157 +8255,156 @@ minutes) instead of
 the actual time.
 .Pp
 Set by default to
-.Sq %#
+.Ql %#\ \&
 in interactive shells.
-.RE
-.TP 8
-.B prompt2 \fR(+)
+.
+.It Ic prompt2 No (+)
 The string with which to prompt in
-.Va while
+.Ic while
 and
-.Va foreach
+.Ic foreach
 loops and
 after lines ending in
-.Sq \e
+.Ql \e .
 The same format sequences may be used as in
-.Va prompt
+.Ic prompt
 (q.v.);
 note the variable meaning of
-.Sq %R
+.Ql \&%R .
 Set by default to
-.Sq %R?
+.Ql \&%R?\ \&
 in interactive shells.
-.TP 8
-.B prompt3 \fR(+)
+.
+.It Ic prompt3 No (+)
 The string with which to prompt when confirming automatic spelling correction.
 The same format sequences may be used as in
-.Va prompt
+.Ic prompt
 (q.v.);
 note the variable meaning of
-.Sq %R
+.Ql \&%R .
 Set by default to
-.Sq CORRECT>%R (y|n|e|a)?
+.Ql CORRECT>%R (y|n|e|a)?\ \&
 in interactive shells.
-.TP 8
-.B promptchars \fR(+)
+.
+.It Ic promptchars No (+)
 If set (to a two-character string), the
-.Sq %#
+.Ql %#
 formatting sequence in the
-.Va prompt
+.Ic prompt
 shell variable is replaced with the first character for
 normal users and the second character for the superuser.
-.TP 8
-.B pushdtohome \fR(+)
+.
+.It Ic pushdtohome No (+)
 If set,
-.Va pushd
+.Ic pushd
 without arguments does
-.Sq pushd ~
-, like
-.Va cd
-.TP 8
-.B pushdsilent \fR(+)
+.Ql pushd ~ ,
+like
+.Ic cd .
+.
+.It Ic pushdsilent No (+)
 If set,
-.Va pushd
+.Ic pushd
 and
-.Va popd
+.Ic popd
 do not print the directory stack.
-.TP 8
-.B recexact \fR(+)
+.
+.It Ic recexact No (+)
 If set, completion completes on an exact match even if a longer match is
 possible.
-.TP 8
-.B recognize_only_executables \fR(+)
+.
+.It Ic recognize_only_executables No (+)
 If set, command listing displays only files in the path that are
 executable.
 Slow.
-.TP 8
-.B rmstar \fR(+)
+.
+.It Ic rmstar No (+)
 If set, the user is prompted before
-.Sq rm *
+.Ql rm *
 is executed.
-.TP 8
-.B rprompt \fR(+)
+.
+.It Ic rprompt No (+)
 The string to print on the right-hand side of the screen (after
 the command input) when the prompt is being displayed on the left.
 It recognizes the same formatting characters as
-.Va prompt
+.Ic prompt .
 It will automatically disappear and reappear as necessary, to ensure that
 command input isn't obscured, and will appear only if the prompt,
 command input, and itself will fit together on the first line.
 If
-.Va edit
+.Ic edit
 isn't set, then
-.Va rprompt
+.Ic rprompt
 will be printed after
 the prompt and before the command input.
-.TP 8
-.B savedirs \fR(+)
+.
+.It Ic savedirs No (+)
 If set, the shell does
-.Sq dirs \-S
+.Ql dirs \-S
 before exiting.
 If the first word is set to a number, at most that many directory stack
 entries are saved.
-.TP 8
-.B savehist
+.
+.It Ic savehist
 If set, the shell does
-.Sq history \-S
+.Ql history \-S
 before exiting.
 If the first word is set to a number, at most that many lines are saved.
 (The number should be less than or equal to the number
-.Va history
+.Ic history
 entries;
 if it is set to greater than the number of
-.Va history
+.Ic history
 settings, only
-.Va history
-entries will be saved)
+.Ic history
+entries will be saved.)
 If the second word is set to
-.Sq merge
-, the history list is merged with
+.Ql merge ,
+the history list is merged with
 the existing history file instead of replacing it (if there is one) and
 sorted by time stamp and the most recent events are retained.
 If the second word of
-.Va savehist
+.Ic savehist
 is
-.Sq merge
+.Ql merge
 and the third word is set to
-`lock', the history file update will be serialized with other shell sessions
+.Ql lock ,
+the history file update will be serialized with other shell sessions
 that would possibly like to merge history at exactly the same time. (+)
-.TP 8
-.B sched \fR(+)
+.
+.It Ic sched No (+)
 The format in which the
-.Va sched
+.Ic sched
 builtin command prints scheduled events;
 if not given,
-.Sq %h\et%T\et%R\en
+.Ql %h\et%T\et%R\en
 is used.
 The format sequences are described above under
-.Va prompt
-;
+.Ic prompt ;
 note the variable meaning of
-.Sq %R
-.TP 8
-.B shell
+.Ql \&%R .
+.
+.It Ic shell
 The file in which the shell resides.
 This is used in forking
 shells to interpret files which have execute bits set, but
 which are not executable by the system.
 (See the description
 of
-.Va Builtin and non-builtin command execution
-.)  Initialized to the
+.Sx "Builtin and non-builtin command execution" . )
+Initialized to the
 (system-dependent) home of the shell.
-.TP 8
-.B shlvl \fR(+)
+.
+.It Ic shlvl No (+)
 The number of nested shells.
 Reset to 1 in login shells.
 See also
-.Va loginsh
-.TP 8
-.B status
+.Ic loginsh .
+.
+.It Ic status
 The exit status from the last command or backquote expansion, or any
 command in a pipeline is propagated to
-.Va status
+.Ic status .
 (This is also the
 default
 .Xr csh 1
@@ -8212,55 +8412,53 @@ behavior.)
 This default does not match what POSIX mandates (to return the
 status of the last command only). To match the POSIX behavior, you need
 to unset
-.Va anyerror
-.RS +8
+.Ic anyerror .
 .Pp
 If the
-.Va anyerror
+.Ic anyerror
 variable is unset, the exit status of a pipeline
 is determined only from the last command in the pipeline, and the exit
 status of a backquote expansion is
-.Va not
+.Em not
 propagated to
-.Va status
+.Ic status .
 .Pp
 If a command terminated abnormally, then 0200 is added to the status.
 Builtin commands which fail return exit status
-.Sq 1
-, all other builtin
+.Ql 1 ,
+all other builtin
 commands return status
-.Sq 0
-.RE
-.TP 8
-.B symlinks \fR(+)
-Can be set to several different values to control symbolic link (`symlink')
+.Ql 0 .
+.
+.It Ic symlinks No (+)
+Can be set to several different values to control symbolic link
+.Pq Sq symlink
 resolution:
-.RS +8
 .Pp
 If set to
-.Sq chase
-, whenever the current directory changes to a directory
+.Ql chase ,
+whenever the current directory changes to a directory
 containing a symbolic link, it is expanded to the real name of the directory
 to which the link points.
 This does not work for the user's home directory;
 this is a bug.
 .Pp
 If set to
-.Sq ignore
-, the shell tries to construct a current directory
+.Ql ignore ,
+the shell tries to construct a current directory
 relative to the current directory before the link was crossed.
 This means that
-.Va cd
+.Ic cd Ns
 ing through a symbolic link and then
-.Sq cd ..
+.Ql cd \&.. Ns
 ing
 returns one to the original directory.
 This affects only builtin commands
 and filename completion.
 .Pp
 If set to
-.Sq expand
-, the shell tries to fix symbolic links by actually expanding
+.Ql expand ,
+the shell tries to fix symbolic links by actually expanding
 arguments which look like path names.
 This affects any command, not just
 builtins.
@@ -8272,713 +8470,670 @@ While this setting is usually the most convenient, it is sometimes
 misleading and sometimes confusing when it fails to recognize an argument
 which should be expanded.
 A compromise is to use
-.Sq ignore
+.Ql ignore
 and use the
 editor command
-.Va normalize-path
-(bound by default to ^X-n) when necessary.
+.Ic normalize-path
+(bound by default to
+.Sq ^X-n )
+when necessary.
 .Pp
 Some examples are in order.
 First, let's set up some play directories:
-.IP "" 4
+.Bd -literal -offset indent
 > cd /tmp
-.br
 > mkdir from from/src to
-.br
 > ln \-s from/src to/dst
+.Ed
 .Pp
 Here's the behavior with
-.Va symlinks
+.Ic symlinks
 unset,
-.IP "" 4
+.Bd -literal -offset indent
 > cd /tmp/to/dst; echo $cwd
-.br
 /tmp/to/dst
-.br
 > cd ..; echo $cwd
-.br
 /tmp/from
+.Ed
 .Pp
 here's the behavior with
-.Va symlinks
+.Ic symlinks
 set to
-.Sq chase
-,
-.IP "" 4
+.Ql chase ,
+.Bd -literal -offset indent
 > cd /tmp/to/dst; echo $cwd
-.br
 /tmp/from/src
-.br
 > cd ..; echo $cwd
-.br
 /tmp/from
+.Ed
 .Pp
 here's the behavior with
-.Va symlinks
+.Ic symlinks
 set to
-.Sq ignore
-,
-.IP "" 4
+.Ql ignore ,
+.Bd -literal -offset indent
 > cd /tmp/to/dst; echo $cwd
-.br
 /tmp/to/dst
-.br
 > cd ..; echo $cwd
-.br
 /tmp/to
+.Ed
 .Pp
 and here's the behavior with
-.Va symlinks
+.Ic symlinks
 set to
-.Sq expand
-.IP "" 4
+.Ql expand .
+.Bd -literal -offset indent
 > cd /tmp/to/dst; echo $cwd
-.br
 /tmp/to/dst
-.br
 > cd ..; echo $cwd
-.br
 /tmp/to
-.br
 > cd /tmp/to/dst; echo $cwd
-.br
 /tmp/to/dst
-.br
 > cd ".."; echo $cwd
-.br
 /tmp/from
-.br
 > /bin/echo ..
-.br
 /tmp/to
-.br
 > /bin/echo ".."
-.br
 \&..
+.Ed
 .Pp
 Note that
-.Sq expand
+.Ql expand
 expansion 1) works just like
-.Sq ignore
+.Ql ignore
 for builtins
 like
-.Va cd
-, 2) is prevented by quoting, and 3) happens before
+.Ic cd ,
+2) is prevented by quoting, and 3) happens before
 filenames are passed to non-builtin commands.
-.RE
-.TP 8
-.B tcsh \fR(+)
+.
+.It Ic tcsh No (+)
 The version number of the shell in the format
-.Sq R.VV.Pp
-,
+.Sq Ar R Ns No \&. Ns Ar VV Ns No \&. Ns Ar PP ,
 where
-.Sq R
+.Sq Ar R
 is the major release number,
-.Sq VV
-the current version
+.Sq Ar VV
+the current version,
 and
-.Sq PP
+.Sq Ar PP
 the patchlevel.
-.TP 8
-.B term
+.
+.It Ic term
 The terminal type.
 Usually set in
-.Va ~/.login
+.Pa ~/.login
 as described under
-.Va Startup and shutdown
-.TP 8
-.B time
+.Sx Startup and shutdown .
+.
+.It Ic time
 If set to a number, then the
-.Va time
+.Ic time
 builtin (q.v.) executes automatically
 after each command which takes more than that many CPU seconds.
 If there is a second word, it is used as a format string for the output
 of the
-.Va time
+.Ic time
 builtin.
 (u) The following sequences may be used in the
 format string:
 .Pp
-.RS +8
-.PD 0
-.TP 4
-%U
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li \&%U
 The time the process spent in user mode in cpu seconds.
-.TP 4
-%S
+.
+.It Li \&%S
 The time the process spent in kernel mode in cpu seconds.
-.TP 4
-%E
+.
+.It Li \&%E
 The elapsed (wall clock) time in seconds.
-.TP 4
-%P
-The CPU percentage computed as (%U + %S) / %E.
-.TP 4
-%W
+.
+.It Li \&%P
+The CPU percentage computed as (\&%U + \&%S) / \&%E.
+.
+.It Li \&%W
 Number of times the process was swapped.
-.TP 4
-%X
+.
+.It Li \&%X
 The average amount in (shared) text space used in Kbytes.
-.TP 4
-%D
+.
+.It Li \&%D
 The average amount in (unshared) data/stack space used in Kbytes.
-.TP 4
-%K
-The total space used (%X + %D) in Kbytes.
-.TP 4
-%M
+.
+.It Li \&%K
+The total space used (\&%X + \&%D) in Kbytes.
+.
+.It Li \&%M
 The maximum memory the process had in use at any time in Kbytes.
-.TP 4
-%F
+.
+.It Li \&%F
 The number of major page faults (page needed to be brought from disk).
-.TP 4
-%R
+.
+.It Li \&%R
 The number of minor page faults.
-.TP 4
-%I
+.
+.It Li \&%I
 The number of input operations.
-.TP 4
-%O
+.
+.It Li \&%O
 The number of output operations.
-.TP 4
-%r
+.
+.It Li %r
 The number of socket messages received.
-.TP 4
-%s
+.
+.It Li %s
 The number of socket messages sent.
-.TP 4
-%k
+.
+.It Li %k
 The number of signals received.
-.TP 4
-%w
+.
+.It Li %w
 The number of voluntary context switches (waits).
-.TP 4
-%c
+.
+.It Li %c
 The number of involuntary context switches.
-.PD
+.
+.El
 .Pp
 Only the first four sequences are supported on systems without BSD resource
 limit functions.
 The default time format is
-.Sq %Uu %Ss %E %P %X+%Dk %I+%Oio %Fpf+%Ww
+.Ql \&%Uu \&%Ss \&%E \&%P \&%X+%Dk \&%I+%Oio \&%Fpf+%Ww
 for
 systems that support resource usage reporting and
-.Sq %Uu %Ss %E %P
+.Ql \&%Uu \&%Ss \&%E \&%P
 for
 systems that do not.
 .Pp
-Under Sequent's DYNIX/ptx, %X, %D, %K, %r and %s are not
+Under Sequent's DYNIX/ptx,
+.Ql \&%X ,
+.Ql \&%D ,
+.Ql \&%K ,
+.Ql %r ,
+and
+.Ql %s
+are not
 available, but the following additional sequences are:
 .Pp
-.PD 0
-.TP 4
-%Y
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li \&%Y
 The number of system calls performed.
-.TP 4
-%Z
+.
+.It Li \&%Z
 The number of pages which are zero-filled on demand.
-.TP 4
-%i
+.
+.It Li %i
 The number of times a process's resident set size was increased by the kernel.
-.TP 4
-%d
+.
+.It Li %d
 The number of times a process's resident set size was decreased by the kernel.
-.TP 4
-%l
+.
+.It Li %l
 The number of read system calls performed.
-.TP 4
-%m
+.
+.It Li %m
 The number of write system calls performed.
-.TP 4
-%p
+.
+.It Li %p
 The number of reads from raw disk devices.
-.TP 4
-%q
+.
+.It Li %q
 The number of writes to raw disk devices.
-.PD
+.
+.El
 .Pp
 and the default time format is
-.Sq %Uu %Ss %E %P %I+%Oio %Fpf+%Ww
+.Ql \&%Uu \&%Ss \&%E \&%P \&%I+%Oio \&%Fpf+%Ww .
 Note that the CPU percentage can be higher than 100% on multi-processors.
-.RE
-.TP 8
-.B tperiod \fR(+)
+.
+.It Ic  tperiod No (+)
 The period, in minutes, between executions of the
-.Va periodic
+.Ic periodic
 special alias.
-.TP 8
-.B tty \fR(+)
+.
+.It Ic tty No (+)
 The name of the tty, or empty if not attached to one.
-.TP 8
-.B uid \fR(+)
+.
+.It Ic uid No (+)
 The user's real user ID.
-.TP 8
-.B user
+.
+.It Ic user
 The user's login name.
-.TP 8
-.B verbose
+.
+.It Ic verbose
 If set, causes the words of each
 command to be printed, after history substitution (if any).
 Set by the
-.Fl v\fR command line option.
-.TP 8
-.B version \fR(+)
+.Fl v
+command line option.
+.
+.It Ic version No (+)
 The version ID stamp.
 It contains the shell's version number (see
-.Va tcsh
-),
+.Ic tcsh ) ,
 origin, release date, vendor, operating system and machine (see
-.Va VENDOR
-,
-.Va OSTYPE
+.Ev VENDOR ,
+.Ev OSTYPE ,
 and
-.Va MACHTYPE
-) and a comma-separated
+.Ev MACHTYPE )
+and a comma-separated
 list of options which were set at compile time.
 Options which are set by default in the distribution are noted.
 .Pp
-.RS +8
-.PD 0
-.TP 6
-8b
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li 8b
 The shell is eight bit clean; default
-.TP 6
-7b
+.
+.It Li 7b
 The shell is not eight bit clean
-.TP 6
-wide
+.
+.It Li wide
 The shell is multibyte encoding clean (like UTF-8)
-.TP 6
-nls
+.
+.It Li nls
 The system's NLS is used; default for systems with NLS
-.TP 6
-lf
+.
+.It Li lf
 Login shells execute
-.Va /etc/csh.login
+.Pa /etc/csh.login
 before instead of after
-.Va /etc/csh.cshrc
+.Pa /etc/csh.cshrc
 and
-.Va ~/.login
+.Pa ~/.login
 before instead of after
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 and
-.Va ~/.history
-.TP 6
-dl
-`.' is put last in
-.Va path
+.Pa ~/.history .
+.
+.It Li dl
+.Ql \&.
+is put last in
+.Ic path
 for security; default
-.TP 6
-nd
-`.' is omitted from
-.Va path
+.
+.It Li nd
+.Ql \&.
+is omitted from
+.Ic path
 for security
-.TP 6
-vi
-.Va vi
-(1)\-style editing is the default rather than
-.Va emacs
-(1)\-style
-.TP 6
-dtr
+.
+.It Li vi
+.Xr vi 1 Ns
+\-style editing is the default rather than
+.Xr emacs 1 Ns
+\-style
+.
+.It Li dtr
 Login shells drop DTR when exiting
-.TP 6
-bye
-.Va bye
+.
+.It Li bye
+.Ic bye
 is a synonym for
-.Va logout
+.Ic logout
 and
-.Va log
+.Ic log
 is an alternate name for
-.Va watchlog
-.TP 6
-al
-.Va autologout
+.Ic watchlog
+.
+.It Li al
+.Ic autologout
 is enabled; default
-.TP 6
-kan
+.
+.It Li kan
 Kanji is used if appropriate according to locale settings,
 unless the
-.Va nokanji
+.Ic nokanji
 shell variable is set
-.TP 6
-sm
+.
+.It Li sm
 The system's
-.Va malloc
-(3) is used
-.TP 6
-hb
+.Xr malloc 3
+is used
+.
+.It Li hb
 The
-.Sq #!<program> <args>
+.Ql #!<program> <args>
 convention is emulated when executing shell scripts
-.TP 6
-ng
+.
+.It Li ng
 The
-.Va newgrp
+.Ic newgrp
 builtin is available
-.TP 6
-rh
+.
+.It Li rh
 The shell attempts to set the
-.Va REMOTEHOST
+.Ev REMOTEHOST
 environment variable
-.TP 6
-afs
+.
+.It Li afs
 The shell verifies your password with the kerberos server if local
 authentication fails.
 The
-.Va afsuser
+.Ic afsuser
 shell variable or the
-.Va AFSUSER
+.Ev AFSUSER
 environment variable override your local username if set.
-.PD
+.
+.El
 .Pp
 An administrator may enter additional strings to indicate differences
 in the local version.
-.RE
-.TP 8
-.B vimode \fR(+)
-.RS +8
+.
+.It Ic vimode No (+)
 If unset, various key bindings change behavior to be more
-.Va emacs
-(1)\-style:
+.Xr emacs 1 Ns
+\-style:
 word boundaries are determined by
-.Va wordchars
+.Ic wordchars
 versus other characters.
 .Pp
 If set, various key bindings change behavior to be more
-.Va vi
-(1)\-style:
+.Xr vi 1 Ns
+\-style:
 word boundaries are determined by
-.Va wordchars
+.Ic wordchars
 versus whitespace
 versus other characters;
 cursor behavior depends upon current vi mode (command, delete, insert, replace).
 .Pp
 This variable is unset by
-.Va bindkey
-
-.Va -e
+.Ic bindkey Fl e
 and
 set by
-.Va bindkey
-
-.Va -v
-.B vimode
+.Ic bindkey Fl v .
+.Ic vimode
 may be explicitly set or unset by the user after those
-.Va bindkey
+.Ic bindkey
 operations if required.
-.RE
-.TP 8
-.B visiblebell \fR(+)
+.
+.It Ic visiblebell No (+)
 If set, a screen flash is used rather than the audible bell.
 See also
-.Va nobeep
-.TP 8
-.B watch \fR(+)
+.Ic nobeep .
+.
+.It Ic watch No (+)
 A list of user/terminal pairs to watch for logins and logouts.
 If either the user is
-.Sq any
+.Ql any
 all terminals are watched for the given user
 and vice versa.
 Setting
-.Va watch
+.Ic watch
 to
-.Sq (any any)
+.Ql (any any)
 watches all users and terminals.
 For example,
-.RS +8
-.IP "" 4
+.Bd -literal -offset indent
 set watch = (george ttyd1 any console $user any)
+.Ed
 .Pp
 reports activity of the user
-.Sq george
-on ttyd1, any user on the console, and
+.Ql george
+on
+.Ql ttyd1 ,
+any user on the console, and
 oneself (or a trespasser) on any terminal.
 .Pp
 Logins and logouts are checked every 10 minutes by default, but the first
 word of
-.Va watch
+.Ic watch
 can be set to a number to check every so many minutes.
 For example,
-.IP "" 4
+.Bd -literal -offset indent
 set watch = (1 any any)
+.Ed
 .Pp
 reports any login/logout once every minute.
 For the impatient, the
-.Va log
+.Ic log
 builtin command triggers a
-.Va watch
+.Ic watch
 report at any time.
 All current logins
 are reported (as with the
-.Va log
+.Ic log
 builtin) when
-.Va watch
+.Ic watch
 is first set.
 .Pp
 The
-.Va who
+.Ic who
 shell variable controls the format of
-.Va watch
+.Ic watch
 reports.
-.RE
-.TP 8
-.B who \fR(+)
+.
+.It Ic who No (+)
 The format string for
-.Va watch
+.Ic watch
 messages.
 The following sequences
 are replaced by the given information:
 .Pp
-.RS +8
-.PD 0
-.TP 4
-%n
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li %n
 The name of the user who logged in/out.
-.TP 4
-%a
+.
+.It Li %a
 The observed action, i.e.,
-.Sq logged on
-,
-.Sq logged off
+.Sq logged on ,
+.Sq logged off ,
 or
-.Sq replaced
-.Va olduser
-on
-.TP 4
-%l
+.Sq replaced Ar olduser No on .
+.
+.It Li %l
 The terminal (tty) on which the user logged in/out.
-.TP 4
-%M
+.
+.It Li \&%M
 The full hostname of the remote host, or
 .Sq local
 if the login/logout was
 from the local host.
-.TP 4
-%m
+.
+.It Li %m
 The hostname of the remote host up to the first
-.Sq .
+.Sq \&. .
 The full name is printed if it is an IP address or an X Window System display.
-.PD
+.
+.El
 .Pp
-%M and %m are available on only systems that store the remote hostname in
-.Va /etc/utmp
+.Ql \&%M
+and
+.Ql %m
+are available on only systems that store the remote hostname in
+.Pa /etc/utmp .
 If unset,
-.Sq %n has %a %l from %m.
+.Ql %n has %a %l from %m.
 is used, or
-.Sq %n has %a %l.
+.Ql %n has %a %l.
 on systems
 which don't store the remote hostname.
-.RE
-.TP 8
-.B wordchars \fR(+)
+.
+.It Ic wordchars No (+)
 A list of non-alphanumeric characters to be considered part of a word by the
-.Va forward-word
-,
-.Va backward-word
+.Ic forward-word ,
+.Ic backward-word ,
 etc., editor commands.
 If unset, the default value is determined based on the state of
-.Va vimode
-:
+.Ic vimode :
 if
-.Va vimode
+.Ic vimode
 is unset,
-.Sq *?_\-.[]~=
+.Ql *?_\-.[]~=
 is used as the default;
 if
-.Va vimode
+.Ic vimode
 is set,
-.Sq _
+.Ql _
 is used as the default.
+.
+.El
+.
 .Sh ENVIRONMENT
-.TP 8
-.B AFSUSER \fR(+)
+.Bl -tag -width 8n
+.
+.It Ev AFSUSER No (+)
 Equivalent to the
-.Va afsuser
+.Ic afsuser
 shell variable.
-.TP 8
-.B COLUMNS
+.
+.It Ev COLUMNS
 The number of columns in the terminal.
 See
-.Va Terminal management
-.TP 8
-.B DISPLAY
+.Sx Terminal management .
+.
+.It Ev DISPLAY
 Used by X Window System (see
-.Va X
-(1)).
+.Xr X 1 ) .
 If set, the shell does not set
-.Va autologout
+.Ic autologout
 (q.v.).
-.TP 8
-.B EDITOR
+.
+.It Ev EDITOR
 The pathname to a default editor.
 Used by the
-.Va run-fg-editor
+.Ic run-fg-editor
 editor command if the
 the
-.Va editors
+.Ic editors
 shell variable is unset.
 See also the
-.Va VISUAL
+.Ev VISUAL
 environment variable.
-.TP 8
-.B GROUP \fR(+)
+.
+.It Ev GROUP No (+)
 Equivalent to the
-.Va group
+.Ic group
 shell variable.
-.TP 8
-.B HOME
+.
+.It Ev HOME
 Equivalent to the
-.Va home
+.Ic home
 shell variable.
-.TP 8
-.B HOST \fR(+)
+.
+.It Ev HOST No (+)
 Initialized to the name of the machine on which the shell
 is running, as determined by the
-.Va gethostname
-(2) system call.
-.TP 8
-.B HOSTTYPE \fR(+)
+.Xr gethostname 2
+system call.
+.
+.It Ev HOSTTYPE No (+)
 Initialized to the type of machine on which the shell
 is running, as determined at compile time.
 This variable is obsolete and
 will be removed in a future version.
-.TP 8
-.B HPATH \fR(+)
+.
+.It Ev HPATH No (+)
 A colon-separated list of directories in which the
-.Va run-help
+.Ic run-help
 editor
 command looks for command documentation.
-.TP 8
-.B LANG
+.
+.It Ev LANG
 Gives the preferred character environment.
 See
-.Va Native Language System support
-.TP 8
-.B LC_CTYPE
+.Sx Native Language System support .
+.
+.It Ev LC_CTYPE
 If set, only ctype character handling is changed.
 See
-.Va Native Language System support
-.TP 8
-.B LINES
+.Sx Native Language System support .
+.
+.It Ev LINES
 The number of lines in the terminal.
 See
-.Va Terminal management
-.TP 8
-.B LS_COLORS
+.Sx Terminal management .
+.
+.It Ev LS_COLORS
 The format of this variable is reminiscent of the
-.Va termcap(5)
+.Xr termcap 5
 file format; a colon-separated list of expressions of the form
-"
-.Va xx=string
-", where "
-.Va xx
-" is a two-character variable name.
+.Li \&" Ns Ar xx Ns Li = Ns Ar string Ns Li \&" ,
+where
+.Li \&" Ns Ar xx Ns Li \&"
+is a two-character variable name.
 The
 variables with their associated defaults are:
 .Pp
-.RS +8
-.RS +4
-.PD 0
-.TP 12
-no	0
-Normal (non-filename) text
-.TP 12
-fi	0
-Regular file
-.TP 12
-di	01;34
-Directory
-.TP 12
-ln	01;36
-Symbolic link
-.TP 12
-pi	33
-Named pipe (FIFO)
-.TP 12
-so	01;35
-Socket
-.TP 12
-do	01;35
-Door
-.TP 12
-bd	01;33
-Block device
-.TP 12
-cd	01;32
-Character device
-.TP 12
-ex	01;32
-Executable file
-.TP 12
-mi	(none)
-Missing file (defaults to fi)
-.TP 12
-or	(none)
-Orphaned symbolic link (defaults to ln)
-.TP 12
-lc	^[[
-Left code
-.TP 12
-rc	m
-Right code
-.TP 12
-ec	(none)
-End code (replaces lc+no+rc)
-.PD
-.RE
+.Bl -column -offset indent "Li XX" "Li XXXXX" 20n
+.
+.It Li no Ta Li 0 Ta Normal (non-filename) text
+.
+.It Li fi Ta Li 0 Ta Regular file
+.
+.It Li di Ta Li 01;34 Ta Directory
+.
+.It Li ln Ta Li 01;36 Ta Symbolic link
+.
+.It Li pi Ta Li 33 Ta Named pipe (FIFO)
+.
+.It Li so Ta Li 01;35 Ta Socket
+.
+.It Li do Ta Li 01;35 Ta Door
+.
+.It Li bd Ta Li 01;33 Ta Block device
+.
+.It Li cd Ta Li 01;32 Ta Character device
+.
+.It Li ex Ta Li 01;32 Ta Executable file
+.
+.It Li mi Ta (none) Ta Missing file (defaults to Li fi Ns )
+.
+.It Li or Ta (none) Ta Orphaned symbolic link (defaults to Li ln Ns )
+.
+.It Li lc Ta Li ^[[ Ta Left code
+.
+.It Li rc Ta Li m Ta Right code
+.
+.It Li ec Ta (none) Ta End code (replaces Li lc Ns + Ns Li no Ns + Ns Li rc Ns )
+.
+.El
 .Pp
 You need to include only the variables you want to change from
 the default.
 .Pp
 File names can also be colorized based on filename extension.
 This is specified in the
-.Va LS_COLORS
+.Ev LS_COLORS
 variable using the syntax
-.Va "*ext=string"
+.Li \&"* Ns Ar ext Ns Li = Ns Ar string Ns Li \&" .
 For example, using ISO 6429 codes, to color
 all C\-language source files blue you would specify
-.Va "*.c=34"
+.Li \&"*.c=34\&" .
 This would color all files ending in
-.Va .c
+.Ql .c
 in blue (34) color.
 .Pp
 Control characters can be written either in C\-style\-escaped
 notation, or in stty\-like ^\-notation.
 The C\-style notation
 adds
-.Va ^[
-for Escape, \fB\_\fR for a normal space character,
+.Ql ^[
+for Escape,
+.Ql \_
+for a normal space character,
 and
-.Va ?
+.Ql \&?
 for Delete.
 In addition, the
-.Va ^[
+.Ql ^[
 escape character
 can be used to override the default interpretation of
-.Va ^[
-,
-.Va ^
-,
-.Va :
+.Ql ^[ ,
+.Ql ^ ,
+.Ql \&: ,
 and
-.Va =
+.Ql = .
 .Pp
 Each file will be written as
-.Va <lc>
-
-.Va <color-code>
-.Va <rc>
-
-.Va <filename>
-
-.Va <ec>
+.Ql <lc> <color-code> <rc> <filename> <ec> .
 If the
-.Va <ec>
+.Ql <ec>
 code is undefined, the sequence
-.Va <lc>
-\fB<no>
-.Va <rc>
+.Ql <lc> <no> <rc>
 will be used instead.
 This is generally more convenient
 to use, but less general.
@@ -8990,80 +9145,77 @@ ISO 6429 color sequences but a different system.
 .Pp
 If your terminal does use ISO 6429 color codes, you can
 compose the type codes (i.e., all except the
-.Va lc
-,
-.Va rc
-,
+.Ql lc ,
+.Ql rc ,
 and
-.Va ec
+.Ql ec
 codes) from numerical commands separated by semicolons.
 The
 most common commands are:
 .Pp
-.RS +8
-.PD 0
-.TP 4
-0
+.Bl -tag -width 4n -offset indent -compact
+.
+.It Li 0
 to restore default color
-.TP 4
-1
+.
+.It Li 1
 for brighter colors
-.TP 4
-4
+.
+.It Li 4
 for underlined text
-.TP 4
-5
+.
+.It Li 5
 for flashing text
-.TP 4
-30
+.
+.It Li 30
 for black foreground
-.TP 4
-31
+.
+.It Li 31
 for red foreground
-.TP 4
-32
+.
+.It Li 32
 for green foreground
-.TP 4
-33
+.
+.It Li 33
 for yellow (or brown) foreground
-.TP 4
-34
+.
+.It Li 34
 for blue foreground
-.TP 4
-35
+.
+.It Li 35
 for purple foreground
-.TP 4
-36
+.
+.It Li 36
 for cyan foreground
-.TP 4
-37
+.
+.It Li 37
 for white (or gray) foreground
-.TP 4
-40
+.
+.It Li 40
 for black background
-.TP 4
-41
+.
+.It Li 41
 for red background
-.TP 4
-42
+.
+.It Li 42
 for green background
-.TP 4
-43
+.
+.It Li 43
 for yellow (or brown) background
-.TP 4
-44
+.
+.It Li 44
 for blue background
-.TP 4
-45
+.
+.It Li 45
 for purple background
-.TP 4
-46
+.
+.It Li 46
 for cyan background
-.TP 4
-47
+.
+.It Li 47
 for white (or gray) background
-.PD
-.RE
+.
+.El
 .Pp
 Not all commands will work on all systems or display devices.
 .Pp
@@ -9071,221 +9223,226 @@ A few terminal programs do not recognize the default end code
 properly.
 If all text gets colorized after you do a directory
 listing, try changing the
-.Va no
+.Ql no
 and
-.Va fi
+.Ql fi
 codes from 0 to the
 numerical codes for your standard fore- and background colors.
-.Pp     
-For symbolic links the "ln" keyword can be set to "target", which makes
+.Pp
+For symbolic links the
+.Ql ln
+keyword can be set to
+.Ql target ,
+which makes
 the file color the same as the color of the link target.
-.RE
-.TP 8
-.B MACHTYPE \fR(+)
+.
+.It Ev MACHTYPE No (+)
 The machine type (microprocessor class or machine model), as determined at compile time.
-.TP 8
-.B NOREBIND \fR(+)
+.
+.It Ev NOREBIND No (+)
 If set, printable characters are not rebound to
-.Va self-insert-command
+.Ic self-insert-command .
 See
-.Va Native Language System support
-.TP 8
-.B OSTYPE \fR(+)
+.Sx Native Language System support .
+.
+.It Ev OSTYPE No (+)
 The operating system, as determined at compile time.
-.TP 8
-.B PATH
+.
+.It Ev PATH
 A colon-separated list of directories in which to look for executables.
 Equivalent to the
-.Va path
+.Ic path
 shell variable, but in a different format.
-.TP 8
-.B PWD \fR(+)
+.
+.It Ev PWD No (+)
 Equivalent to the
-.Va cwd
+.Ic cwd
 shell variable, but not synchronized to it;
 updated only after an actual directory change.
-.TP 8
-.B REMOTEHOST \fR(+)
+.
+.It Ev REMOTEHOST No (+)
 The host from which the user has logged in remotely, if this is the case and
 the shell is able to determine it.
 Set only if the shell was so compiled;
 see the
-.Va version
+.Ic version
 shell variable.
-.TP 8
-.B SHLVL \fR(+)
+.
+.It Ev SHLVL No (+)
 Equivalent to the
-.Va shlvl
+.Ic shlvl
 shell variable.
-.TP 8
-.B SYSTYPE \fR(+)
+.
+.It Ev SYSTYPE No (+)
 The current system type.
 (Domain/OS only)
-.TP 8
-.B TERM
+.
+.It Ev TERM
 Equivalent to the
-.Va term
+.Ic term
 shell variable.
-.TP 8
-.B TERMCAP
+.
+.It Ev TERMCAP
 The terminal capability string.
 See
-.Va Terminal management
-.TP 8
-.B USER
+.Sx Terminal management .
+.
+.It Ev USER
 Equivalent to the
-.Va user
+.Ic user
 shell variable.
-.TP 8
-.B VENDOR \fR(+)
+.
+.It Ev VENDOR No (+)
 The vendor, as determined at compile time.
-.TP 8
-.B VISUAL
+.
+.It Ev VISUAL
 The pathname to a default full-screen editor.
 Used by the
-.Va run-fg-editor
+.Ic run-fg-editor
 editor command if the
 the
-.Va editors
+.Ic editors
 shell variable is unset.
 See also the
-.Va EDITOR
+.Ev EDITOR
 environment variable.
+.
+.El
+.
 .Sh FILES
-.PD 0
-.TP 16
-.I /etc/csh.cshrc
+.Bl -tag -width 16n -compact
+.
+.It Pa /etc/csh.cshrc
 Read first by every shell.
 ConvexOS, Stellix and Intel use
-.Va /etc/cshrc
+.Pa /etc/cshrc
 and
 NeXTs use
-.Va /etc/cshrc.std
+.Pa /etc/cshrc.std .
 A/UX, AMIX, Cray and IRIX have no equivalent in
-.Xr csh 1
-,
+.Xr csh 1 ,
 but read this file in
 .Nm
 anyway.
 Solaris 2.x does not have it either, but
 .Nm
 reads
-.Va /etc/.cshrc
+.Pa /etc/.cshrc .
 (+)
-.TP 16
-.I /etc/csh.login
+.
+.It Pa /etc/csh.login
 Read by login shells after
-.Va /etc/csh.cshrc
+.Pa /etc/csh.cshrc .
 ConvexOS, Stellix and Intel use
-.Va /etc/login
-,
+.Pa /etc/login ,
 NeXTs use
-.Va /etc/login.std
-, Solaris 2.x uses
-.Va /etc/.login
+.Pa /etc/login.std ,
+Solaris 2.x uses
+.Pa /etc/.login
 and
 A/UX, AMIX, Cray and IRIX use
-.Va /etc/cshrc
-.TP 16
-.I ~/.tcshrc \fR(+)
+.Pa /etc/cshrc .
+.
+.It Pa ~/.tcshrc No (+)
 Read by every shell after
-.Va /etc/csh.cshrc
+.Pa /etc/csh.cshrc
 or its equivalent.
-.TP 16
-.I ~/.cshrc
+.
+.It Pa ~/.cshrc
 Read by every shell, if
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 doesn't exist,
 after
-.Va /etc/csh.cshrc
+.Pa /etc/csh.cshrc
 or its equivalent.
 This manual uses
-.Sq
-.Va ~/.tcshrc
-to mean `
-.Va ~/.tcshrc
+.Sq Pa ~/.tcshrc
+to mean
+.Do
+.Pa ~/.tcshrc
 or,
 if
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 is not found,
-.Va ~/.cshrc
-'.
-.TP 16
-.I ~/.history
+.Pa ~/.cshrc
+.Dc .
+.
+.It Pa ~/.history
 Read by login shells after
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 if
-.Va savehist
+.Ic savehist
 is set, but see also
-.Va histfile
-.TP 16
-.I ~/.login
+.Ic histfile .
+.
+.It Pa ~/.login
 Read by login shells after
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 or
-.Va ~/.history
+.Pa ~/.history .
 The shell may be compiled to read
-.Va ~/.login
+.Pa ~/.login
 before instead of after
-.Va ~/.tcshrc
+.Pa ~/.tcshrc
 and
-.Va ~/.history
-; see the
-.Va version
+.Pa ~/.history ;
+see the
+.Ic version
 shell variable.
-.TP 16
-.I ~/.cshdirs \fR(+)
+.
+.It Pa ~/.cshdirs No (+)
 Read by login shells after
-.Va ~/.login
+.Pa ~/.login
 if
-.Va savedirs
+.Ic savedirs
 is set, but see also
-.Va dirsfile
-.TP 16
-.I /etc/csh.logout
+.Ic dirsfile .
+.
+.It Pa /etc/csh.logout
 Read by login shells at logout.
 ConvexOS, Stellix and Intel use
-.Va /etc/logout
+.Pa /etc/logout
 and
 NeXTs use
-.Va /etc/logout.std
+.Pa /etc/logout.std .
 A/UX, AMIX, Cray and IRIX have no equivalent in
-.Xr csh 1
-,
+.Xr csh 1 ,
 but read this file in
 .Nm
 anyway.
 Solaris 2.x does not have it either, but
 .Nm
 reads
-.Va /etc/.logout
+.Pa /etc/.logout .
 (+)
-.TP 16
-.I ~/.logout
+.
+.It Pa ~/.logout
 Read by login shells at logout after
-.Va /etc/csh.logout
+.Pa /etc/csh.logout
 or its equivalent.
-.TP 16
-.I /bin/sh
+.
+.It Pa /bin/sh
 Used to interpret shell scripts not starting with a
-.Sq #
-.TP 16
-.I /tmp/sh*
+.Ql # .
+.
+.It Pa /tmp/sh*
 Temporary file for
-.Sq <<
-.TP 16
-.I /etc/passwd
+.Ql << .
+.
+.It Pa /etc/passwd
 Source of home directories for
 .Sq ~name
 substitutions.
-.PD
+.
+.El
 .Pp
 The order in which startup files are read may differ if the shell was so
 compiled; see
-.Va Startup and shutdown
+.Sx Startup and shutdown
 and the
-.Va version
+.Ic version
 shell variable.
+.
 .Sh "NEW FEATURES (+)"
 This manual describes
 .Nm
@@ -9293,186 +9450,168 @@ as a single entity,
 but experienced
 .Xr csh 1
 users will want to pay special attention to
-.Nm
-'s new features.
+.Nm Ns
+\&'s new features.
 .Pp
 A command-line editor, which supports
-.Va emacs
-(1)\-style
+.Xr emacs 1 Ns
+\-style
 or
-.Va vi
-(1)\-style key bindings.
+.Xr vi 1 Ns
+\-style key bindings.
 See
-.Va The command-line editor
+.Sx The command-line editor
 and
-.Va Editor commands
+.Sx Editor commands .
 .Pp
 Programmable, interactive word completion and listing.
 See
 .Sx Completion and listing
 and the
-.Va complete
+.Ic complete
 and
-.Va uncomplete
+.Ic uncomplete
 builtin commands.
 .Pp
-.Va Spelling correction
+.Sx Spelling correction
 (q.v.) of filenames, commands and variables.
 .Pp
-.Va Editor commands
+.Sx Editor commands
 (q.v.) which perform other useful functions in the middle of
 typed commands, including documentation lookup
-.Va ( run-help ),
+.Ic ( run-help ) ,
 quick editor restarting
-.Va ( run-fg-editor )
+.Ic ( run-fg-editor ) ,
 and
 command resolution
-.Va ( which-command ).
+.Ic ( which-command ) .
 .Pp
 An enhanced history mechanism.
 Events in the history list are time-stamped.
 See also the
-.Va history
+.Ic history
 command and its associated shell variables,
 the previously undocumented
-.Sq #
+.Ql #
 event specifier and new modifiers
 under
-.Va History substitution
-,
+.Sx History substitution ,
 the
-.Va *-history
-,
-.Va history-search-*
-,
-.Va i-search-*
-,
-.Va vi-search-*
+.Ic down-history ,
+.Ic expand-history ,
+.Ic history-search-backward ,
+.Ic history-search-forward ,
+.Ic i-search-back ,
+.Ic i-search-fwd ,
+.Ic toggle-literal-history ,
+.Ic vi-search-back ,
+.Ic vi-search-fwd ,
 and
-.Va toggle-literal-history
+.Ic up-history
 editor commands
 and the
-.Va histlit
+.Ic histlit
 shell variable.
 .Pp
 Enhanced directory parsing and directory stack handling.
 See the
-.Va cd
-,
-.Va pushd
-,
-.Va popd
+.Ic cd ,
+.Ic pushd ,
+.Ic popd ,
 and
-.Va dirs
+.Ic dirs
 commands and their associated
 shell variables, the description of
-.Va Directory stack substitution
-,
+.Sx Directory stack substitution ,
 the
-.Va dirstack
-,
-.Va owd
+.Ic dirstack ,
+.Ic owd ,
 and
-.Va symlinks
+.Ic symlinks
 shell variables and
 the
-.Va normalize-command
+.Ic normalize-command
 and
-.Va normalize-path
+.Ic normalize-path
 editor commands.
 .Pp
 Negation in glob-patterns.
 See
-.Va Filename substitution
+.Sx Filename substitution .
 .Pp
 New
-.Va File inquiry operators
+.Sx File inquiry operators
 (q.v.) and a
-.Va filetest
+.Ic filetest
 builtin which uses them.
 .Pp
 A variety of
-.Va Automatic, periodic and timed events
+.Sx Automatic, periodic and timed events
 (q.v.) including
 scheduled events, special aliases, automatic logout and terminal locking,
 command timing and watching for logins and logouts.
 .Pp
 Support for the Native Language System
 (see
-.Va Native Language System support
-),
+.Sx Native Language System support ) ,
 OS variant features
 (see
-.Va OS variant support
+.Sx OS variant support
 and the
-.Va echo_style
+.Ic echo_style
 shell variable)
 and system-dependent file locations (see
-.Va FILES
-).
+.Sx FILES ) .
 .Pp
 Extensive terminal-management capabilities.
 See
-.Va Terminal management
+.Sx Terminal management .
 .Pp
 New builtin commands including
-.Va builtins
-,
-.Va hup
-, \fIls\-F\fR,
-.Va newgrp
-,
-.Va printenv
-,
-.Va which
+.Ic builtins ,
+.Ic hup ,
+.Ic ls\-F ,
+.Ic newgrp ,
+.Ic printenv ,
+.Ic which ,
 and
-.Va where
+.Ic where
 (q.v.).
 .Pp
 New variables that make useful information easily available to the shell.
 See the
-.Va gid
-,
-.Va loginsh
-,
-.Va oid
-,
-.Va shlvl
-,
-.Va tcsh
-,
-.Va tty
-,
-.Va uid
+.Ic gid ,
+.Ic loginsh ,
+.Ic oid ,
+.Ic shlvl ,
+.Ic tcsh ,
+.Ic tty ,
+.Ic uid ,
 and
-.Va version
+.Ic version
 shell variables and the
-.Va HOST
-,
-.Va REMOTEHOST
-,
-.Va VENDOR
-,
-.Va OSTYPE
+.Ev HOST ,
+.Ev REMOTEHOST ,
+.Ev VENDOR ,
+.Ev OSTYPE ,
 and
-.Va MACHTYPE
+.Ev MACHTYPE
 environment
 variables.
 .Pp
 A new syntax for including useful information in the prompt string
 (see
-.Va prompt
-),
+.Ic prompt ) ,
 and special prompts for loops and spelling correction
 (see
-.Va prompt2
+.Ic prompt2
 and
-.Va prompt3
-).
+.Ic prompt3 ) .
 .Pp
 Read-only variables.
 See
-.Va Variable substitution
+.Sx Variable substitution .
+.
 .Sh BUGS
 When a suspended command is restarted, the shell prints the directory
 it started in if this is different from the current directory.
@@ -9482,18 +9621,20 @@ be misleading (i.e., wrong) as the job may have changed directories internally.
 Shell builtin functions are not stoppable/restartable.
 Command sequences
 of the form
-.Sq a ; b ; c
+.Ql a \&; b \&; c
 are also not handled gracefully when stopping is
 attempted.
 If you suspend
-.Sq b
-, the shell will then immediately execute
-`c'.
+.Ql b ,
+the shell will then immediately execute
+.Ql c .
 This is especially noticeable if this expansion results from an
-.Va alias
-It suffices to place the sequence of commands in ()'s to force it
+.Ic alias .
+It suffices to place the sequence of commands in
+.Ql () Ns
+\&'s to force it
 to a subshell, i.e.,
-.Sq ( a ; b ; c )
+.Ql \&( a \&; b \&; c \&) .
 .Pp
 Control over tty output after processes are started is primitive; perhaps
 this will inspire someone to work on a good virtual terminal interface.
@@ -9507,65 +9648,65 @@ Control structures should be parsed rather than being recognized as
 built-in commands.
 This would allow control commands to be placed anywhere,
 to be combined with
-.Sq |
-, and to be used with
-.Sq &
+.Ql | ,
+and to be used with
+.Ql &
 and
-.Sq ;
+.Ql \&;
 metasyntax.
 .Pp
-.Va foreach
+.Ic foreach
 doesn't ignore here documents when looking for its
-.Va end
+.Ic end .
 .Pp
 It should be possible to use the
-.Sq \&:
+.Ql \&:
 modifiers on the output of command
 substitutions.
 .Pp
 The screen update for lines longer than the screen width is very poor
 if the terminal cannot move the cursor up (i.e., terminal type
-.Sq dumb
-).
+.Ql dumb ) .
 .Pp
-.Va HPATH
+.Ev HPATH
 and
-.Va NOREBIND
+.Ev NOREBIND
 don't need to be environment variables.
 .Pp
 Glob-patterns which do not use
-.Sq \&?
-,
-.Sq *
+.Ql \&? ,
+.Ql * ,
 or
-.Sq []
+.Ql [] ,
 or which use
-.Sq {}
+.Ql {}
 or
-.Sq ~
+.Ql ~
 are not negated correctly.
 .Pp
 The single-command form of
-.Va if
+.Ic if
 does output redirection even if
 the expression is false and the command is not executed.
 .Pp
-\fIls\-F\fR includes file identification characters when sorting filenames
+.Ic ls\-F
+includes file identification characters when sorting filenames
 and does not handle control characters in filenames well.
 It cannot be
 interrupted.
 .Pp
 Command substitution supports multiple commands and conditions, but not
 cycles or backward
-.Va goto
+.Ic goto Ns
 s.
 .Pp
-Report bugs at https://bugs.astron.com/, preferably with fixes.
+Report bugs at
+.Lk https://bugs.astron.com/
+preferably with fixes.
 If you want to
 help maintain and test tcsh, add yourself to the mailing list in
-https://mailman.astron.com/.
-.Sq subscribe tcsh
-on a line by itself in the body.
+.Lk https://mailman.astron.com/
+.
 .Sh THE T IN TCSH
 In 1964, DEC produced the PDP-6.
 The PDP-10 was a later re-implementation.
@@ -9598,6 +9739,7 @@ supervisor call mechanism [are my IBM roots also showing?]).
 .Pp
 The creator of tcsh was impressed by this feature and several others of TENEX
 and TOPS-20, and created a version of csh which mimicked them.
+.
 .Sh LIMITATIONS
 The system limits argument lists to ARG_MAX characters.
 .Pp
@@ -9608,218 +9750,248 @@ Command substitutions may substitute no more characters than are allowed in
 an argument list.
 .Pp
 To detect looping, the shell restricts the number of
-.Va alias
+.Ic alias
 substitutions on a single line to 20.
+.
 .Sh "SEE ALSO"
-csh(1), emacs(1), ls(1), newgrp(1), sh(1), setpath(1), stty(1), su(1),
-tset(1), vi(1), x(1), access(2), execve(2), fork(2), killpg(2),
-pipe(2), setrlimit(2), sigvec(2), stat(2), umask(2), vfork(2), wait(2),
-malloc(3), setlocale(3), tty(4), a.out(5), termcap(5), environ(7),
-termio(7), Introduction to the C Shell
+.Xr csh 1 ,
+.Xr emacs 1 ,
+.Xr ls 1 ,
+.Xr newgrp 1 ,
+.Xr sh 1 ,
+.Xr setpath 1 ,
+.Xr stty 1 ,
+.Xr su 1 ,
+.Xr tset 1 ,
+.Xr vi 1 ,
+.Xr x 1 ,
+.Xr access 2 ,
+.Xr execve 2 ,
+.Xr fork 2 ,
+.Xr killpg 2 ,
+.Xr pipe 2 ,
+.Xr setrlimit 2 ,
+.Xr sigvec 2 ,
+.Xr stat 2 ,
+.Xr umask 2 ,
+.Xr vfork 2 ,
+.Xr wait 2 ,
+.Xr malloc 3 ,
+.Xr setlocale 3 ,
+.Xr tty 4 ,
+.Xr a.out 5 ,
+.Xr termcap 5 ,
+.Xr environ 7 ,
+.Xr termio 7 ,
+.Em Introduction to the C Shell
+.
 .Sh VERSION
 .\" UPDATE NEXT LINE FOR RELEASE
 This manual documents tcsh 6.24.01 (Astron) 2022-05-12.
+.
 .Sh AUTHORS
-.PD 0
-.TP 2
-William Joy
+.
+.Bl -tag -width 2n -compact
+.
+.It William Joy
 Original author of
 .Xr csh 1
-.TP 2
-J.E. Kulp, IIASA, Laxenburg, Austria
+.
+.It J.E. Kulp, IIASA, Laxenburg, Austria
 Job control and directory stack features
-.TP 2
-Ken Greer, HP Labs, 1981
+.
+.It Ken Greer, HP Labs, 1981
 File name completion
-.TP 2
-Mike Ellis, Fairchild, 1983
+.
+.It Mike Ellis, Fairchild, 1983
 Command name recognition/completion
-.TP 2
-Paul Placeway, Ohio State CIS Dept., 1983-1993
+.
+.It Paul Placeway, Ohio State CIS Dept., 1983-1993
 Command line editor, prompt routines, new glob syntax and numerous fixes
 and speedups
-.TP 2
-Karl Kleinpaste, CCI 1983-4
+.
+.It Karl Kleinpaste, CCI 1983-4
 Special aliases, directory stack extraction stuff, login/logout watch,
 scheduled events, and the idea of the new prompt format
-.TP 2
-Rayan Zachariassen, University of Toronto, 1984
-\fIls\-F\fR and
-.Va which
+.
+.It Rayan Zachariassen, University of Toronto, 1984
+.Ic ls\-F
+and
+.Ic which
 builtins and numerous bug fixes, modifications
 and speedups
-.TP 2
-Chris Kingsley, Caltech
+.
+.It Chris Kingsley, Caltech
 Fast storage allocator routines
-.TP 2
-Chris Grevstad, TRW, 1987
+.
+.It Chris Grevstad, TRW, 1987
 Incorporated 4.3BSD
 .Xr csh 1
 into
 .Nm
-.TP 2
-Christos S. Zoulas, Cornell U. EE Dept., 1987-94
+.
+.It Christos S. Zoulas, Cornell U. EE Dept., 1987-94
 Ports to HPUX, SVR2 and SVR3, a SysV version of getwd.c, SHORT_STRINGS support
 and a new version of sh.glob.c
-.TP 2
-James J Dempsey, BBN, and Paul Placeway, OSU, 1988
+.
+.It James J Dempsey, BBN, and Paul Placeway, OSU, 1988
 A/UX port
-.TP 2
-Daniel Long, NNSC, 1988
-.Va wordchars
-.TP 2
-Patrick Wolfe, Kuck and Associates, Inc., 1988
-.Va vi
+.
+.It Daniel Long, NNSC, 1988
+.Ic wordchars
+.
+.It Patrick Wolfe, Kuck and Associates, Inc., 1988
+.Ic vi
 mode cleanup
-.TP 2
-David C Lawrence, Rensselaer Polytechnic Institute, 1989
-.Va autolist
+.
+.It David C Lawrence, Rensselaer Polytechnic Institute, 1989
+.Ic autolist
 and ambiguous completion listing
-.TP 2
-Alec Wolman, DEC, 1989
+.
+.It Alec Wolman, DEC, 1989
 Newlines in the prompt
-.TP 2
-Matt Landau, BBN, 1989
-.Va ~/.tcshrc
-.TP 2
-Ray Moody, Purdue Physics, 1989
+.
+.It Matt Landau, BBN, 1989
+.Pa ~/.tcshrc
+.
+.It Ray Moody, Purdue Physics, 1989
 Magic space bar history expansion
-.TP 2
-Mordechai ????, Intel, 1989
+.
+.It Mordechai ????, Intel, 1989
 printprompt() fixes and additions
-.TP 2
-Kazuhiro Honda, Dept. of Computer Science, Keio University, 1989
+.
+.It Kazuhiro Honda, Dept. of Computer Science, Keio University, 1989
 Automatic spelling correction and
-.Va prompt3
-.TP 2
-Per Hedeland, Ellemtel, Sweden, 1990-
+.Ic prompt3
+.
+.It Per Hedeland, Ellemtel, Sweden, 1990-
 Various bugfixes, improvements and manual updates
-.TP 2
-Hans J. Albertsson (Sun Sweden)
-.Va ampm
-,
-.Va settc
+.
+.It Hans J. Albertsson (Sun Sweden)
+.Ic ampm ,
+.Ic settc ,
 and
-.Va telltc
-.TP 2
-Michael Bloom
+.Ic telltc
+.
+.It Michael Bloom
 Interrupt handling fixes
-.TP 2
-Michael Fine, Digital Equipment Corp
+.
+.It Michael Fine, Digital Equipment Corp
 Extended key support
-.TP 2
-Eric Schnoebelen, Convex, 1990
+.
+.It Eric Schnoebelen, Convex, 1990
 Convex support, lots of
 .Xr csh 1
 bug fixes,
 save and restore of directory stack
-.TP 2
-Ron Flax, Apple, 1990
+.
+.It Ron Flax, Apple, 1990
 A/UX 2.0 (re)port
-.TP 2
-Dan Oscarsson, LTH Sweden, 1990
+.
+.It Dan Oscarsson, LTH Sweden, 1990
 NLS support and simulated NLS support for non NLS sites, fixes
-.TP 2
-Johan Widen, SICS Sweden, 1990
-.Va shlvl
-, Mach support,
-.Va correct-line
-, 8-bit printing
-.TP 2
-Matt Day, Sanyo Icon, 1990
+.
+.It Johan Widen, SICS Sweden, 1990
+.Ic shlvl ,
+Mach support,
+.Ic correct-line ,
+8-bit printing
+.
+.It Matt Day, Sanyo Icon, 1990
 POSIX termio support, SysV limit fixes
-.TP 2
-Jaap Vermeulen, Sequent, 1990-91
+.
+.It Jaap Vermeulen, Sequent, 1990-91
 Vi mode fixes, expand-line, window change fixes, Symmetry port
-.TP 2
-Martin Boyer, Institut de recherche d'Hydro-Quebec, 1991
-.Va autolist
+.
+.It Martin Boyer, Institut de recherche d'Hydro-Quebec, 1991
+.Ic autolist
 beeping options, modified the history search to search for
 the whole string from the beginning of the line to the cursor.
-.TP 2
-Scott Krotz, Motorola, 1991
+.
+.It Scott Krotz, Motorola, 1991
 Minix port
-.TP 2
-David Dawes, Sydney U. Australia, Physics Dept., 1991
+.
+.It David Dawes, Sydney U. Australia, Physics Dept., 1991
 SVR4 job control fixes
-.TP 2
-Jose Sousa, Interactive Systems Corp., 1991
+.
+.It Jose Sousa, Interactive Systems Corp., 1991
 Extended
-.Va vi
+.Ic vi
 fixes and
-.Va vi
+.Ic vi
 delete command
-.TP 2
-Marc Horowitz, MIT, 1991
+.
+.It Marc Horowitz, MIT, 1991
 ANSIfication fixes, new exec hashing code, imake fixes,
-.Va where
-.TP 2
-Bruce Sterling Woodcock, sterling@netcom.com, 1991-1995
+.Ic where
+.
+.It Bruce Sterling Woodcock, sterling@netcom.com, 1991-1995
 ETA and Pyramid port, Makefile and lint fixes,
-.Va ignoreeof
+.Ic ignoreeof Ns
 =n addition, and
 various other portability changes and bug fixes
-.TP 2
-Jeff Fink, 1992
-.Va complete-word-fwd
+.
+.It Jeff Fink, 1992
+.Ic complete-word-fwd
 and
-.Va complete-word-back
-.TP 2
-Harry C. Pulley, 1992
+.Ic complete-word-back
+.
+.It Harry C. Pulley, 1992
 Coherent port
-.TP 2
-Andy Phillips, Mullard Space Science Lab U.K., 1992
+.
+.It Andy Phillips, Mullard Space Science Lab U.K., 1992
 VMS-POSIX port
-.TP 2
-Beto Appleton, IBM Corp., 1992
+.
+.It Beto Appleton, IBM Corp., 1992
 Walking process group fixes,
 .Xr csh 1
 bug fixes,
 POSIX file tests, POSIX SIGHUP
-.TP 2
-Scott Bolte, Cray Computer Corp., 1992
+.
+.It Scott Bolte, Cray Computer Corp., 1992
 CSOS port
-.TP 2
-Kaveh R. Ghazi, Rutgers University, 1992
+.
+.It Kaveh R. Ghazi, Rutgers University, 1992
 Tek, m88k, Titan and Masscomp ports and fixes.
 Added autoconf support.
-.TP 2
-Mark Linderman, Cornell University, 1992
+.
+.It Mark Linderman, Cornell University, 1992
 OS/2 port
-.TP 2
-Mika Liljeberg, liljeber@kruuna.Helsinki.FI, 1992
+.
+.It Mika Liljeberg, liljeber@kruuna.Helsinki.FI, 1992
 Linux port
-.TP 2
-Tim P. Starrin, NASA Langley Research Center Operations, 1993
+.
+.It Tim P. Starrin, NASA Langley Research Center Operations, 1993
 Read-only variables
-.TP 2
-Dave Schweisguth, Yale University, 1993-4
+.
+.It Dave Schweisguth, Yale University, 1993-4
 New man page and tcsh.man2html
-.TP 2
-Larry Schwimmer, Stanford University, 1993
+.
+.It Larry Schwimmer, Stanford University, 1993
 AFS and HESIOD patches
-.TP 2
-Luke Mewburn, RMIT University, 1994-6
+.
+.It Luke Mewburn, RMIT University, 1994-6
 Enhanced directory printing in prompt,
 added
-.Va ellipsis
+.Ic ellipsis
 and
-.Va rprompt
-.TP 2
-Edward Hutchins, Silicon Graphics Inc., 1996
+.Ic rprompt .
+.
+.It Edward Hutchins, Silicon Graphics Inc., 1996
 Added implicit cd.
-.TP 2
-Martin Kraemer, 1997
+.
+.It Martin Kraemer, 1997
 Ported to Siemens Nixdorf EBCDIC machine
-.TP 2
-Amol Deshpande, Microsoft, 1997
+.
+.It Amol Deshpande, Microsoft, 1997
 Ported to WIN32 (Windows/95 and Windows/NT); wrote all the missing library
 and message catalog code to interface to Windows.
-.TP 2
-Taga Nayuta, 1998
+.
+.It Taga Nayuta, 1998
 Color ls additions.
-.PD
-.Pp
+.
+.El
+.
 .Sh "THANKS TO"
 Bryan Dunlap, Clayton Elwell, Karl Kleinpaste, Bob Manson, Steve Romig,
 Diana Smetters, Bob Sutterfield, Mark Verber, Elizabeth Zwicky and all

--- a/tcsh.man.new
+++ b/tcsh.man.new
@@ -933,6 +933,8 @@ on terminals without a meta key.
 Case counts, but commands that are bound
 to letters by default are bound to both lower- and uppercase letters for
 convenience.
+.Pp
+Supported editor commands are:
 .Bl -tag -width indent
 .
 .It Ic backward-char No (^B, left)
@@ -1575,11 +1577,13 @@ controlled by the
 .Ic echo_style
 shell variable.
 .Pp
+Supported escape sequences are:
+.Pp
 .Bl -tag -width 12n -offset indent -compact
 .It Li \ea
-Bell
+Bell.
 .It Li \eb
-Backspace
+Backspace.
 .It Li \ec Ns Ar c
 The control character denoted by
 .Ql ^ Ns Ar c
@@ -1589,38 +1593,38 @@ If
 .Ar c
 is a backslash, it must be doubled.
 .It Li \ee
-Escape
+Escape.
 .It Li \ef
-Form feed
+Form feed.
 .It Li \en
-Newline
+Newline.
 .It Li \er
-Carriage return
+Carriage return.
 .It Li \et
-Horizontal tab
+Horizontal tab.
 .It Li \ev
-Vertical tab
+Vertical tab.
 .It Li \e\e
-Literal backslash
+Literal backslash.
 .It Li \e\&'
-Literal single quote
+Literal single quote.
 .It Li \e\&"
-Literal double quote
+Literal double quote.
 .It Li \e Ns Ar nnn
 The character corresponding to the octal number
-.Ar nnn
+.Ar nnn .
 .It Li \ex Ns Ar nn
 The character corresponding to the hexadecimal number
 .Ar nn
-(1\-2 hexadecimal digits)
+(1\-2 hexadecimal digits).
 .It Li \ex{ Ns Ar nnnnnnnn Ns Li }
 The character corresponding to the hexadecimal number
 .Ar nnnnnnnn
-(1\-8 hexadecimal digits)
+(1\-8 hexadecimal digits).
 .It Li \eu Ns Ar nnnn
 The Unicode code point
 .Ar nnnn
-(1\-4 hexadecimal digits)
+(1\-4 hexadecimal digits).
 .It Li \eU Ns Ar nnnnnnnn
 The Unicode code point
 .Ar nnnnnnnn
@@ -1733,17 +1737,17 @@ which selects particular words from the chosen event, and/or a
 .Dq modifier ,
 which manipulates the selected words.
 .Pp
-An event specification can be
+An event specification can be:
 .Pp
 .Bl -tag -width 5n -offset indent -compact
 .
 .It Ar n
-A number, referring to a particular event
+A number, referring to a particular event.
 .
 .It Li \- Ns Ar n
 An offset, referring to the event
 .Ar n
-before the current event
+before the current event.
 .
 .It Li #
 The current event.
@@ -1755,11 +1759,11 @@ allows 10 levels of recursion. (+)
 .
 .It Li \&!
 The previous event (equivalent to
-.Ql \-1 )
+.Ql \-1 ) .
 .
 .It Ar s
 The most recent event whose first word begins with the string
-.Ar s
+.Ar s .
 .
 .It Li ? Ns Ar s Ns Li ?
 The most recent event which contains the string
@@ -1841,7 +1845,7 @@ To expand
 .Ql !3d
 as in
 .Xr csh 1
-say
+type
 .Ql !{3}d .
 .Pp
 To select words from an event we can follow the event specification by a
@@ -1850,50 +1854,51 @@ and a designator for the desired words.
 The words of an input line are
 numbered from 0, the first (usually command) word being 0, the second word
 (first argument) being 1, etc.
+.Pp
 The basic word designators are:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
 .
 .It Li 0
-The first (command) word
+The first (command) word.
 .
 .It Ar n
 The
 .Ar n Ns
-th argument
+th argument.
 .
 .It Li ^
 The first argument, equivalent to
-.Ql 1
+.Ql 1 .
 .
 .It Li $
-The last argument
+The last argument.
 .
 .It Li %
 The word matched by an
-.Li ? Ns Ar s Ns Li ? No search
+.Li ? Ns Ar s Ns Li ? No search.
 .
 .It Ar x Ns Li \- Ns Ar y
-A range of words
+A range of words.
 .
 .It Li \- Ns Ar y
 Equivalent to
-.Ql 0\- Ns Ar y
+.Ql 0\- Ns Ar y .
 .
 .It Li *
 Equivalent to
 .Ql ^\-$ ,
-but returns nothing if the event contains only 1 word
+but returns nothing if the event contains only 1 word.
 .
 .It Ar x Ns Li *
 Equivalent to
-.Sq Ar x Ns Li \-$
+.Sq Ar x Ns Li \-$ .
 .
 .It Ar x Ns Li \-
 Equivalent to
 .Sq Ar x Ns Li * ,
 but omitting the last word
-.Pq Ql $
+.Pq Ql $ .
 .El
 .Pp
 Selected words are inserted into the command line separated by single blanks.
@@ -1928,7 +1933,7 @@ to refer to the current event.
 would reuse the first two words from the
 .Ql nroff
 command
-to say
+to type
 .Ql nroff \-man hurkle.man .
 .Pp
 The
@@ -2089,16 +2094,18 @@ to remove
 .Ql .old
 from the first argument on the same line
 (`!#^').
-We could say
+We could type
 .Ql echo hello out there ,
 then
 .Ql echo !*:u
 to capitalize
 .Ql hello ,
 .Ql echo !*:au
-to say it out loud, or
+to upper case the first word to
+.QL HELLO ,
+or
 .Ql echo !*:agu
-to really shout.
+to upper case all words.
 We might follow
 .Ql mail \-s \&"I forgot my password\&" rot
 with
@@ -2361,9 +2368,7 @@ multiple words with each word separated by a blank and quoted to prevent later
 command or filename substitution.
 .Pp
 The following metasequences are provided for introducing variable values into
-the shell input.
-Except as noted, it is an error to reference a variable which
-is not set.
+the shell input:
 .Pp
 .Bl -tag -width 10n -offset indent -compact
 .
@@ -2432,6 +2437,9 @@ which is equivalent to
 .Ql $argv[*] .
 .El
 .Pp
+Except as noted, it is an error to reference a variable which
+is not set.
+.Pp
 The
 .Ql \&:
 modifiers described under
@@ -2449,7 +2457,7 @@ within the braces.
 .Pp
 The following substitutions can not be modified with
 .Ql \&:
-modifiers.
+modifiers:
 .Pp
 .Bl -tag -width 10n -offset indent -compact
 .
@@ -3082,7 +3090,9 @@ is given in
 is allowed on empty files;
 if
 .Ql ask
-is set, an interacive confirmation is presented, rather than an
+is given in
+.Ic noclobber ,
+an interacive confirmation is presented, rather than an
 error.
 .Pp
 The forms involving
@@ -3198,7 +3208,7 @@ builtin command (q.v.) has its own separate syntax.
 .
 .Ss "Logical, arithmetical and comparison operators"
 These operators are similar to those of C and have the same precedence.
-They include
+They include:
 .Pp
 .Bl -tag -width 6n -offset indent -compact
 .It Li "||  &&  |  ^  &  ==  !=  =~  !~  <=  >="
@@ -3298,18 +3308,18 @@ They are of the form
 .Fl Ar op file ,
 where
 .Ar op
-is one of
+is one of:
 .Pp
 .Bl -tag -width 3n -offset indent -compact
 .
 .It Li r
-Read access
+Read access.
 .
 .It Li w
-Write access
+Write access.
 .
 .It Li x
-Execute access
+Execute access.
 .
 .It Li X
 Executable in the path or shell builtin, e.g.,
@@ -3319,61 +3329,61 @@ and
 are
 generally true, but
 .Ql \-X /bin/ls
-is not (+)
+is not. (+)
 .
 .It Li e
-Existence
+Existence.
 .
 .It Li o
-Ownership
+Ownership.
 .
 .It Li z
-Zero size
+Zero size.
 .
 .It Li s
-Non-zero size (+)
+Non-zero size. (+)
 .
 .It Li f
-Plain file
+Plain file.
 .
 .It Li d
-Directory
+Directory.
 .
 .It Li l
-Symbolic link (+) *
+Symbolic link. (+) *
 .
 .It Li b
-Block special file (+)
+Block special file. (+)
 .
 .It Li c
-Character special file (+)
+Character special file. (+)
 .
 .It Li p
-Named pipe (fifo) (+) *
+Named pipe (fifo). (+) *
 .
 .It Li S
-Socket special file (+) *
+Socket special file. (+) *
 .
 .It Li u
-Set-user-ID bit is set (+)
+Set-user-ID bit is set. (+)
 .
 .It Li g
-Set-group-ID bit is set (+)
+Set-group-ID bit is set. (+)
 .
 .It Li k
-Sticky bit is set (+)
+Sticky bit is set. (+)
 .
 .It Li t
 .Ar file
 (which must be a digit) is an open file descriptor
-for a terminal device (+)
+for a terminal device. (+)
 .
 .It Li R
-Has been migrated (Convex only) (+)
+Has been migrated (Convex only). (+)
 .
 .It Li L
 Applies subsequent operators in a multiple-operator test to a symbolic link
-rather than to the file to which the link points (+) *
+rather than to the file to which the link points. (+) *
 .El
 .Pp
 .Ar file
@@ -3435,61 +3445,61 @@ or
 (+)
 They have the same format as before;
 .Ar op
-may be one of
+may be one of:
 .Pp
 .Bl -tag -width 6n -offset indent -compact
 .
 .It Li A
-Last file access time, as the number of seconds since the epoch
+Last file access time, as the number of seconds since the epoch.
 .
 .It Li A:
 Like
 .Ql A ,
 but in timestamp format, e.g.,
-.Sq Fri May 14 16:36:10 1993
+.Sq Fri May 14 16:36:10 1993 .
 .
 .It Li M
-Last file modification time
+Last file modification time.
 .
 .It Li M:
 Like
 .Ql M ,
-but in timestamp format
+but in timestamp format.
 .
 .It Li C
-Last inode modification time
+Last inode modification time.
 .
 .It Li C:
 Like
 .Ql C ,
-but in timestamp format
+but in timestamp format.
 .
 .It Li D
-Device number
+Device number.
 .
 .It Li I
-Inode number
+Inode number.
 .
 .It Li F
 Composite
 .Li f Ns
 ile identifier, in the form
 .Ar device : Ns
-.Ar inode
+.Ar inode .
 .
 .It Li L
-The name of the file pointed to by a symbolic link
+The name of the file pointed to by a symbolic link.
 .
 .It Li N
-Number of (hard) links
+Number of (hard) links.
 .
 .It Li P
-Permissions, in octal, without leading zero
+Permissions, in octal, without leading zero.
 .
 .It Li P:
 Like
 .Ql P ,
-with leading zero
+with leading zero.
 .
 .It Li P Ns Ar mode
 Equivalent to
@@ -3505,27 +3515,27 @@ is writable by group and other,
 if by group only,
 and
 .Sq 0
-if by neither
+if by neither.
 .
 .It Li P Ns Ar mode Ns Li \&:
 Like
 .Ql P Ns Ar mode ,
-with leading zero
+with leading zero.
 .
 .It Li U
-Numeric userid
+Numeric userid.
 .
 .It Li U:
-Username, or the numeric userid if the username is unknown
+Username, or the numeric userid if the username is unknown.
 .
 .It Li G
-Numeric groupid
+Numeric groupid.
 .
 .It Li G:
-Groupname, or the numeric groupid if the groupname is unknown
+Groupname, or the numeric groupid if the groupname is unknown.
 .
 .It Li Z
-Size, in bytes
+Size, in bytes.
 .El
 .Pp
 Only one of these operators may appear in a multiple-operator test, and it
@@ -3665,7 +3675,7 @@ is a synonym
 for
 .Ql fg %1 ,
 bringing job 1 back into the foreground.
-Similarly, saying
+Similarly, typing
 .Ql %1 &
 resumes job 1 in the background, just like
 .Ql bg %1 .
@@ -3678,7 +3688,7 @@ normally restart a suspended
 job, if there were only one suspended
 job whose name began with the string
 .Ql ex .
-It is also possible to say
+It is also possible to type
 .Ql %? Ns Ar string
 to specify a job whose text contains
 .Ar string ,
@@ -3740,7 +3750,7 @@ single process so that its status changes will be immediately reported.
 By
 default
 .Ic notify
-marks the current process; simply say
+marks the current process; simply enter
 .Ql notify
 after
 starting a background job to mark it.
@@ -3852,7 +3862,11 @@ When using the system's NLS, the
 .Xr setlocale 3
 function is called
 to determine appropriate character code/classification and sorting
-(e.g., a 'en_CA.UTF-8' would yield "UTF-8" as a character code).
+(e.g.,
+.Sq en_CA.UTF-8
+would yield
+.Sq UTF-8
+as the character code).
 This function typically examines the
 .Ev LANG
 and
@@ -4113,6 +4127,7 @@ The second form assigns the value of
 .Ar expr
 to
 .Ar name .
+.Pp
 The third form assigns the value of
 .Ar expr
 to the
@@ -4233,42 +4248,25 @@ as described under
 .It Ic bindkey Oo Fl l Ns | Ns Fl d Ns | Ns Fl e Ns | Ns Fl v Ns | Ns Fl u Oc No (+)
 .It Ic bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl r Oc Oo Fl \- Oc Ar key No (+)
 .It Ic bindkey Oo Fl a Oc Oo Fl b Oc Oo Fl k Oc Oo Fl c Ns | Ns Fl s Oc Oo Fl \- Oc Ar key command No (+)
-Without options, the first form lists all bound keys and the editor command to which each is bound,
-the second form lists the editor command to which
+The first form either lists all bound keys and the editor
+command to which each is bound,
+lists a description of the commands,
+or binds all keys to a specific mode.
+.Pp
+The second form lists the editor command to which
 .Ar key
-is bound and
-the third form binds the editor command
+is bound.
+.Pp
+The third form binds the editor command
 .Ar command
 to
 .Ar key .
-Options include:
+.Pp
+Supported
+.Ic bindkey
+options:
 .Pp
 .Bl -tag -width 5n -offset indent -compact
-.
-.It Fl l
-Lists all editor commands and a short description of each.
-.
-.It Fl d
-Binds all keys to the standard bindings for the default editor,
-as per
-.Fl e
-and
-.Fl v
-below.
-.
-.It Fl e
-Binds all keys to
-.Xr emacs 1 Ns
-\-style bindings.
-Unsets
-.Ic vimode .
-.
-.It Fl v
-Binds all keys to
-.Xr vi 1 Ns
-\-style bindings.
-Sets
-.Ic vimode .
 .
 .It Fl a
 Lists or changes key-bindings in the alternative key map.
@@ -4300,6 +4298,25 @@ or an extended prefix key written
 (e.g.,
 .Sq X-A ) .
 .
+.It Fl c
+.Ar command
+is interpreted as a builtin or external command instead of an
+editor command.
+.
+.It Fl d
+Binds all keys to the standard bindings for the default editor,
+as per
+.Fl e
+and
+.Fl v .
+.
+.It Fl e
+Binds all keys to
+.Xr emacs 1 Ns
+\-style bindings.
+Unsets
+.Ic vimode .
+.
 .It Fl k
 .Ar key
 is interpreted as a symbolic arrow key name, which may be one of
@@ -4308,6 +4325,9 @@ is interpreted as a symbolic arrow key name, which may be one of
 .Sq left ,
 or
 .Sq right .
+.
+.It Fl l
+Lists all editor commands and a short description of each.
 .
 .It Fl r
 Removes
@@ -4325,11 +4345,6 @@ to
 .Ar key
 completely.
 .
-.It Fl c
-.Ar command
-is interpreted as a builtin or external command instead of an
-editor command.
-.
 .It Fl s
 .Ar command
 is taken as a literal string and treated as terminal input when
@@ -4340,15 +4355,22 @@ Bound keys in
 are themselves
 reinterpreted, and this continues for ten levels of interpretation.
 .
+.It Fl u No (or any invalid option)
+Prints a usage message.
+.
+.It Fl v
+Binds all keys to
+.Xr vi 1 Ns
+\-style bindings.
+Sets
+.Ic vimode .
+.
 .It Fl \-
 Forces a break from option processing, so the next word is taken as
 .Ar key
 even if it begins with
 .Ql \- .
 .
-.It Fl u
-(or any invalid option).
-Prints a usage message.
 .El
 .Pp
 .Ar key
@@ -4381,24 +4403,24 @@ as follows:
 .Bl -tag -width 5n -offset indent -compact
 .
 .It Li \ea
-Bell
+Bell.
 .It Li \eb
-Backspace
+Backspace.
 .It Li \ee
-Escape
+Escape.
 .It Li \ef
-Form feed
+Form feed.
 .It Li \en
-Newline
+Newline.
 .It Li \er
-Carriage return
+Carriage return.
 .It Li \et
-Horizontal tab
+Horizontal tab.
 .It Li \ev
-Vertical tab
+Vertical tab.
 .It Li \e Ns Ar nnn
 The ASCII character corresponding to the octal number
-.Ar nnn
+.Ar nnn .
 .El
 .Pp
 .Ql \e
@@ -4623,65 +4645,65 @@ the list of possible completions, may be one of the following:
 .Bl -tag -width 5n -offset indent -compact
 .
 .It Li a
-Aliases
+Aliases.
 .
 .It Li b
-Bindings (editor commands)
+Bindings (editor commands).
 .
 .It Li c
-Commands (builtin or external commands)
+Commands (builtin or external commands).
 .
 .It Li C
-External commands which begin with the supplied path prefix
+External commands which begin with the supplied path prefix.
 .
 .It Li d
-Directories
+Directories.
 .
 .It Li D
-Directories which begin with the supplied path prefix
+Directories which begin with the supplied path prefix.
 .
 .It Li e
-Environment variables
+Environment variables.
 .
 .It Li f
-Filenames
+Filenames.
 .
 .It Li F
-Filenames which begin with the supplied path prefix
+Filenames which begin with the supplied path prefix.
 .
 .It Li g
-Groupnames
+Groupnames.
 .
 .It Li j
-Jobs
+Jobs.
 .
 .It Li l
-Limits
+Limits.
 .
 .It Li n
-Nothing
+Nothing.
 .
 .It Li s
-Shell variables
+Shell variables.
 .
 .It Li S
-Signals
+Signals.
 .
 .It Li t
 Plain
 .Dq ( text )
-files
+files.
 .
 .It Li T
 Plain
 .Dq ( text )
-files which begin with the supplied path prefix
+files which begin with the supplied path prefix.
 .
 .It Li v
-Any variables
+Any variables.
 .
 .It Li u
-Usernames
+Usernames.
 .
 .It Li x
 Like
@@ -4693,17 +4715,17 @@ when
 is used.
 .
 .It Li X
-Completions
+Completions.
 .
 .It Li $ Ns Ar var
 Words from the variable
-.Ar var
+.Ar var .
 .
 .It Li (...)
-Words from the given list
+Words from the given list.
 .
 .It Li \`...\`
-Words from the output of command
+Words from the output of command.
 .El
 .Pp
 .Ar select
@@ -4716,7 +4738,14 @@ are considered
 and the
 .Ic fignore
 shell variable is ignored.
-The last three types of completion may not have a
+The
+.Ar list
+types
+.Ql $ Ns Ar var ,
+.Ql (...) ,
+and
+.Ql \`...\`
+may not have a
 .Ar select
 pattern, and
 .Ql x
@@ -5161,7 +5190,7 @@ should be set in
 rather than
 .Pa ~/.login .
 .Pp
-The last form clears the directory stack.
+The third form clears the directory stack.
 .
 .El
 .Bl -tag -width 8n
@@ -5518,7 +5547,7 @@ If
 is set, the first and second forms print and save the literal
 (unexpanded) form of the history list.
 .Pp
-The last form clears the history list.
+The third form clears the history list.
 .
 .El
 .Bl -tag -width 8n
@@ -5647,12 +5676,14 @@ is provided, the process title will be cleared.
 .\" adjacant multi-tag items; add a blank
 .Pp
 .
+.It Ic kill Fl l
 .It Ic kill Xo
 .Op Fl s Ar signal
 .Cm % Ns Ar job Ns | Ns Ar pid No \&...
 .Xc
-.It Ic kill Fl l
-The first form sends the specified
+The first form lists the signal names.
+.Pp
+The second form sends the specified
 .Ar signal
 (or, if none
 is given, the TERM (terminate) signal) to the specified jobs or processes.
@@ -5671,14 +5702,13 @@ stripped of the prefix
 .Sq SIG ) .
 There is no default
 .Ar job ;
-saying just
+entering just
 .Ql kill
 does not send a signal
 to the current job.
 If the signal being sent is TERM (terminate)
 or HUP (hangup), then the job or process is sent a
 CONT (continue) signal as well.
-The second form lists the signal names.
 .
 .El
 .Bl -tag -width 8n
@@ -5711,66 +5741,91 @@ Controllable
 .Ar resource
 types currently include (if supported by the OS):
 .Bl -tag -width 12n -offset indent
+.
 .It Ic cputime
-the maximum number of cpu-seconds to be used by each process
+Maximum number of cpu-seconds to be used by each process.
+.
 .It Ic filesize
-the largest single file which can be created
+Largest single file which can be created.
+.
 .It Ic datasize
-the maximum growth of the data+stack region via
+Maximum growth of the data+stack region via
 .Xr sbrk 2
-beyond the end of the program text
+beyond the end of the program text.
+.
 .It Ic stacksize
-the maximum size of the automatically-extended stack region
+Maximum size of the automatically-extended stack region.
+.
 .It Ic coredumpsize
-the size of the largest core dump that will be created
+Size of the largest core dump that will be created.
+.
 .It Ic memoryuse
-the maximum amount of physical memory a process
-may have allocated to it at a given time
+Maximum amount of physical memory a process
+may have allocated to it at a given time.
+.
 .It Ic vmemoryuse
-the maximum amount of virtual memory a process
-may have allocated to it at a given time (address space)
+Maximum amount of virtual memory a process
+may have allocated to it at a given time (address space).
+.
 .It Ic heapsize
-the maximum amount of memory a process
+Maximum amount of memory a process
 may allocate per
 .Xr brk 2
-system call
+system call.
+.
 .It Ic descriptors No or Ic openfiles
-the maximum number of open files for this process
+Maximum number of open files for this process.
+.
 .It Ic pseudoterminals
-the maximum number of pseudo-terminals for this user
+Maximum number of pseudo-terminals for this user.
+.
 .It Ic kqueues
-the maximum number of kqueues allocated for this process
+Maximum number of kqueues allocated for this process.
+.
 .It Ic concurrency
-the maximum number of threads for this process
+Maximum number of threads for this process.
+.
 .It Ic memorylocked
-the maximum size which a process may lock into memory using
-.Xr mlock 2
+Maximum size which a process may lock into memory using
+.Xr mlock 2 .
+.
 .It Ic maxproc
-the maximum number of simultaneous processes for this user id
+Maximum number of simultaneous processes for this user id.
+.
 .It Ic maxthread
-the maximum number of simultaneous threads (lightweight processes) for this
-user id
+Maximum number of simultaneous threads (lightweight processes) for this
+user id.
+.
 .It Ic threads
-the maximum number of threads for this process
+Maximum number of threads for this process.
+.
 .It Ic sbsize
-the maximum size of socket buffer usage for this user
+Maximum size of socket buffer usage for this user.
+.
 .It Ic swapsize
-the maximum amount of swap space reserved or used for this user
+Maximum amount of swap space reserved or used for this user.
+.
 .It Ic maxlocks
-the maximum number of locks for this user
+Maximum number of locks for this user.
+.
 .It Ic posixlocks
-the maximum number of POSIX advisory locks for this user
+Maximum number of POSIX advisory locks for this user.
+.
 .It Ic maxsignal
-the maximum number of pending signals for this user
+Maximum number of pending signals for this user.
+.
 .It Ic maxmessage
-the maximum number of bytes in POSIX mqueues for this user
+Maximum number of bytes in POSIX mqueues for this user.
+.
 .It Ic maxnice
-the maximum nice priority the user is allowed to raise mapped from [19...-20]
-to [0...39] for this user
+Maximum nice priority the user is allowed to raise mapped from [19...-20]
+to [0...39] for this user.
+.
 .It Ic maxrtprio
-the maximum realtime priority for this user
+Maximum realtime priority for this user.
+.
 .It Ic maxrttime
-the timeout for RT tasks in microseconds for this user
+Timeout for RT tasks in microseconds for this user.
 .El
 .Pp
 .Ar maximum-use
@@ -5856,23 +5911,23 @@ special file in the listing with a special character:
 .Pp
 .Bl -tag -width 5n -offset indent -compact
 .It Li /
-Directory
+Directory.
 .It Li *
-Executable
+Executable.
 .It Li #
-Block device
+Block device.
 .It Li %
-Character device
+Character device.
 .It Li |
-Named pipe (systems with named pipes only)
+Named pipe (systems with named pipes only).
 .It Li =
-Socket (systems with sockets only)
+Socket (systems with sockets only).
 .It Li @
-Symbolic link (systems with symbolic links only)
+Symbolic link (systems with symbolic links only).
 .It Li +
-Hidden directory (AIX only) or context dependent (HP/UX only)
+Hidden directory (AIX only) or context dependent (HP/UX only).
 .It Li :
-Network special (HP/UX only)
+Network special (HP/UX only).
 .El
 .Pp
 If the
@@ -5882,11 +5937,11 @@ in more detail (on only systems that have them, of course):
 .Pp
 .Bl -tag -width 5n -offset indent -compact
 .It Li @
-Symbolic link to a non-directory
+Symbolic link to a non-directory.
 .It Li >
-Symbolic link to a directory
+Symbolic link to a directory.
 .It Li &
-Symbolic link to nowhere
+Symbolic link to nowhere.
 .El
 .Pp
 .Ic listlinks
@@ -5954,6 +6009,8 @@ environment variable.
 .It Ic migrate Fl Ar site No (+)
 The first form migrates the process or job to the site specified or the
 default site determined by the system path.
+(TCF only)
+.Pp
 The second form is equivalent to
 .Ql migrate \- Ns Ar site Li $$ :
 it migrates the
@@ -6316,17 +6373,21 @@ based on the time of day.
 The first form of the command prints the value of all shell variables.
 Variables which contain more than a single word print as a
 parenthesized word list.
+.Pp
 The second form sets
 .Ar name
 to the null string.
+.Pp
 The third form sets
 .Ar name
 to the single
 .Ar word .
+.Pp
 The fourth form sets
 .Ar name
 to the list of words in
 .Ar wordlist .
+.Pp
 In all cases the value is command and filename expanded.
 If
 .Fl r
@@ -6340,6 +6401,7 @@ are specified, set only unique words keeping their order.
 prefers the first occurrence of a word, and
 .Fl l
 the last.
+.Pp
 The fifth form sets the
 .Ar index Ns
 \&'th component of
@@ -6347,10 +6409,13 @@ The fifth form sets the
 to
 .Ar word ;
 this component must already exist.
+.Pp
 The sixth form lists only the names of all shell variables that are read-only.
+.Pp
 The seventh form makes
 .Ar name
 read-only, whether or not it has a value.
+.Pp
 The eighth form is the same as the third form, but
 make
 .Ar name
@@ -6532,7 +6597,7 @@ as described under
 .Sx Jobs .
 There is no default
 .Ar job ;
-saying just
+entering just
 .Ql stop
 does not stop
 the current job.
@@ -6808,6 +6873,8 @@ through the loop as with
 If set, each of these aliases executes automatically at the indicated time.
 They are all initially undefined.
 .Pp
+Supported special aliases are:
+.Pp
 .Bl -tag -width 8n
 .
 .It Ic beepcmd
@@ -7004,6 +7071,9 @@ converts between the different formats of
 .Ic path
 and
 .Ev PATH .
+.
+.Pp
+Supported special shell variables are:
 .
 .Bl -tag -width 8n
 .
@@ -7290,7 +7360,7 @@ and
 shell variables.
 .
 .It Ic dspmbyte No (+)
-Has an effect iff
+Has an effect only if
 .Ql dspm
 is listed as part of the
 .Ic version
@@ -7404,7 +7474,7 @@ command line option.
 The style of the
 .Ic echo
 builtin.
-May be set to
+May be set to:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
 .It Li bsd
@@ -7814,7 +7884,7 @@ shell variable.
 A list of files and directories to check for incoming mail, optionally
 preceded by a numeric word.
 Before each prompt, if 10 minutes have
-passed since the last check, the shell checks each file and says
+passed since the last check, the shell checks each file and displays
 .Sq You have new mail.
 (or, if
 .Ic mail
@@ -7881,6 +7951,14 @@ redirections refer to existing
 files, as described in the
 .Sx Input/output
 section.
+If contains
+.Ql ask ,
+an interacive confirmation is presented, rather than an
+error.
+If contains
+.Ql notempty ,
+.Ql >
+is allowed on empty files.
 .
 .It Ic noding
 If set, disable the printing of
@@ -8015,6 +8093,7 @@ prints
 .
 .It Ic prompt
 The string which is printed before reading each command from the terminal.
+.Pp
 .Ic prompt
 may include any of the following formatting sequences (+), which
 are replaced by the given information:
@@ -8575,7 +8654,9 @@ If there is a second word, it is used as a format string for the output
 of the
 .Ic time
 builtin.
+.Pp
 (u) The following sequences may be used in the
+.Ic time
 format string:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
@@ -8722,19 +8803,23 @@ and a comma-separated
 list of options which were set at compile time.
 Options which are set by default in the distribution are noted.
 .Pp
+Supported
+.Ic version
+options include:
+.Pp
 .Bl -tag -width 4n -offset indent -compact
 .
 .It Li 8b
-The shell is eight bit clean; default
+The shell is eight bit clean; default.
 .
 .It Li 7b
-The shell is not eight bit clean
+The shell is not eight bit clean.
 .
 .It Li wide
-The shell is multibyte encoding clean (like UTF-8)
+The shell is multibyte encoding clean (like UTF-8).
 .
 .It Li nls
-The system's NLS is used; default for systems with NLS
+The system's NLS is used; default for systems with NLS.
 .
 .It Li lf
 Login shells execute
@@ -8752,22 +8837,22 @@ and
 .Ql \&.
 is put last in
 .Ic path
-for security; default
+for security; default.
 .
 .It Li nd
 .Ql \&.
 is omitted from
 .Ic path
-for security
+for security.
 .
 .It Li vi
 .Xr vi 1 Ns
 \-style editing is the default rather than
 .Xr emacs 1 Ns
-\-style
+\-style.
 .
 .It Li dtr
-Login shells drop DTR when exiting
+Login shells drop DTR when exiting.
 .
 .It Li bye
 .Ic bye
@@ -8776,37 +8861,37 @@ is a synonym for
 and
 .Ic log
 is an alternate name for
-.Ic watchlog
+.Ic watchlog .
 .
 .It Li al
 .Ic autologout
-is enabled; default
+is enabled; default.
 .
 .It Li kan
 Kanji is used if appropriate according to locale settings,
 unless the
 .Ic nokanji
-shell variable is set
+shell variable is set.
 .
 .It Li sm
 The system's
 .Xr malloc 3
-is used
+is used.
 .
 .It Li hb
 The
 .Ql #!<program> <args>
-convention is emulated when executing shell scripts
+convention is emulated when executing shell scripts.
 .
 .It Li ng
 The
 .Ic newgrp
-builtin is available
+builtin is available.
 .
 .It Li rh
 The shell attempts to set the
 .Ev REMOTEHOST
-environment variable
+environment variable.
 .
 .It Li afs
 The shell verifies your password with the kerberos server if local
@@ -8980,6 +9065,20 @@ Equivalent to the
 .Ic afsuser
 shell variable.
 .
+.It Ev COMMAND_LINE
+Set by
+.Nm
+to the current command line when invoking programs
+for the
+.Ic complete
+.Ar list
+mode
+.Ql \`...\` .
+See
+.Ic complete
+in
+.Sq Builtin commands .
+.
 .It Ev COLUMNS
 The number of columns in the terminal.
 See
@@ -9055,40 +9154,41 @@ file format; a colon-separated list of expressions of the form
 where
 .Li \&" Ns Ar xx Ns Li \&"
 is a two-character variable name.
+.Pp
 The
 variables with their associated defaults are:
 .Pp
 .Bl -column -offset indent "Li XX" "Li XXXXX" 20n
 .
-.It Li no Ta Li 0 Ta Normal (non-filename) text
+.It Li no Ta Li 0 Ta Normal (non-filename) text.
 .
-.It Li fi Ta Li 0 Ta Regular file
+.It Li fi Ta Li 0 Ta Regular file.
 .
-.It Li di Ta Li 01;34 Ta Directory
+.It Li di Ta Li 01;34 Ta Directory.
 .
-.It Li ln Ta Li 01;36 Ta Symbolic link
+.It Li ln Ta Li 01;36 Ta Symbolic link.
 .
-.It Li pi Ta Li 33 Ta Named pipe (FIFO)
+.It Li pi Ta Li 33 Ta Named pipe (FIFO).
 .
-.It Li so Ta Li 01;35 Ta Socket
+.It Li so Ta Li 01;35 Ta Socket.
 .
-.It Li do Ta Li 01;35 Ta Door
+.It Li do Ta Li 01;35 Ta Door.
 .
-.It Li bd Ta Li 01;33 Ta Block device
+.It Li bd Ta Li 01;33 Ta Block device.
 .
-.It Li cd Ta Li 01;32 Ta Character device
+.It Li cd Ta Li 01;32 Ta Character device.
 .
-.It Li ex Ta Li 01;32 Ta Executable file
+.It Li ex Ta Li 01;32 Ta Executable file.
 .
-.It Li mi Ta (none) Ta Missing file (defaults to Li fi Ns )
+.It Li mi Ta (none) Ta Missing file (defaults to Li fi Ns ) .
 .
-.It Li or Ta (none) Ta Orphaned symbolic link (defaults to Li ln Ns )
+.It Li or Ta (none) Ta Orphaned symbolic link (defaults to Li ln Ns ) .
 .
-.It Li lc Ta Li ^[[ Ta Left code
+.It Li lc Ta Li ^[[ Ta Left code.
 .
-.It Li rc Ta Li m Ta Right code
+.It Li rc Ta Li m Ta Right code.
 .
-.It Li ec Ta (none) Ta End code (replaces Li lc Ns + Ns Li no Ns + Ns Li rc Ns )
+.It Li ec Ta (none) Ta End code (replaces Li lc Ns + Ns Li no Ns + Ns Li rc Ns ) .
 .
 .El
 .Pp
@@ -9150,70 +9250,71 @@ compose the type codes (i.e., all except the
 and
 .Ql ec
 codes) from numerical commands separated by semicolons.
+.Pp
 The
 most common commands are:
 .Pp
 .Bl -tag -width 4n -offset indent -compact
 .
 .It Li 0
-to restore default color
+To restore default color.
 .
 .It Li 1
-for brighter colors
+For brighter colors.
 .
 .It Li 4
-for underlined text
+For underlined text.
 .
 .It Li 5
-for flashing text
+For flashing text.
 .
 .It Li 30
-for black foreground
+For black foreground.
 .
 .It Li 31
-for red foreground
+For red foreground.
 .
 .It Li 32
-for green foreground
+For green foreground.
 .
 .It Li 33
-for yellow (or brown) foreground
+For yellow (or brown) foreground.
 .
 .It Li 34
-for blue foreground
+For blue foreground.
 .
 .It Li 35
-for purple foreground
+For purple foreground.
 .
 .It Li 36
-for cyan foreground
+For cyan foreground.
 .
 .It Li 37
-for white (or gray) foreground
+For white (or gray) foreground.
 .
 .It Li 40
-for black background
+For black background.
 .
 .It Li 41
-for red background
+For red background.
 .
 .It Li 42
-for green background
+For green background.
 .
 .It Li 43
-for yellow (or brown) background
+For yellow (or brown) background.
 .
 .It Li 44
-for blue background
+For blue background.
 .
 .It Li 45
-for purple background
+For purple background.
 .
 .It Li 46
-for cyan background
+For cyan background.
 .
 .It Li 47
-for white (or gray) background
+For white (or gray) background.
 .
 .El
 .Pp
@@ -9310,7 +9411,7 @@ environment variable.
 .El
 .
 .Sh FILES
-.Bl -tag -width 16n -compact
+.Bl -tag -width 8n
 .
 .It Pa /etc/csh.cshrc
 Read first by every shell.
@@ -9970,12 +10071,15 @@ New man page and tcsh.man2html
 .It Larry Schwimmer, Stanford University, 1993
 AFS and HESIOD patches
 .
-.It Luke Mewburn, RMIT University, 1994-6
-Enhanced directory printing in prompt,
-added
+.It Luke Mewburn, 1991-
+Enhanced directory printing in prompt.
+Added
 .Ic ellipsis
 and
 .Ic rprompt .
+.Ic vimode
+improvements.
+Manual page improvements.
 .
 .It Edward Hutchins, Silicon Graphics Inc., 1996
 Added implicit cd.


### PR DESCRIPTION
Cleanup of tcsh.man (old man(7) format).
Completion of conversion of tcsh.man.new to mdoc(7) format, functionally equivalent to tcsh.man.
Followup commits to tcsh.man.new with further improvements.