### PR TITLE
tests: use diff -U0 for busybox

### DIFF
--- a/tests/commands.at
+++ b/tests/commands.at
@@ -15,10 +15,10 @@ AT_SETUP([@])
 
 # Not testing much...
 AT_CHECK([tcsh -f -c 'set' > out1 && tcsh -f -c '@' > out2])
-AT_CHECK([diff out1 out2 | tail -n +2], ,
-[< command	set
----
-> command	@
+AT_CHECK([diff -U0 out1 out2 | tail -n +3], [], [dnl
+@@ -5 +5 @@
+-command	set
++command	@
 ])
 
 AT_CHECK([tcsh -f -c '@ var=2 * 3; echo $var'], ,


### PR DESCRIPTION
busybox diff is unified by default (not old-style diff). Use `diff -U0` to force unified with no context, which seems to work for various diff implementations including BSD, GNU diffutils, and busybox.

May resolve a testsuite failure reported on the tcsh mailing list on 2022-11-26.