### PR TITLE
tests: fix stdin-as-tty comment and edit tests

### DIFF
--- a/tests/lexical.at
+++ b/tests/lexical.at
@@ -57,6 +57,11 @@ AT_CHECK([cat stdout], ,
 ])
 ])
 
+dnl Explicitly disable stdin as terminal
+AT_CHECK([tcsh -f -c 'echo @%:@no comment' < /dev/null], ,
+[
+])
+
 AT_DATA([comment2.csh],
 [[echo testing...@%:@\
 OK

--- a/tests/lexical.at
+++ b/tests/lexical.at
@@ -36,17 +36,25 @@ AT_CLEANUP()
 dnl
 dnl	Comments
 dnl
+dnl Note that '#' is not a comment if stdin is a terminal.
+dnl
 
 AT_SETUP([Comments])
 AT_KEYWORDS([lexical])
 
-AT_CHECK([if [ ! -t 0 ]; then exit 77; fi],, [Skipping comment tests])
-
 AT_CHECK([echo 'echo OK@%:@comment' | tcsh -f], , [OK
 ])
 
-AT_CHECK([tcsh -f -c 'echo @%:@no comment'], ,
+dnl Different behavior if stdin is a terminal or not.
+AT_CHECK([tcsh -f -c 'echo @%:@no comment'], , [stdout])
+AS_IF([test -t 0], [dnl
+AT_CHECK([cat stdout], ,
 [@%:@no comment
+])
+], [dnl
+AT_CHECK([cat stdout], ,
+[
+])
 ])
 
 AT_DATA([comment2.csh],

--- a/tests/variables.at
+++ b/tests/variables.at
@@ -543,6 +543,11 @@ AT_CHECK([cat stdout], ,
 ])
 ])
 
+dnl Explicitly disable stdin as terminal
+AT_CHECK([TERM=something tcsh -f -c 'echo $?edit' < /dev/null], ,
+[0
+])
+
 AT_CHECK([TERM=dumb tcsh -f -c 'echo $?edit'], ,
 [0
 ])

--- a/tests/variables.at
+++ b/tests/variables.at
@@ -526,14 +526,21 @@ AT_CLEANUP()
 dnl
 dnl	$ edit
 dnl
+dnl Note that editing is disabled if stdin is not a terminal.
+dnl
 
 AT_SETUP([$ edit])
 AT_KEYWORDS([variables])
 
-AT_CHECK([if [ ! -t 0 ]; then exit 77; fi],, [Skipping $edit tests])
-
-AT_CHECK([TERM=something tcsh -f -c 'echo $?edit'], ,
+AT_CHECK([TERM=something tcsh -f -c 'echo $?edit'], , [stdout])
+AS_IF([test -t 0], [dnl
+AT_CHECK([cat stdout], ,
 [1
+])
+], [dnl
+AT_CHECK([cat stdout], ,
+[0
+])
 ])
 
 AT_CHECK([TERM=dumb tcsh -f -c 'echo $?edit'], ,


### PR DESCRIPTION
Handle '#' and $edit tests that have different
behavior whether stdin is a terminal or not.

(The change in commit 242842a didn't correctly
determine if stdin is a tty and always skipped the group).