### PR TITLE
Introduce 'function' built-in. 

### DIFF
--- a/sh.c
+++ b/sh.c
@@ -2004,7 +2004,7 @@ process(int catch)
 	     funcmain[] = { 'm', 'a', 'i', 'n', 0 };
 	struct Strbuf aword = Strbuf_INIT;
 	cleanup_push(&aword, Strbuf_cleanup);
-	Sgoal = funcmain;
+	Sgoal = fargv->v[2];
 	Stype = TC_GOTO;
 
 	if (!fargv->prev)
@@ -2027,7 +2027,6 @@ process(int catch)
 	    struct Ain a;
 
 	    cleanup_push(&aword, Strbuf_cleanup);
-	    Sgoal = fargv->v[2];
 	    Stype = TC_EXIT;
 	    a.type = TCSH_F_SEEK;
 	    btell(&a);
@@ -2038,7 +2037,7 @@ process(int catch)
 		Strbuf_terminate(&aword);
 
 		if (aword.s[0] != ':' && lastchr(aword.s) == ':')
-		    funcerror(fargv->v[2], funcexit);
+		    funcerror(Sgoal, funcexit);
 		else if (eq(aword.s, funcexit))
 		    funcdelim = 1;
 

--- a/sh.c
+++ b/sh.c
@@ -1997,7 +1997,12 @@ process(int catch)
     getexit(osetexit);
     omark = cleanup_push_mark();
 
-    /* If this is a function, setup STRargv and invoke goto. */
+    /* Functions must have an exit to their end.
+     * if (!fargv->prev) is only true if this is a first function call.
+     * First seek for an exit before jumping to the label,
+     * then seek for an exit on the requested label.
+     * Function arguments are passed to STRargv.
+     * STRargv is reset after the function is done. */
     if (fargv) {
 	int funcdelim = 0;
 	Char funcexit[] = { 'e', 'x', 'i', 't', 0 },
@@ -2229,19 +2234,6 @@ process(int catch)
 	    cleanup_until(&paraml);
 	else
 	    haderr = 1;
-    }
-
-    if (fargv) {
-	/* Reset STRargv on function exit. */
-	setv(STRargv, NULL, VAR_READWRITE);
-
-	if (fargv->prev)
-	{
-	    fargv = fargv->prev;
-	    free(fargv->next);
-	}
-	else
-	    free(fargv);
     }
 
     cleanup_pop_mark(omark);

--- a/sh.c
+++ b/sh.c
@@ -2003,7 +2003,6 @@ process(int catch)
 	Char funcexit[] = { 'e', 'x', 'i', 't', 0 },
 	     funcmain[] = { 'm', 'a', 'i', 'n', 0 };
 	struct Strbuf aword = Strbuf_INIT;
-	cleanup_push(&aword, Strbuf_cleanup);
 	Sgoal = fargv->v[2];
 	Stype = TC_GOTO;
 
@@ -2020,13 +2019,12 @@ process(int catch)
 		(void) getword(NULL);
 	    }
 
