### PR TITLE
Fix variable expansion on expressions.

### DIFF
--- a/sh.decls.h
+++ b/sh.decls.h
@@ -300,6 +300,9 @@ extern	int		  xopen		(const char *, int, ...);
 extern	ssize_t		  xread		(int, void *, size_t);
 extern	int		  xtcsetattr	(int, int, const struct termios *);
 extern	ssize_t		  xwrite	(int, const void *, size_t);
+extern	int		  blkcmp	(Char **, Char **);
+extern	void		  blkcmpfree	(Char **, Char **);
+extern	void		  blkcmp_cleanup(void *);
 
 /*
  * sh.parse.c

--- a/sh.dol.c
+++ b/sh.dol.c
@@ -54,8 +54,6 @@ static Char *Dcp, *const *Dvp;	/* Input vector for Dreadc */
 
 #define	unDgetC(c)	Dpeekc = c
 
-#define QUOTES		(_QF|_QB|_ESC)	/* \ ' " ` */
-
 /*
  * The following variables give the information about the current
  * $ expansion, recording the current word position, the remaining

--- a/sh.exp.c
+++ b/sh.exp.c
@@ -180,7 +180,40 @@ sh_access(const Char *fname, int mode)
 tcsh_number_t
 expr(Char ***vp)
 {
-    return (exp0(vp, 0));
+    Char **vpi, **vpc, *nblk[2], **blks[2];
+    tcsh_number_t i;
+    int len;
+
+    *blks = blks[1] = NULL;
+    cleanup_push(blks, blkcmp_cleanup);
+    len = blklen(*vp) + 1;
+    vpi = *vp;
+    vpc = *blks = xmalloc(sizeof **blks * len);
+    nblk[1] = NULL;
+    while (*vpi) {
+	*nblk = Strsave(*vpi++);
+	(void) blkcpy(vpc++, nblk);
+    }
+    blks[1] = blkcpy(xmalloc(sizeof *blks[1] * len), vpc = *blks);
+    i = exp0(&vpc, 0);
+    *vp += --len - blklen(vpc);
+    {
+	Char **nvp;
+
+	len -= blklen(vpc);
+	vpi = *blks;
+	cleanup_push(nvp = xmalloc(sizeof *nvp * (len + 1)), xfree);
+	while (vpi != vpc) {
+	    *nblk = *vpi++;
+	    (void) blkcpy(nvp++, nblk);
+	}
+	nvp -= len;
+	xechoit(nvp);
+	cleanup_until(nvp);
+    }
+    cleanup_until(blks);
+
+    return i;
 }
 
 tcsh_number_t
@@ -587,8 +620,8 @@ exp6(Char ***vp, int ignore)
 		(*vp)++;
 		return Strsave(STRNULL);
 	    }
-	    cleanup_push(cp = Dfix1(*(*vp)++), xfree);
-	    buf = globone(cp, G_ERROR);
+	    cleanup_push(cp = Dfix1(**vp), xfree);
+	    *(*vp)++ = Strsave(buf = globone(cp, G_ERROR));
 	    cleanup_until(cp);
 	    return buf;
 	}

--- a/sh.exp.c
+++ b/sh.exp.c
@@ -579,6 +579,13 @@ exp6(Char ***vp, int ignore)
 	etraci("exp6 {} status", getstatus(), vp);
 	return putn(getstatus() == 0);
     }
+    for (cp = **vp; *cp; cp++)
+	if (cmap(*cp, _DOL | QUOTES)) {
+	    (*vp)++;
+	    if (ignore & TEXP_IGNORE)
+		return Strsave(STRNULL);
+	    return Dfix1(cp);
+	}
     if (isa(**vp, ANYOP))
 	return (Strsave(STRNULL));
     cp = *(*vp)++;

--- a/sh.exp.c
+++ b/sh.exp.c
@@ -581,10 +581,16 @@ exp6(Char ***vp, int ignore)
     }
     for (cp = **vp; *cp; cp++)
 	if (cmap(*cp, _DOL | QUOTES)) {
-	    (*vp)++;
-	    if (ignore & TEXP_IGNORE)
+	    Char *buf;
+
+	    if (ignore & TEXP_IGNORE) {
+		(*vp)++;
 		return Strsave(STRNULL);
-	    return Dfix1(cp);
+	    }
+	    cleanup_push(cp = Dfix1(*(*vp)++), xfree);
+	    buf = globone(cp, G_ERROR);
+	    cleanup_until(cp);
+	    return buf;
 	}
     if (isa(**vp, ANYOP))
 	return (Strsave(STRNULL));

--- a/sh.func.c
+++ b/sh.func.c
@@ -131,7 +131,11 @@ func(struct command *t, const struct biltins *bp)
 {
     int     i;
 
-    xechoit(t->t_dcom);
+    if (bp->bfunct != doexit &&
+	bp->bfunct != dolet &&
+	bp->bfunct != doif &&
+	bp->bfunct != dowhile)
+	xechoit(t->t_dcom);
     setname(bp->bname);
     i = blklen(t->t_dcom) - 1;
     if (i < bp->minargs)

--- a/sh.h
+++ b/sh.h
@@ -1305,5 +1305,6 @@ extern int    filec;
 #define TEXP_IGNORE 1	/* in ignore, it means to ignore value, just parse */
 #define TEXP_NOGLOB 2	/* in ignore, it means not to globone */
 
