### PR TITLE
Make nice priority incremental even with setpriority(2)

### DIFF
--- a/Fixes
+++ b/Fixes
@@ -1,3 +1,5 @@
+ 30. Make nice priority incremental even with setpriority(2) to match
+     how it worked with nice(3) (Kimmo Suominen)
  29. V6.24.10 - 2023-04-14
  28. Restore skipping of the "$edit" and "Comments" tests when not running
      on a terminal (Kimmo Suominen)

--- a/sh.proc.c
+++ b/sh.proc.c
@@ -1879,6 +1879,11 @@ pfork(struct command *t, int wanttty)
 	if (t->t_dflg & F_NICE) {
 	    int nval = SIGN_EXTEND_CHAR(t->t_nice);
 #if defined(HAVE_SETPRIORITY) && defined(PRIO_PROCESS)
+	    int oval;
+	    errno = 0;
+	    if ((oval = getpriority(PRIO_PROCESS, 0)) == -1 && errno)
+		stderror(ERR_SYSTEM, "getpriority", strerror(errno));
+	    nval += oval;
 	    if (setpriority(PRIO_PROCESS, 0, nval) == -1 && errno)
 		stderror(ERR_SYSTEM, "setpriority", strerror(errno));
 #else /* !HAVE_SETPRIORITY || !PRIO_PROCESS */

--- a/sh.sem.c
+++ b/sh.sem.c
@@ -574,6 +574,12 @@ execute(struct command *t, volatile int wanttty, int *pipein, int *pipeout,
 		    if (t->t_dflg & F_NICE) {
 			int nval = SIGN_EXTEND_CHAR(t->t_nice);
 # if defined(HAVE_SETPRIORITY) && defined(PRIO_PROCESS)
+			int oval;
+			errno = 0;
+			if ((oval = getpriority(PRIO_PROCESS, 0)) == -1 && errno)
+				stderror(ERR_SYSTEM, "getpriority",
+				    strerror(errno));
+			nval += oval;
 			if (setpriority(PRIO_PROCESS, 0, nval) == -1 && errno)
 				stderror(ERR_SYSTEM, "setpriority",
 				    strerror(errno));

--- a/sh.time.c
+++ b/sh.time.c
@@ -147,6 +147,9 @@ donice(Char **v, struct command *c)
 {
     Char *cp;
     int	    nval = 0;
+#if defined(HAVE_SETPRIORITY) && defined(PRIO_PROCESS)
+    int	    oval;
+#endif
 
     USE(c);
     v++, cp = *v++;
@@ -155,6 +158,10 @@ donice(Char **v, struct command *c)
     else if (*v	== 0 &&	any("+-", cp[0]))
 	nval = getn(cp);
 #if defined(HAVE_SETPRIORITY) && defined(PRIO_PROCESS)
+    errno = 0;
+    if ((oval = getpriority(PRIO_PROCESS, 0)) == -1 && errno)
+	stderror(ERR_SYSTEM, "getpriority", strerror(errno));
+    nval += oval;
     if (setpriority(PRIO_PROCESS, 0, nval) == -1 && errno)
 	stderror(ERR_SYSTEM, "setpriority", strerror(errno));
 #else /* !HAVE_SETPRIORITY || !PRIO_PROCESS */

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -6203,11 +6203,11 @@ see the
 shell variable.
 .
 .It Ic nice Oo Cm + Ns Ar number Oc Op Ar command
-Sets the scheduling priority for the shell to
+Increments the scheduling priority for the shell by
 .Ar number ,
 or, without
 .Ar number ,
-to 4.
+by 4.
 With
 .Ar command ,
 runs
@@ -6218,8 +6218,7 @@ The greater the
 .Ar number ,
 the less cpu
 the process gets.
-The super-user may specify negative
-priority by using
+The super-user may decrement the priority by using
 .Dl nice \- Ns Ar number Li \&...
 .Pp
 .Ar command


### PR DESCRIPTION
Make `nice` work like `renice -n` (see [`renice(8)`](https://man.netbsd.org/renice.8)).
Closes issue #94.