-	setq(STRargv, &fargv->v[3], &shvhed, 0);
+	setq(STRargv, &fargv->v[3], &shvhed, VAR_READWRITE);
 	dogoto(&fargv->v[1], fargv->t);
 
 	{
 	    struct Ain a;
 
-	    cleanup_push(&aword, Strbuf_cleanup);
 	    Stype = TC_EXIT;
 	    a.type = TCSH_F_SEEK;
 	    btell(&a);
@@ -2235,7 +2233,7 @@ process(int catch)
 
     if (fargv) {
 	/* Reset STRargv on function exit. */
-	setv(STRargv, NULL, 0);
+	setv(STRargv, NULL, VAR_READWRITE);
 
 	if (fargv->prev)
 	{

--- a/sh.c
+++ b/sh.c
@@ -1670,6 +1670,11 @@ st_restore(void *xst)
 
     xclose(SHIN);
 
+    if (insource == 2) {
+	xclose(fpipe);
+	fpipe = st->fpipe;
+	fdecl = st->fdecl;
+    }
     insource	= st->insource;
     SHIN	= st->SHIN;
     if (st->OLDSTD != -1)

--- a/sh.c
+++ b/sh.c
@@ -1827,6 +1827,7 @@ srcunit(int unit, int onlyown, int hflg, Char **av)
 	    a.type = TCSH_F_SEEK;
 	    btell(&a);
 
+	    cleanup_push(&aword, Strbuf_cleanup);
 	    while (1) {
 		(void) getword(&aword);
 		Strbuf_terminate(&aword);
@@ -1873,7 +1874,7 @@ srcunit(int unit, int onlyown, int hflg, Char **av)
 	    bseek(&a);
 	}
 
-	cleanup_push(&aword, Strbuf_cleanup);
+	cleanup_until(&aword);
     }
 
     process(0);		/* 0 -> blow away on errors */

--- a/sh.c
+++ b/sh.c
@@ -1627,12 +1627,18 @@ st_save(struct saved_state *st, int unit, int hflg, Char **al, Char **av)
     gointr	= 0;
     evalvec	= 0;
     evalp	= 0;
-    alvec	= al;
     alvecp	= 0;
     enterhist	= hflg;
     if (enterhist)
 	HIST	= '\0';
-    insource	= 1;
+    if (al == &fdecl) {
+	alvec	= NULL;
+	insource = 2;
+    }
+    else {
+	alvec	= al;
+	insource = 1;
+    }
 }
 
 

--- a/sh.c
+++ b/sh.c
@@ -142,11 +142,6 @@ struct saved_state {
 };
 
 static	int		  srccat	(Char *, Char *);
-#ifndef WINNT_NATIVE
-static	int		  srcfile	(const char *, int, int, Char **);
-#else
-int		  srcfile	(const char *, int, int, Char **);
-#endif /*WINNT_NATIVE*/
 static	void		  srcunit	(int, int, int, Char **);
 static	void		  mailchk	(void);
 #ifndef _PATH_DEFPATH
@@ -1544,11 +1539,7 @@ srccat(Char *cp, Char *dp)
 /*
  * Source to a file putting the file descriptor in a safe place (> 2).
  */
-#ifndef WINNT_NATIVE
-static int
-#else
 int
-#endif /*WINNT_NATIVE*/
 srcfile(const char *f, int onlyown, int flag, Char **av)
 {
     int unit;
@@ -1779,7 +1770,7 @@ srcunit(int unit, int onlyown, int hflg, Char **av)
 	Char funcexit[] = { 'e', 'x', 'i', 't', 0 },
 	     funcmain[] = { 'm', 'a', 'i', 'n', 0 };
 	struct Strbuf aword = Strbuf_INIT;
-	Sgoal = fargv->v[2];
+	Sgoal = fargv->v[0];
 	Stype = TC_GOTO;
 	fargv->eof = 0;
 
@@ -1817,8 +1808,8 @@ srcunit(int unit, int onlyown, int hflg, Char **av)
 		(void) getword(NULL);
 	    }
 
-	setq(STRargv, &fargv->v[3], &shvhed, VAR_READWRITE);
-	dogoto(&fargv->v[1], fargv->t);
+	setq(STRargv, &fargv->v[1], &shvhed, VAR_READWRITE);
+	gotolab(fargv->v[0]);
 
 	{
 	    struct Ain a;

--- a/sh.c
+++ b/sh.c
@@ -1634,6 +1634,9 @@ st_save(struct saved_state *st, int unit, int hflg, Char **al, Char **av)
     if (al == &fdecl) {
 	alvec	= NULL;
 	insource = 2;
+	st->fpipe = fpipe;
+	st->fdecl = *al;
+	flvl++;
     }
     else {
 	alvec	= al;
@@ -1674,6 +1677,7 @@ st_restore(void *xst)
 	xclose(fpipe);
 	fpipe = st->fpipe;
 	fdecl = st->fdecl;
+	flvl--;
     }
     insource	= st->insource;
     SHIN	= st->SHIN;

--- a/sh.decls.h
+++ b/sh.decls.h
@@ -52,6 +52,8 @@ extern	void		  done		(int) __attribute__((__noreturn__));
 extern	void		  xexit		(int) __attribute__((__noreturn__));
 #endif
 extern	int		  grabpgrp	(int, pid_t);
+extern	void		  st_save	(struct saved_state *, int, int, Char **, Char **);
+extern	void		  st_restore	(void *);
 
 /*
  * sh.dir.c
@@ -166,6 +168,7 @@ extern	void		  dohup		(Char **, struct command *);
 extern	void		  doonintr	(Char **, struct command *);
 extern	void		  doprintenv	(Char **, struct command *);
 extern	void		  dorepeat	(Char **, struct command *);
+extern	void		  doreturn	(Char **, struct command *);
 extern	void		  dofiletest	(Char **, struct command *);
 extern	void		  dosetenv	(Char **, struct command *);
 extern	void		  dosuspend	(Char **, struct command *);

--- a/sh.decls.h
+++ b/sh.decls.h
@@ -107,7 +107,6 @@ extern	void		  xfree_indirect(void *);
 extern	void		  errinit	(void);
 extern	void		  seterror	(unsigned int, ...);
 extern	void		  fixerror	(void);
-extern	void		  funcerror	(Char *, Char *);
 extern	void		  stderror	(unsigned int, ...)
     __attribute__((__noreturn__));
 

--- a/sh.decls.h
+++ b/sh.decls.h
@@ -105,6 +105,7 @@ extern	void		  xfree_indirect(void *);
 extern	void		  errinit	(void);
 extern	void		  seterror	(unsigned int, ...);
 extern	void		  fixerror	(void);
+extern	void		  funcerror	(Char *, Char *);
 extern	void		  stderror	(unsigned int, ...)
     __attribute__((__noreturn__));
 
@@ -150,6 +151,7 @@ extern	void		  doend		(Char **, struct command *);
 extern	void		  doeval	(Char **, struct command *);
 extern	void		  doexit	(Char **, struct command *);
 extern	void		  doforeach	(Char **, struct command *);
+extern	void		  dofunction	(Char **, struct command *);
 extern	void		  doglob	(Char **, struct command *);
 extern	void		  dogoto	(Char **, struct command *);
 extern	void		  doif		(Char **, struct command *);

--- a/sh.err.c
+++ b/sh.err.c
@@ -188,12 +188,11 @@ extern int enterhist;
 #define ERR_BADCOLORVAR	134
 #define ERR_EOF		135
 #define ERR_UNAVAILABLE	136
-#define ERR_FUNC	137
-#define ERR_RETURN	138
-#define ERR_FUNCBEGIN	139
-#define ERR_FUNCALNUM	140
-#define ERR_RECURSION	141
-#define NO_ERRORS	142
+#define ERR_UNDFUNC	137
+#define ERR_FUNCBEGIN	138
+#define ERR_FUNCALNUM	139
+#define ERR_RECURSION	140
+#define NO_ERRORS	141
 
 static const char *elst[NO_ERRORS] INIT_ZERO_STRUCT;
 
@@ -372,8 +371,7 @@ errinit(void)
     elst[ERR_BADCOLORVAR] = CSAVS(1, 137, "Unknown %s color variable '%c%c'");
     elst[ERR_EOF] = CSAVS(1, 138, "Unexpected end of file");
     elst[ERR_UNAVAILABLE] = CSAVS(1, 139, "%s: Feature is not available for this platform");
-    elst[ERR_FUNC] = CSAVS(1, 140, "%S: Undeclared function");
-    elst[ERR_RETURN] = CSAVS(1, 141, "Not in a declaration");
+    elst[ERR_UNDFUNC] = CSAVS(1, 140, "%S: Undeclared function");
     elst[ERR_FUNCBEGIN] = CSAVS(1, 142, "Function name must begin with a letter");
     elst[ERR_FUNCALNUM] = CSAVS(1, 143, "Function name must contain alphanumeric characters");
     elst[ERR_RECURSION] = CSAVS(1, 144, "Too deep a recursion or nest");

--- a/sh.err.c
+++ b/sh.err.c
@@ -188,7 +188,7 @@ extern int enterhist;
 #define ERR_BADCOLORVAR	134
 #define ERR_EOF		135
 #define ERR_UNAVAILABLE	136
-#define ERR_DOLFUNC	137
+#define ERR_FUNC	137
 #define NO_ERRORS	138
 
 static const char *elst[NO_ERRORS] INIT_ZERO_STRUCT;
@@ -368,7 +368,7 @@ errinit(void)
     elst[ERR_BADCOLORVAR] = CSAVS(1, 137, "Unknown %s color variable '%c%c'");
     elst[ERR_EOF] = CSAVS(1, 138, "Unexpected end of file");
     elst[ERR_UNAVAILABLE] = CSAVS(1, 139, "%s: Feature is not available for this platform");
-    elst[ERR_DOLFUNC] = CSAVS(1, 140, "Functions are only supported for scripts");
+    elst[ERR_FUNC] = CSAVS(1, 140, "Functions are only supported for scripts");
 }
 
 /* Cleanup data. */

--- a/sh.err.c
+++ b/sh.err.c
@@ -376,7 +376,7 @@ errinit(void)
     elst[ERR_RETURN] = CSAVS(1, 141, "Not in a declaration");
     elst[ERR_FUNCBEGIN] = CSAVS(1, 142, "Function name must begin with a letter");
     elst[ERR_FUNCALNUM] = CSAVS(1, 143, "Function name must contain alphanumeric characters");
-    elst[ERR_RECURSION] = CSAVS(1, 144, "Recursion too deep");
+    elst[ERR_RECURSION] = CSAVS(1, 144, "Too deep a recursion or nest");
 }
 
 /* Cleanup data. */

--- a/sh.err.c
+++ b/sh.err.c
@@ -192,7 +192,8 @@ extern int enterhist;
 #define ERR_RETURN	138
 #define ERR_FUNCBEGIN	139
 #define ERR_FUNCALNUM	140
-#define NO_ERRORS	141
+#define ERR_RECURSION	141
+#define NO_ERRORS	142
 
 static const char *elst[NO_ERRORS] INIT_ZERO_STRUCT;
 
@@ -375,6 +376,7 @@ errinit(void)
     elst[ERR_RETURN] = CSAVS(1, 141, "Not in a declaration");
     elst[ERR_FUNCBEGIN] = CSAVS(1, 142, "Function name must begin with a letter");
     elst[ERR_FUNCALNUM] = CSAVS(1, 143, "Function name must contain alphanumeric characters");
+    elst[ERR_RECURSION] = CSAVS(1, 144, "Recursion too deep");
 }
 
 /* Cleanup data. */