+#define QUOTES (_QB|_QF|_ESC) /* \ " ' ` */
 
 #endif /* _h_sh */

--- a/sh.misc.c
+++ b/sh.misc.c
@@ -751,7 +751,8 @@ blkcmpfree(Char **fb, Char **sb)
 
 	while (*fb)
 	    xfree(*fb++);
-	xfree(ofb);
+	if (ofb != osb)
+	    xfree(ofb);
 	while (*sb)
 	    xfree(*sb++);
 	xfree(osb);
@@ -759,8 +760,9 @@ blkcmpfree(Char **fb, Char **sb)
 	return;
     }
 
+    if (fb != sb)
+	xfree(sb);
     blkfree(fb);
-    xfree(sb);
 }
 
 void

--- a/sh.misc.c
+++ b/sh.misc.c
@@ -721,3 +721,53 @@ xwrite(int fildes, const void *buf, size_t nbyte)
     while ((res = write(fildes, buf, nbyte)) == -1 && errno == EINTR);
     return res;
 }
+
+int
+blkcmp(Char **fb, Char **sb)
+{
+    if (blklen(fb) != blklen(sb))
+	return 1;
+    while (*fb == *sb++)
+	if (*fb++ == NULL)
+	    return 0;
+    return 1;
+}
+
+void
+blkcmpfree(Char **fb, Char **sb)
+{
+    if (fb == NULL)
+	fb = xcalloc(1, sizeof *fb);
+    if (sb == NULL)
+	sb = xcalloc(1, sizeof *sb);
+    if (blkcmp(fb, sb)) {
+	Char **ofb, **osb;
+
+	for (ofb = fb, osb = sb; *fb && *sb; fb++, sb++) {
+	    if (*fb != *sb)
+		xfree(*sb);
+	    xfree(*fb);
+	}
+
+	while (*fb)
+	    xfree(*fb++);
+	xfree(ofb);
+	while (*sb)
+	    xfree(*sb++);
+	xfree(osb);
+
+	return;
+    }
+
+    blkfree(fb);
+    xfree(sb);
+}
+
+void
+blkcmp_cleanup(void *xblks)
+{
+    Char **(*blks)[2];
+
+    blks = xblks;
+    blkcmpfree(**blks, (*blks)[1]);
+}


### PR DESCRIPTION
It's known variables expand earlier than expression evaluations. The procedure
```sh
if ( $?a && "$a" != ) echo "$a"
```
would fail if `a` isn't set. The correct behavior is to evaluate `$?a` first, and, if expanded to zero, cancel further processing.

This work remedies the issue by postponing variable expansions during expression evaluations. The function `Dfix1` is used for I/O redirections, and fails if the expansion is null or, if not quoted, larger than one word/vector. I believe this behavior is fine.

This work was also supposed to fix `$<` expansions on pipes and redirections. I had some success with a fix, but ends up blocking  the shell, making it unusable and uninterruptible. 