### PR TITLE
typo on ed.chared

### DIFF
--- a/ed.chared.c
+++ b/ed.chared.c
@@ -1821,7 +1821,7 @@ c_hmatch(Char *str)
 }
 
 /*
- * c_hsetpat(): Set the history seatch pattern
+ * c_hsetpat(): Set the history search pattern
  */
 static void
 c_hsetpat(void)


### PR DESCRIPTION
[at ed.chared.c](https://github.com/tcsh-org/tcsh/blob/360a97d20b164b71e0d525bf54cbf1dee2dedc99/ed.chared.c#L1824), seatch->search