--- a/sh.err.c
+++ b/sh.err.c
@@ -189,7 +189,10 @@ extern int enterhist;
 #define ERR_EOF		135
 #define ERR_UNAVAILABLE	136
 #define ERR_FUNC	137
-#define NO_ERRORS	138
+#define ERR_RETURN	138
+#define ERR_FUNCBEGIN	139
+#define ERR_FUNCALNUM	140
+#define NO_ERRORS	141
 
 static const char *elst[NO_ERRORS] INIT_ZERO_STRUCT;
 
@@ -368,7 +371,10 @@ errinit(void)
     elst[ERR_BADCOLORVAR] = CSAVS(1, 137, "Unknown %s color variable '%c%c'");
     elst[ERR_EOF] = CSAVS(1, 138, "Unexpected end of file");
     elst[ERR_UNAVAILABLE] = CSAVS(1, 139, "%s: Feature is not available for this platform");
-    elst[ERR_FUNC] = CSAVS(1, 140, "Functions are only supported for scripts");
+    elst[ERR_FUNC] = CSAVS(1, 140, "%S: Undeclared function");
+    elst[ERR_RETURN] = CSAVS(1, 141, "Not in a declaration");
+    elst[ERR_FUNCBEGIN] = CSAVS(1, 142, "Function name must begin with a letter");
+    elst[ERR_FUNCALNUM] = CSAVS(1, 143, "Function name must contain alphanumeric characters");
 }
 
 /* Cleanup data. */
@@ -657,14 +663,4 @@ stderror(unsigned int id, ...)
     fixerror();
 
     reset();		/* Unwind */
-}
-
-void
-funcerror(Char *n, Char *msg)
-{
-    char nconv[Strlen(n) + 1],
-	 msgconv[Strlen(msg) + 1];
-
-    setname(strcpy(nconv, short2str(n)));
-    stderror(ERR_NAME | ERR_NOTFOUND, strcpy(msgconv, short2str(msg)));
 }

--- a/sh.err.c
+++ b/sh.err.c
@@ -188,7 +188,8 @@ extern int enterhist;
 #define ERR_BADCOLORVAR	134
 #define ERR_EOF		135
 #define ERR_UNAVAILABLE	136
-#define NO_ERRORS	137
+#define ERR_DOLFUNC	137
+#define NO_ERRORS	138
 
 static const char *elst[NO_ERRORS] INIT_ZERO_STRUCT;
 
@@ -367,7 +368,7 @@ errinit(void)
     elst[ERR_BADCOLORVAR] = CSAVS(1, 137, "Unknown %s color variable '%c%c'");
     elst[ERR_EOF] = CSAVS(1, 138, "Unexpected end of file");
     elst[ERR_UNAVAILABLE] = CSAVS(1, 139, "%s: Feature is not available for this platform");
-
+    elst[ERR_DOLFUNC] = CSAVS(1, 140, "Functions are only supported for scripts");
 }
 
 /* Cleanup data. */
@@ -656,4 +657,17 @@ stderror(unsigned int id, ...)
     fixerror();
 
     reset();		/* Unwind */
+}
+
+void
+funcerror(Char *n, Char *msg)
+{
+    char nconv[Strlen(n) + 1],
+	 msgconv[Strlen(msg) + 1];
+
+    strcpy(nconv, short2str(n));
+    strcpy(msgconv, short2str(msg));
+
+    setname(nconv);
+    stderror(ERR_NAME | ERR_NOTFOUND, msgconv);
 }

