### PR TITLE
Variable assignment from pipes and redirections

### DIFF
--- a/sh.func.c
+++ b/sh.func.c
@@ -1353,8 +1353,21 @@ dosetenv(Char **v, struct command *c)
     if (*lp != '\0')
 	stderror(ERR_NAME | ERR_VARALNUM);
 
-    if ((lp = *v++) == 0)
-	lp = STRNULL;
+    if ((lp = *v++) == 0) {
+	if (c->t_dflg & F_PIPEIN || c->t_dlef) {
+	    Char c;
+	    struct Strbuf s = Strbuf_INIT;
+
+	    while (wide_read(0, &c, (size_t) 1, 0) > 0) {
+		if (c == '\n')
+		    break;
+		Strbuf_append1(&s, c | LITERAL);
+	    }
+	    Strbuf_terminate(&s);
+	    lp = s.s;
+	} else
+	    lp = STRNULL;
+    }
 
     lp = globone(lp, G_APPEND);
     cleanup_push(lp, xfree);

--- a/sh.func.c
+++ b/sh.func.c
@@ -1361,7 +1361,7 @@ dosetenv(Char **v, struct command *c)
 	    while (wide_read(0, &c, (size_t) 1, 0) > 0) {
 		if (c == '\n')
 		    break;
-		Strbuf_append1(&s, c | LITERAL);
+		Strbuf_append1(&s, c | QUOTE);
 	    }
 	    Strbuf_terminate(&s);
 	    lp = s.s;

--- a/sh.func.c
+++ b/sh.func.c
@@ -1354,7 +1354,7 @@ dosetenv(Char **v, struct command *c)
 	stderror(ERR_NAME | ERR_VARALNUM);
 
     if ((lp = *v++) == 0) {
-	if (c->t_dflg & F_PIPEIN || c->t_dlef) {
+	if (c->t_dlef || !isatty(OLDSTD)) {
 	    Char c;
 	    struct Strbuf s = Strbuf_INIT;
 

--- a/sh.sem.c
+++ b/sh.sem.c
@@ -849,7 +849,7 @@ doio(struct command *t, int *pipein, int *pipeout)
 	}
 	else if (flags & F_PIPEIN) {
 	    xclose(0);
-	    OLDSTD = dmove(pipein[0], 0);
+	    (void) dmove(pipein[0], 0);
 	    xclose(pipein[1]);
 	}
 	else if ((flags & F_NOINTERRUPT) && tpgrp == -1) {
@@ -911,7 +911,7 @@ doio(struct command *t, int *pipein, int *pipeout)
     }
     else if (flags & F_PIPEOUT) {
 	xclose(1);
-	SHOUT = dcopy(pipeout[1], 1);
+	(void) dcopy(pipeout[1], 1);
 	is1atty = 0;
     }
     else {
@@ -925,7 +925,7 @@ doio(struct command *t, int *pipein, int *pipeout)
 
     xclose(2);
     if (flags & F_STDERR) {
-	SHDIAG = dcopy(1, 2);
+	(void) dcopy(1, 2);
 	is2atty = is1atty;
     }
     else {

--- a/sh.set.c
+++ b/sh.set.c
@@ -365,7 +365,7 @@ doset(Char **v, struct command *c)
 		if (empty && s.s == NULL) {
 		    Char **empty;
 
-		    *(empty = xmalloc(sizeof *empty)) = NULL;
+		    empty = xcalloc(1, sizeof *empty);
 		    set1(vp, empty, &shvhed, flags);
 		}
 		else {

--- a/sh.set.c
+++ b/sh.set.c
@@ -280,7 +280,7 @@ doset(Char **v, struct command *c)
 	return;
     }
     pipe = 0;
-    if (c->t_dflg & F_PIPEIN || c->t_dlef)
+    if (c->t_dlef || !isatty(OLDSTD))
 	pipe = 1;
     do {
 	hadsub = 0;

--- a/sh.set.c
+++ b/sh.set.c
@@ -248,8 +248,7 @@ doset(Char **v, struct command *c)
     int	    flags = VAR_READWRITE;
     int    first_match = 0;
     int    last_match = 0;
-    int    changed;
-    int    pipe;
+    int    changed, pipe;
 
     USE(c);
     v++;
@@ -283,6 +282,9 @@ doset(Char **v, struct command *c)
     if (c->t_dlef || !isatty(OLDSTD))
 	pipe = 1;
     do {
+	Char c;
+	struct Strbuf s;
+
 	hadsub = 0;
 	vp = p;
 	if (!letter(*p))
@@ -334,11 +336,9 @@ doset(Char **v, struct command *c)
 	    Char *copy;
 
 	    if (pipe) {
-		Char c;
-		struct Strbuf s = Strbuf_INIT;
-
+		memset(&s, 0, sizeof s);
 		while (wide_read(0, &c, (size_t) 1, 0) > 0)
-		    Strbuf_append1(&s, c | LITERAL);
+		    Strbuf_append1(&s, c | QUOTE);
 		Strbuf_terminate(&s);
 		copy = s.s;
 	    } else
@@ -350,17 +350,16 @@ doset(Char **v, struct command *c)
 	}
 	else {
 	    if (pipe) {
-		Char c;
-		struct Strbuf s = Strbuf_INIT;
 		int empty = 1;
 
+		memset(&s, 0, sizeof s);
 		while (wide_read(0, &c, (size_t) 1, 0) > 0) {
 		    if (c == '\n') {
 			empty = 0;
 
 			break;
 		    }
-		    Strbuf_append1(&s, c | LITERAL);
+		    Strbuf_append1(&s, c | QUOTE);
 		}
 		if (empty && s.s == NULL) {
 		    Char **empty;

--- a/sh.set.c
+++ b/sh.set.c
@@ -337,11 +337,8 @@ doset(Char **v, struct command *c)
 		Char c;
 		struct Strbuf s = Strbuf_INIT;
 
-		while (wide_read(0, &c, (size_t) 1, 0) > 0) {
-		    if (c == '\n')
-			break;
+		while (wide_read(0, &c, (size_t) 1, 0) > 0)
 		    Strbuf_append1(&s, c | LITERAL);
-		}
 		Strbuf_terminate(&s);
 		copy = s.s;
 	    } else


### PR DESCRIPTION
In recognition of Bourne-compatible Shells and Mashey Shell, I came up with an implementation for assigning variables from pipes and redirections. Normal assignment reads until EOF or a newline is found. Indexed assignment reads until EOF. This is implemented for environment variable assignment as well. In order to avoid confusion with manual assignment, assignment from pipes and redirections is only possible if the variable name doesn't precede the assignment operator [equal sign]. This means subsequent names in a single command (e.g: set a b c) will be assigned from a pipe or redirection. If the name precedes the assignment operator, subsequent names, even if preceded or not by the assignment operator, won't read from a pipe or redirection.

This work also provides a fix for pipes and piped built-ins, at the cost of having piped built-ins forked. I don't think this cost should be taken badly, since most (if not all) Bourne-compatible Shells fork piped built-ins. The fix remedies the issue regarded [here](https://mailman.astron.com/pipermail/tcsh/2023-November/000337.html), on blank output from pipes.