### PR TITLE
Fix job count reported by set prompt=%j

### DIFF
--- a/tc.prompt.c
+++ b/tc.prompt.c
@@ -538,13 +538,19 @@ tprintf(int what, const Char *fmt, const char *str, time_t tim, ptr_t info)
 
 	    case 'j':
 		{
-		    int njobs = -1;
+		    int njobs = 0;
 		    struct process *pp;
 
-		    for (pp = proclist.p_next; pp; pp = pp->p_next)
-			njobs++;
-		    if (njobs == -1)
-			njobs++;
+		    /* this counts jobs which haven't been "reaped" yet, but
+		       unless you've just run kill -9 %1, it shouldn't be an issue */
+		    for (pp = proclist.p_next; pp; pp = pp->p_next) {
+			if (pp->p_index > 0 && pp->p_index <= pmaxindex
+				&& pp->p_procid == pp->p_jobid)
+			{
+			    ++njobs;
+			}
+		    }
+
 		    p = Itoa(njobs, 1, attributes);
 		    Strbuf_append(&buf, p);
 		    xfree(p);


### PR DESCRIPTION
I noticed that if I have %j in my $prompt it wouldn't update until I run a (non builtin) command.

Without this patch, on master HEAD:

        tcsh$ set prompt=%j\
        0 ed
        ^Z
        Suspended
        0 ed
        ^Z
        Suspended
        1 sleep 5 &
        [3] 317772
        2
        [3]    Done                          sleep 5
        2 kill -9 %1
        2
        [1]    Killed                        ed
        2 fg
        ed
        Q
        2

Notice how after coming out of the first `ed', it still prints 0 (!). After the second it prints 1 (?).
sleep gets it to 2. killing a job is still 2. Going back to the last remaining ed and exiting... still 2.
The jobs builtin always reports correctly.

Running a ls >& /dev/null in between would update the job count reported by prompt=%j

The `jobs' builtin always reports the correct amount of jobs.

I couldn't quite wrap my head around the existing code (like why it started at -1, but -1 was printed as 0, etc), but the `jobs' builtin seemed to always report the correct count.  So I cut-pasted code from `dojobs' into the `%j' handler in tc.prompt.c so that it now reports the number of jobs in a way I actually expect.

I don't know how to automate tests for this, I couldn't even effectively break into gdb because ^Z was involved and it ended up getting processed by the shell controlling the terminal and I gave up trying to figure it out with `kill(1)' blabla. Anyway...

I tested by hand:

	tcsh$ set prompt='%j '
	0 ed
	^Z
	Suspended
	1 ed
	^Z
	Suspended
	2 sleep 5 &
	[3] 12345
	3
	[3]	Done		sleep 5
	2 kill -9 %1
	2
	[1]	Killed
	1
	fg
	ed
	Q
	0

Notice how after coming out of `ed' after ^Z, the prompt is 1; same after the second one. Same after sleep.

Killing a job does not update it, but I didn't want to mess with how it usually works and get in the way of the jobs builtin or how the shell eventually reports jobs that went away etc.

If anyone has a better implementation, I'd be happy to test it/use it, but the existing code doesn't quite seem to work right.

Why did I end up with %j in $prompt? I got bored of the endless ^D There are jobs running fg fg fg ^D There are jobs running fg fg ^D There are jobs running fg fg fg fg when trying to shut down everything that was running in tmux for reboot. And dealing with floating vim swap files that got left around isn't what I'd consider fun :-)