--- a/sh.err.c
+++ b/sh.err.c
@@ -665,9 +665,6 @@ funcerror(Char *n, Char *msg)
     char nconv[Strlen(n) + 1],
 	 msgconv[Strlen(msg) + 1];
 
-    strcpy(nconv, short2str(n));
-    strcpy(msgconv, short2str(msg));
-
-    setname(nconv);
-    stderror(ERR_NAME | ERR_NOTFOUND, msgconv);
+    setname(strcpy(nconv, short2str(n)));
+    stderror(ERR_NAME | ERR_NOTFOUND, strcpy(msgconv, short2str(msg)));
 }

--- a/sh.func.c
+++ b/sh.func.c
@@ -2732,44 +2732,38 @@ dofunction(Char **v, struct command *t)
     if (!dolzero)
 	stderror(ERR_FUNC);
 
+    if (fargv) {
+	fargv->next = malloc(sizeof *fargv);
+	fargv->next->prev = fargv;
+	fargv = fargv->next;
+    } else {
+	fargv = malloc(sizeof *fargv);
+	fargv->prev = NULL;
+    }
+
     {
-	int i, j;
-	Char **vh;
+	int i = 0;
+	Char **vh = NULL;
 
-	for (i = 0; v[i]; i++)
-	    ;
-
-	vh = xmalloc(sizeof(Char [i + 2]));
-	vh[i + 1] = NULL;
-
-	for (j = i--; i; i--, j--) {
-	    vh[j] = xmalloc(sizeof(Char [Strlen(v[i]) + 1]));
-	    Strcpy(vh[j], v[i]);
-	}
-	vh[1] = xmalloc(sizeof (Char [Strlen(ffile) + 1]));
-	Strcpy(vh[1], ffile);
-	*vh = xmalloc(sizeof (Char [Strlen(*v) + 1]));
-	Strcpy(*vh, *v);
-
-	if (fargv) {
-	    fargv->next = malloc(sizeof *fargv);
-	    fargv->next->prev = fargv;
-	    fargv = fargv->next;
-	} else {
-	    fargv = malloc(sizeof *fargv);
-	    fargv->prev = NULL;
+	for (v++; *v; v++, i++) {
+	    vh = xrealloc(vh, sizeof(Char *[i + 2]));
+	    vh[i] = xmalloc(sizeof(Char [Strlen(*v) + 1]));
+	    Strcpy(vh[i], *v);
 	}
 
-	dosource(fargv->v = vh, fargv->t = t);
-	/* Reset STRargv on function exit. */
-	setv(STRargv, NULL, VAR_READWRITE);
+	vh[i] = NULL;
+	fargv->v = vh;
+    }
 
-	if (fargv->prev) {
-	    fargv = fargv->prev;
-	    free(fargv->next);
-	} else {
-	    free(fargv);
-	    fargv = NULL;
-	}
+    srcfile(short2str(ffile), 0, 0, NULL);
+    /* Reset STRargv on function exit. */
+    setv(STRargv, NULL, VAR_READWRITE);
+
+    if (fargv->prev) {
+	fargv = fargv->prev;
+	free(fargv->next);
+    } else {
+	free(fargv);
+	fargv = NULL;
     }
 }

--- a/sh.func.c
+++ b/sh.func.c
@@ -1096,6 +1096,8 @@ past:
 	break;
 
     case TC_EXIT:
+	if (fargv->eof)
+	    return (intptr_t) &fargv;
 	setname(short2str(Sgoal));
 	stderror(ERR_NAME | ERR_NOTFOUND, "exit");
 	break;

--- a/sh.func.c
+++ b/sh.func.c
@@ -2783,7 +2783,8 @@ dofunction(Char **v, struct command *c)
 	    stderror(ERR_FUNC, Sgoal);
 	{
 	    Char funcexit[] = { 'r', 'e', 't', 'u', 'r', 'n', '\0' },
-		 *(*varvec)[2];
+		 alarg[] = { '!', '*', '\0' },
+		 *(*varvec)[4];
 	    struct Strbuf aword = Strbuf_INIT,
 			  func = Strbuf_INIT;
 	    struct wordent *histent = NULL,
@@ -2847,9 +2848,16 @@ dofunction(Char **v, struct command *c)
 	    if (!func.len)
 		return;
 	    func.s[--func.len] = 0;
-	    **(varvec = xmalloc(sizeof *varvec)) = func.s;
-	    *varvec[1] = NULL;
+	    **(varvec = xcalloc(1, sizeof *varvec -
+				(sizeof **varvec * 2))) = func.s;
 	    setq(Sgoal, *varvec, &functions, VAR_READONLY);
+	    **(varvec =
+	       xcalloc(1, sizeof *varvec)) = Strsave(str2short(bname));
+	    (*varvec)[1] = Strsave(Sgoal);
+	    (*varvec)[2] = Strsave(alarg);
+	    setq(Sgoal, *varvec, &aliases, VAR_READWRITE);
+
+	    tw_cmd_free();
 	}
     }
 }

--- a/sh.func.c
+++ b/sh.func.c
@@ -2767,7 +2767,9 @@ dofunction(Char **v, struct command *t)
 	if (fargv->prev) {
 	    fargv = fargv->prev;
 	    free(fargv->next);
-	} else
+	} else {
 	    free(fargv);
+	    fargv = NULL;
+	}
     }
 }

--- a/sh.func.c
+++ b/sh.func.c
@@ -2772,7 +2772,7 @@ dofunction(Char **v, struct command *c)
 	}
 	if (*v || c->t_dlef || c->t_drit ||
 	    c->t_dflg & (F_PIPEIN | F_PIPEOUT))
-	    stderror(ERR_FUNC, Sgoal);
+	    stderror(ERR_UNDFUNC, Sgoal);
 	{
 	    Char funcexit[] = { 'r', 'e', 't', 'u', 'r', 'n', '\0' },
 		 alarg[] = { '!', '*', '\0' },
@@ -2853,13 +2853,4 @@ dofunction(Char **v, struct command *c)
 	    tw_cmd_free();
 	}
     }
-}
-
-void
-doreturn(Char **v, struct command *c)
-{
-    USE(c);
-    USE(v);
-
-    stderror(ERR_NAME | ERR_RETURN);
 }

--- a/sh.func.c
+++ b/sh.func.c
@@ -2732,7 +2732,8 @@ getYN(const char *prompt)
     return doit;
 }
 
-int fpipe = -1;
+int flvl,
+    fpipe = -1;
 Char *fdecl;
 
 void
@@ -2757,23 +2758,15 @@ dofunction(Char **v, struct command *c)
 	    if (!alnum(*p))
 		stderror(ERR_NAME | ERR_FUNCALNUM);
 	if ((varp = adrof1(Sgoal, &functions))) {
-	    static int l;
-
-	    if (l == 100) {
-		l = 0;
+	    if (flvl == 100)
 		stderror(ERR_RECURSION);
-	    }
 	    mypipe(pv);
 	    cleanup_push(&st, st_restore);
 	    st_save(&st, pv[0], 0, &fdecl, v);
-	    st.fpipe = fpipe;
 	    fpipe = pv[1];
-	    st.fdecl = fdecl;
 	    fdecl = *varp->vec;
-	    l++;
 	    process(0);
 	    cleanup_until(&st);
-	    l--;
 
 	    return;
 	}

--- a/sh.func.c
+++ b/sh.func.c
@@ -498,11 +498,18 @@ doexit(Char **v, struct command *c)
 	    stderror(ERR_NAME | ERR_EXPRESSION);
     }
     btoeof();
-#if 0
-    if (intty)
-#endif
-    /* Always close, why only on ttys? */
+
+    /* Always close, except in the context of
+     * dosource or dofunction.
+     * st_restore will handle. */
+    switch (insource) {
+    case 0:
 	xclose(SHIN);
+	SHIN = -1;
+	break;
+    case 2:
+	fdecl += Strlen(fdecl);
+    }
 }
 
 /*ARGSUSED*/
@@ -2760,7 +2767,7 @@ dofunction(Char **v, struct command *c)
 	    }
 	    mypipe(pv);
 	    cleanup_push(&st, st_restore);
-	    st_save(&st, pv[0], 0, NULL, v);
+	    st_save(&st, pv[0], 0, &fdecl, v);
 	    pvsav = fpipe;
 	    fpipe = pv[1];
 	    fsav = fdecl;

--- a/sh.func.c
+++ b/sh.func.c
@@ -2729,7 +2729,7 @@ getYN(const char *prompt)
 void
 dofunction(Char **v, struct command *t)
 {
-    if (!ffile)
+    if (!dolzero)
 	stderror(ERR_FUNC);
 
     {

--- a/sh.func.c
+++ b/sh.func.c
@@ -2730,7 +2730,7 @@ void
 dofunction(Char **v, struct command *t)
 {
     if (!ffile)
-	stderror(ERR_DOLFUNC);
+	stderror(ERR_FUNC);
 
     {
 	int i, j;

--- a/sh.func.c
+++ b/sh.func.c
@@ -2765,10 +2765,9 @@ dofunction(Char **v, struct command *c)
 	    fdecl = *varp->vec;
 	    ohaderr = haderr;
 	    getexit(oldexit);
-	    if (!setexit()) {
-		l++;
+	    l++;
+	    if (!setexit())
 		process(0);
-	    }
 	    resexit(oldexit);
 	    haderr = ohaderr;
 	    st_restore(&st);
@@ -2810,17 +2809,8 @@ dofunction(Char **v, struct command *c)
 		    histent = histent->next;
 		}
 
-		if (eq(aword.s, funcexit)) {
-		    if (intty) {
-			ohistent->prev = histgetword(histent);
-			ohistent->prev->next = ohistent;
-			savehist(ohistent, 0);
-			freelex(ohistent);
-			xfree(ohistent);
-		    }
-
+		if (eq(aword.s, funcexit))
 		    break;
-		}
 		Strbuf_append(&func, aword.s);
 		Strbuf_append1(&func, ' ');
 		while (getword(&aword)) {
@@ -2846,10 +2836,17 @@ dofunction(Char **v, struct command *c)
 		    (void) getword(NULL);
 	    }
 
+	    if (intty) {
+		ohistent->prev = histgetword(histent);
+		ohistent->prev->next = ohistent;
+		savehist(ohistent, 0);
+		freelex(ohistent);
+		xfree(ohistent);
+	    }
 	    cleanup_until(&aword);
 	    if (!func.len)
 		return;
-	    Strbuf_terminate(&func);
+	    func.s[--func.len] = 0;
 	    **(varvec = xmalloc(sizeof *varvec)) = func.s;
 	    *varvec[1] = NULL;
 	    setq(Sgoal, *varvec, &functions, VAR_READONLY);

--- a/sh.func.c
+++ b/sh.func.c
@@ -2739,16 +2739,16 @@ dofunction(Char **v, struct command *t)
 	for (i = 0; v[i]; i++)
 	    ;
 
-	vh = xmalloc((i + 2) * sizeof(Char *));
+	vh = xmalloc(sizeof(Char [i + 2]));
 	vh[i + 1] = NULL;
 
 	for (j = i--; i; i--, j--) {
-	    vh[j] = xmalloc(((Strlen(v[i]) + 1) * sizeof(Char)));
+	    vh[j] = xmalloc(sizeof(Char [Strlen(v[i]) + 1]));
 	    Strcpy(vh[j], v[i]);
 	}
-	vh[1] = xmalloc(Strlen(ffile) + 1);
+	vh[1] = xmalloc(sizeof (Char [Strlen(ffile) + 1]));
 	Strcpy(vh[1], ffile);
-	*vh = xmalloc(Strlen(*v) + 1);
+	*vh = xmalloc(sizeof (Char [Strlen(*v) + 1]));
 	Strcpy(*vh, *v);
 
 	if (fargv) {

--- a/sh.func.c
+++ b/sh.func.c
@@ -2732,7 +2732,7 @@ getYN(const char *prompt)
     return doit;
 }
 
-int fpipe;
+int fpipe = -1;
 Char *fdecl;
 
 void
@@ -2758,8 +2758,6 @@ dofunction(Char **v, struct command *c)
 		stderror(ERR_NAME | ERR_FUNCALNUM);
 	if ((varp = adrof1(Sgoal, &functions))) {
 	    static int l;
-	    int pvsav;
-	    Char *fsav;
 
 	    if (l == 100) {
 		l = 0;
@@ -2768,16 +2766,13 @@ dofunction(Char **v, struct command *c)
 	    mypipe(pv);
 	    cleanup_push(&st, st_restore);
 	    st_save(&st, pv[0], 0, &fdecl, v);
-	    pvsav = fpipe;
+	    st.fpipe = fpipe;
 	    fpipe = pv[1];
-	    fsav = fdecl;
+	    st.fdecl = fdecl;
 	    fdecl = *varp->vec;
 	    l++;
 	    process(0);
 	    cleanup_until(&st);
-	    xclose(pv[1]);
-	    fpipe = pvsav;
-	    fdecl = fsav;
 	    l--;
 
 	    return;
@@ -2851,7 +2846,7 @@ dofunction(Char **v, struct command *c)
 	    cleanup_until(&aword);
 	    if (!func.len)
 		return;
-	    func.s[--func.len] = 0;
+	    Strbuf_terminate(&func);
 	    **(varvec = xcalloc(1, sizeof *varvec -
 				(sizeof **varvec * 2))) =
 	    func.s;

--- a/sh.func.c
+++ b/sh.func.c
@@ -2782,8 +2782,8 @@ dofunction(Char **v, struct command *c)
 
 	    return;
 	}
-	if (*v || c->t_dflg & (F_PIPEIN | F_PIPEOUT) ||
-	    c->t_dlef || c->t_drit || !isatty(OLDSTD))
+	if (*v || c->t_dlef || c->t_drit ||
+	    c->t_dflg & (F_PIPEIN | F_PIPEOUT))
 	    stderror(ERR_FUNC, Sgoal);
 	{
 	    Char funcexit[] = { 'r', 'e', 't', 'u', 'r', 'n', '\0' },

--- a/sh.func.c
+++ b/sh.func.c
@@ -2759,5 +2759,13 @@ dofunction(Char **v, struct command *t)
 	}
 
 	dosource(fargv->v = vh, fargv->t = t);
+	/* Reset STRargv on function exit. */
+	setv(STRargv, NULL, VAR_READWRITE);
+
+	if (fargv->prev) {
+	    fargv = fargv->prev;
+	    free(fargv->next);
+	} else
+	    free(fargv);
     }
 }

--- a/sh.h
+++ b/sh.h
@@ -1019,7 +1019,9 @@ EXTERN struct varent {
 #define VAR_LAST        64
     struct varent *v_link[3];	/* The links, see below */
     int     v_bal;		/* Balance factor */
-}       shvhed IZERO_STRUCT, aliases IZERO_STRUCT;
+} shvhed IZERO_STRUCT,
+  aliases IZERO_STRUCT,
+  functions IZERO_STRUCT;
 
 #define v_left		v_link[0]
 #define v_right		v_link[1]
@@ -1266,6 +1268,34 @@ EXTERN nl_catd catd;
 extern int    filec;
 #endif /* FILEC */
 
+/*
+ * This preserves the input state of the shell. It is used by
+ * st_save and st_restore to manupulate shell state.
+ */
+struct saved_state {
+    int		  insource;
+    int		  OLDSTD;
+    int		  SHIN;
+    int		  SHOUT;
+    int		  SHDIAG;
+    int		  intty;
+    struct whyle *whyles;
+    Char 	 *gointr;
+    Char 	 *arginp;
+    Char	 *evalp;
+    Char	**evalvec;
+    Char	 *alvecp;
+    Char	**alvec;
+    int		  onelflg;
+    int	  enterhist;
+    Char	**argv;
+    Char	**av;
+    Char	  HIST;
+    int	  cantell;
+    struct Bin	  B;
+    int		  justpr;
+};
+
 #include "sh.decls.h"
 /*
  * Since on some machines characters are unsigned, and the signed
@@ -1305,26 +1335,5 @@ extern int    filec;
 #define TEXP_IGNORE 1	/* in ignore, it means to ignore value, just parse */
 #define TEXP_NOGLOB 2	/* in ignore, it means not to globone */
 
-/* Function variable(s) and function(s). */
-extern Char *Sgoal;
-extern int Stype;
-extern struct funccurr {
-    struct funcargs {
-	Char **v;
-	struct funcargs *prev,
-			*next;
-    } *fargv;
-    struct funcfile {
-	char *file;
-	struct funcfile *prev,
-			*next;
-    } *ffile;
-    char *file;
-    int eof,
-	src,
-	ready;
-} fcurr;
-extern int getword(struct Strbuf *);
-extern int srcfile(const char *, int, int, Char **);
 
 #endif /* _h_sh */

--- a/sh.h
+++ b/sh.h
@@ -1308,12 +1308,22 @@ extern int    filec;
 /* Function variable(s) and function(s). */
 extern Char *Sgoal;
 extern int Stype;
-extern struct funcargs {
-    Char **v;
-    int eof;
-    struct funcargs *prev,
-		    *next;
-} *fargv;
+extern struct funccurr {
+    struct funcargs {
+	Char **v;
+	struct funcargs *prev,
+			*next;
+    } *fargv;
+    struct funcfile {
+	char *file;
+	struct funcfile *prev,
+			*next;
+    } *ffile;
+    char *file;
+    int eof,
+	src,
+	ready;
+} fcurr;
 extern int getword(struct Strbuf *);
 extern int srcfile(const char *, int, int, Char **);
 

--- a/sh.h
+++ b/sh.h
@@ -1305,5 +1305,15 @@ extern int    filec;
 #define TEXP_IGNORE 1	/* in ignore, it means to ignore value, just parse */
 #define TEXP_NOGLOB 2	/* in ignore, it means not to globone */
 
+/* Function variable(s) and function(s). */
+extern Char *Sgoal;
+extern int Stype;
+extern struct funcargs {
+    Char **v;
+    struct command *t;
+    struct funcargs *prev,
+		    *next;
+} *fargv;
+extern int getword(struct Strbuf *);
 
 #endif /* _h_sh */

--- a/sh.h
+++ b/sh.h
@@ -1337,7 +1337,9 @@ struct saved_state {
 #define TEXP_IGNORE 1	/* in ignore, it means to ignore value, just parse */
 #define TEXP_NOGLOB 2	/* in ignore, it means not to globone */
 
-extern int fpipe; /* Write end of a pipe used by dofunction. */
+extern int flvl, /* Level of nesting or recursion used
+		  * used by dofunction. */
+	   fpipe; /* Write end of a pipe used by dofunction. */
 extern Char *fdecl; /* Pointer to function declaration
 		     * used by dofunction. */
 

--- a/sh.h
+++ b/sh.h
@@ -1294,6 +1294,8 @@ struct saved_state {
     int	  cantell;
     struct Bin	  B;
     int		  justpr;
+    int		fpipe;
+    Char	*fdecl;
 };
 
 #include "sh.decls.h"

--- a/sh.h
+++ b/sh.h
@@ -1310,11 +1310,11 @@ extern Char *Sgoal;
 extern int Stype;
 extern struct funcargs {
     Char **v;
-    struct command *t;
+    int eof;
     struct funcargs *prev,
 		    *next;
-    int eof;
 } *fargv;
 extern int getword(struct Strbuf *);
+extern int srcfile(const char *, int, int, Char **);
 
 #endif /* _h_sh */

--- a/sh.h
+++ b/sh.h
@@ -1313,6 +1313,7 @@ extern struct funcargs {
     struct command *t;
     struct funcargs *prev,
 		    *next;
+    int eof;
 } *fargv;
 extern int getword(struct Strbuf *);
 

--- a/sh.h
+++ b/sh.h
@@ -1335,5 +1335,8 @@ struct saved_state {
 #define TEXP_IGNORE 1	/* in ignore, it means to ignore value, just parse */
 #define TEXP_NOGLOB 2	/* in ignore, it means not to globone */
 
+extern int fpipe; /* Write end of a pipe used by dofunction. */
+extern Char *fdecl; /* Pointer to function declaration
+		     * used by dofunction. */
 
 #endif /* _h_sh */

--- a/sh.init.c
+++ b/sh.init.c
@@ -80,6 +80,7 @@ const struct biltins bfunc[] = {
     { "fg",		dofg,		0,	INF	},
     { "filetest",	dofiletest,	2,	INF	},
     { "foreach",	doforeach,	3,	INF	},
+    { "function",	dofunction,	1,	INF	},
 #ifdef TCF
     { "getspath",	dogetspath,	0,	0	},
     { "getxvers",	dogetxvers,	0,	0	},

--- a/sh.init.c
+++ b/sh.init.c
@@ -123,7 +123,7 @@ const struct biltins bfunc[] = {
     { "pushd",		dopushd,	0,	INF	},
     { "rehash",		dohash,		0,	3	},
     { "repeat",		dorepeat,	2,	INF	},
-    { "return",		doreturn,		0,	0	},
+    { "return",		dozip,		0,	0	},
 #ifdef apollo
     { "rootnode",	dorootnode,	1,	1	},
 #endif /* apollo */

--- a/sh.init.c
+++ b/sh.init.c
@@ -80,7 +80,7 @@ const struct biltins bfunc[] = {
     { "fg",		dofg,		0,	INF	},
     { "filetest",	dofiletest,	2,	INF	},
     { "foreach",	doforeach,	3,	INF	},
-    { "function",	dofunction,	1,	INF	},
+    { "function",	dofunction,	0,	INF	},
 #ifdef TCF
     { "getspath",	dogetspath,	0,	0	},
     { "getxvers",	dogetxvers,	0,	0	},
@@ -123,6 +123,7 @@ const struct biltins bfunc[] = {
     { "pushd",		dopushd,	0,	INF	},
     { "rehash",		dohash,		0,	3	},
     { "repeat",		dorepeat,	2,	INF	},
+    { "return",		doreturn,		0,	0	},
 #ifdef apollo
     { "rootnode",	dorootnode,	1,	1	},
 #endif /* apollo */

--- a/sh.lex.c
+++ b/sh.lex.c
@@ -1717,7 +1717,7 @@ bgetc(void)
 	    buf = (int) feobp / BUFSIZE;
 	    balloc(buf);
 	    roomleft = BUFSIZE - off;
-	    if (fpipe) {
+	    if (insource == 2) {
 		if (!*fdecl)
 		    return CHAR_ERR;
 		(void) xwrite(fpipe, fdecl++, (size_t) 1);

--- a/sh.lex.c
+++ b/sh.lex.c
@@ -1717,6 +1717,11 @@ bgetc(void)
 	    buf = (int) feobp / BUFSIZE;
 	    balloc(buf);
 	    roomleft = BUFSIZE - off;
+	    if (fpipe) {
+		if (!*fdecl)
+		    return CHAR_ERR;
+		(void) xwrite(fpipe, fdecl++, (size_t) 1);
+	    }
 	    c = wide_read(SHIN, fbuf[buf] + off, roomleft, 0);
 	    if (c > 0)
 		feobp += c;

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -5424,12 +5424,14 @@ messages are verbose.
 .It Ic end
 .It Ic endif
 .It Ic endsw
+.It Ic return
 See the description of the
 .Ic foreach ,
 .Ic if ,
 .Ic switch ,
+.Ic while ,
 and
-.Ic while
+.Ic return
 statements below.
 .
 .El
@@ -5521,29 +5523,33 @@ the loop are executed.
 If you make a mistake typing in a
 loop at the terminal you can rub it out.
 .
-.It Ic function Ar label Xo
-.Op Ar arg
-\&... (+)
+.It Ic function No (+)
+.It Ic function Ar name No (+)
+.It Ic \&...
+.It Ic return
+.It Ic function Ar name Xo
+.Op Ar arg No ...
+(+)
 .Xc
-.Ar label
-is a
-.Ic goto
-label. The shell recurses the current script,
-searches for and continues execution after a line of the form
-.Dl Ar label Ns No \&:
-.Ar arg
-is a list of arguments to be passed to
-.Ic argv Ns No \&.
-Use outside a label is labeled
-.Ar main Ns No \&.
-It's an error
-.Sq Ar label Ns No \&:
-not contain an ending
-.Ic exit Ns No \&.
-It's an error
-.Ar main
-not contain an ending
-.Ic exit Ns No \&.
+The first form of the command prints the value of all shell functions.
+.Pp
+The second form declares a function
+.Ar name Ns No .
+A declaration ends when a
+.Ic return
+is matched. (Both
+.Ic function
+and
+.Ic return
+must appear alone on separate lines.)
+May not be declared otherwise, and declared
+functions may not be redeclared or undeclared.
+.Pp
+The third form calls a function
+.Ar name Ns No ,
+optionally, preceded by
+.Ar arg Ns No ,
+which is a list of arguments to be passed.
 .
 .El
 .Bl -tag -width 6n

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -5530,6 +5530,9 @@ loop at the terminal you can rub it out.
 .It Ic function Ar name Xo
 .Op Ar arg No ...
 (+)
+.It Ar name Xo
+.Op Ar arg No ...
+(+)
 .Xc
 The first form of the command prints the value of all shell functions.
 .Pp
@@ -5552,6 +5555,10 @@ optionally, preceded by
 which is a list of arguments to be passed.
 Function calls may be nested or recursive,
 but too deep a nest or recursion will raise an error.
+.Pp
+The fourth form is an
+.Ic alias
+for the third form.
 .
 .El
 .Bl -tag -width 6n

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -5521,6 +5521,30 @@ the loop are executed.
 If you make a mistake typing in a
 loop at the terminal you can rub it out.
 .
+.It Ic function Ar label Xo
+.Op Ar arg
+\&... (+)
+.Xc
+.Ar label
+is a
+.Ic goto
+label. The shell recurses the current script,
+searches for and continues execution after a line of the form
+.Dl Ar label Ns No \&:
+.Ar arg
+is a list of arguments to be passed to
+.Ic argv Ns No \&.
+Use outside a label is labeled
+.Ar main Ns No \&.
+It's an error
+.Sq Ar label Ns No \&:
+not contain an ending
+.Ic exit Ns No \&.
+It's an error
+.Ar main
+not contain an ending
+.Ic exit Ns No \&.
+.
 .El
 .Bl -tag -width 6n
 .
@@ -10642,6 +10666,12 @@ and message catalog code to interface to Windows.
 .br
 Color ls additions.
 .
+.It Matheus Garcia ,
+2023.
+.br
+.Ic function
+built-in.
+.
 .El
 .
 .Sh THANKS TO
@@ -10743,6 +10773,10 @@ Command substitution supports multiple commands and conditions, but not
 cycles or backward
 .Ic goto Ns
 s.
+.Pp
+Functions fallthrough if the ending
+.Ic exit
+is piped from or executed in background.
 .Pp
 Report bugs at
 .Lk @PACKAGE_BUGREPORT@

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -5550,6 +5550,8 @@ The third form calls a function
 optionally, preceded by
 .Ar arg Ns No ,
 which is a list of arguments to be passed.
+Function calls may be nested or recursive,
+but too deep a nest or recursion will raise an error.
 .
 .El
 .Bl -tag -width 6n
@@ -10779,10 +10781,6 @@ Command substitution supports multiple commands and conditions, but not
 cycles or backward
 .Ic goto Ns
 s.
-.Pp
-Functions fallthrough if the ending
-.Ic exit
-is piped from or executed in background.
 .Pp
 Report bugs at
 .Lk @PACKAGE_BUGREPORT@

--- a/tests/commands.at
+++ b/tests/commands.at
@@ -636,6 +636,39 @@ c
 AT_CLEANUP()
 
 
+AT_SETUP([function])
+AT_KEYWORDS([commands])
+
+AT_DATA([function.csh],
+[[
+if ( ! { function test test } ) then
+  echo 'FAIL: '\''function'\'' is not passing arguments!'
+  exit 1
+else if >& /dev/null ( { function test2 } ) then
+  echo 'FAIL: '\''function'\'' is not seeking for an ending exit!'
+  exit 1
+else if >& /dev/null ( ! { function test3 } ) then
+  echo 'FAIL: '\''function'\'' is not seeking for an ending exit on EOF!'
+  exit 1
+endif
+exit
+
+test:
+if ( "$1" == ) exit 1
+exit
+
+test2:
+exit
+echo test
+
+test3:
+exit
+]])
+AT_CHECK([tcsh -f function.csh])
+
+AT_CLEANUP()
+
+
 dnl
 dnl	getspath
 dnl
@@ -1868,5 +1901,24 @@ else
 endif
 ]])
 AT_CHECK([tcsh -f time_output.csh], 0, [ignore])
+
+AT_CLEANUP()
+
+AT_SETUP([main function])
+AT_KEYWORDS([commands])
+
+AT_DATA([main.csh],
+[[
+if >& /dev/null ( { function test } ) then
+  echo 'FAIL: '\''function'\'' is not seeking for an ending first exit!'
+  exit 1
+endif
+exit
+echo test
+
+test:
+exit
+]])
+AT_CHECK([tcsh -f main.csh])
 
 AT_CLEANUP()


### PR DESCRIPTION
As requested in https://github.com/tcsh-org/tcsh/issues/4, here's my proposal. This is a wrapper around `goto` and `source`. The script recurses itself and searches for a `goto` label. It's an error for labels not contain an `exit` to their end. Function calls outside labels are, by default, labeled `main`.

This was tested sparsely, and may contain bugs I haven't faced, but is working as expected. One bug to be noted is that pipes don't give up on errors. This is possibly due to forking.

I noticed Tcsh has a built-in `function` command, but I can't trace the code. Said built-in `function` command is evaluated before mine, thus those who attempt to execute it won't get the correct error message. 