### PR TITLE
fix typos

### DIFF
--- a/Announce-6.07.02
+++ b/Announce-6.07.02
@@ -1,7 +1,7 @@
 Hello,
 
 I am pleased to announce that tcsh-6.07 is finally available; this is
-a bug fix maintainance release with only two new features:
+a bug fix maintenance release with only two new features:
 
 	- GNU style configure script (ghazi@caip.rutgers.edu)
 	- implicit chdir (hutchins@sgi.com & dbg@sgi.com)

--- a/BUILDING
+++ b/BUILDING
@@ -160,7 +160,7 @@ minix to config.h, and then 'make sh.err.h tc.const.h ed.defns.h'
 
 The OS/dependent files are in mi.termios.h, mi.wait.h, mi.varargs.h
 
-You will get some warnings, but dont worry about them, just ignore them.
+You will get some warnings, but don't worry about them, just ignore them.
 After tcsh has compiled and the gcc binary is converted to a minix
 binary, remember to chmem it to give it more memory - it will need it!
 How much you need depends on how many aliases you have, etc..  Add at

--- a/Fixes
+++ b/Fixes
@@ -451,7 +451,7 @@
  61. V6.14.06 - 2006-08-24
  60. set PROGRAM_ENVIRONMENT for OSD_POSIX (Martin Kraemer)
  59. EBCDIC patch (Martin Kraemer)
- 58. Remove globbing support in history rearches (Ryan Barrett)
+ 58. Remove globbing support in history searches (Ryan Barrett)
  57. Highlighting patch (Ryan Barrett)
  56. Mark-Cursor exchange emacs editing fix (Martin Kraemer)
  55. V6.14.05 - 2006-03-04
@@ -595,7 +595,7 @@
  24. Additional architectures support for $HOSTTYPE and $MACHTYPE
      (Miloslav Trmac)
  23. Use nl_langinfo(CODESET) to determine $dspmbyte (Miloslav Trmac)
- 22. Complete arguments that contant a # (Steven Grady)
+ 22. Complete arguments that contain a # (Steven Grady)
  21. Set close-on-exec in subshells
  20. Compilation fixes (Miloslav Trmac)
  19. V6.13.02 - 2004-08-04
@@ -789,7 +789,7 @@
      http://www.linux.or.jp/JF/JFdocs/Japanese-Locale-Policy.txt
      (Tomohiro KUBOTA)
  48. Ukrainian nls map (Olexander Kunytsa)
- 47. exit immeditiately if we get an error while we are setting up
+ 47. exit immediately if we get an error while we are setting up
      (Michael Shalayeff)
  46. (unset path; unsetenv PATH; rehash) -> crash (Kent Vander Velden)
  45. change winnt to winnt_native (Randolph Fritz)
@@ -976,7 +976,7 @@
  44. Pentium DGUX fixes (Miko Nahum)
  43. Spanish nls message catalogs (Luis Francisco Gonzalez)
  42. Fix trailing whitespace parsing in HASHBANG code (Martin Kraemer)
- 41. Remove stray debuggin message from unmatched substitutions.
+ 41. Remove stray debugging message from unmatched substitutions.
      (from Amol Deshpande)
  40. Fix reversed arguments in Usagae message. (from Amol Deshpande)
  39. Fix bug introduced at tcsh-7.06.03 [expdollar] that affected %.n prompt
@@ -1434,7 +1434,7 @@ V6.04.00, 07/03/93
  64. Unsigned long rlimit type for 64 bit machines (alpha)
  63. Fixed Imakefile for alpha
  62. tilde expansion now obeys $nonomatch
- 61. readonly veriables. 'set -r x=3' will set x to a very sticky 3...
+ 61. readonly variables. 'set -r x=3' will set x to a very sticky 3...
  60. Fixed bug in the new tab'ed completion that interfered with old listing.
  59. Fixed entry -> item in tw.parse.c
  58. Added -f option to unlimit
@@ -1474,9 +1474,9 @@ V6.04.00, 07/03/93
  40. Fixed 'unset home; dirs' bug
  39. fixed $HOME->$home memory problem.
  38. $?0 returns false now on interactive shells for csh compatibility.
- 37. Default watch inteval was 10 hours not 10 minutes as advertized in the
+ 37. Default watch interval was 10 hours not 10 minutes as advertised in the
      manual!
- 36. Fixed clobbered veriable warning from gcc-1.39 in tw.parse.c
+ 36. Fixed clobbered variable warning from gcc-1.39 in tw.parse.c
  35. Fixed typo with INVPTR in sh.lex.c
  34. 6.03.03 03/04/93
  33. Eliminate 'Reset tty pgrp error message'. It is normal for the
@@ -1513,7 +1513,7 @@ V6.04.00, 07/03/93
      ...
  15. 6.03.01 08/01/93
  14. #undef SHORT_STRINGS gcc warning fixes...
- 13. csh bug fix in foreach [quoteing problem]
+ 13. csh bug fix in foreach [quoting problem]
      > foreach i ("*")
      > echo $i:q
      > end
@@ -1659,7 +1659,7 @@ V6.03.00, 11/20/92
 19. Fix automatic correction to work with the new completion.
 18. Globbing bug with brace expansion, when arguments need to be realloced...
     e.g. echo 134{6,7}{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
-17. shift and left operators update variables correcly ('shift path' did not 
+17. shift and left operators update variables correctly ('shift path' did not 
     work)
 16. apollo fixes for cd.
 15. STRNULL <-> NULL bug fixes.
@@ -1763,7 +1763,7 @@ V6.02.00, 5/15/92
 35. sysv_echo is gone too. Now we have a variable called echo_style
     which can be set to "none", "bsd", "sysv", "both" that defines
     the builtin echo_style. The default is "bsd" for systems with
-    SYSVREL == 0, "sysv" otherwise. This can be overriden in config.h
+    SYSVREL == 0, "sysv" otherwise. This can be overridden in config.h
     by defining ECHO_STYLE ro be BSD_ECHO, SYSV_ECHO, BOTH_ECHO, 
     or NONE_ECHO.
 34. asynchronous notification in run-fg-editor would try to change the 
@@ -2157,7 +2157,7 @@ V5.20.00, 11/10/90.
 26. Fixed system V and POSIX time reporting.
 25. Fixed ed.screen.c so that it does not use malloc().
 24. Fixed SIGWINCH on the iris
-23. Fixed ed.screen.c, so that settc works correcly. It used to set
+23. Fixed ed.screen.c, so that settc works correctly. It used to set
     the termcap with a string that was allocated from the stack!
 22. Fixed listing of commands, where the last command was not checked.
 21. Fixed which command. It did not work for

--- a/Imakefile
+++ b/Imakefile
@@ -388,7 +388,7 @@ AFSDIR = /usr/afsws
 #else
 #define AFS33LIB
 #endif
-/* Auxilliary libs needed for AFS */
+/* Auxiliary libs needed for AFS */
 /* Both HPUX and Solaris need the BSD libraries.  We need -lc before
  * the bsd library to avoid using any more of it than is necessary.
  */

--- a/Ported
+++ b/Ported
@@ -841,7 +841,7 @@ CONFIG	:	coh3
 ENVIRON	:	gnu tools (see below)
 NOTES	:	The standard make, /bin/sh and sed that come with Coherent are
 NOTES	:	not quite up to the makefile.  Either use gnu make or change 
-NOTES	:	occurances of '# to '\# since Coherent's make takes all '#'s to
+NOTES	:	occurrences of '# to '\# since Coherent's make takes all '#'s to
 NOTES	:	be a comment, even when quoted, except when escaped by '\'.
 NOTES	:	Coherent's /bin/sh does not allow you to set VERSION, etc.
 NOTES	:	since they are hard-wired internal variables.  Either use 

--- a/csh-mode.el
+++ b/csh-mode.el
@@ -833,7 +833,7 @@ Installation:
            (insert completion))
 	  ;;
 	  ;; write possible completion in the minibuffer,
-	  ;; use this instead of a seperate buffer (usual)
+	  ;; use this instead of a separate buffer (usual)
 	  ;;
           (t
            (let ((list (all-completions pattern csh-completion-list predicate))

--- a/dotlock.c
+++ b/dotlock.c
@@ -121,7 +121,7 @@ bad:
 
 /*
  * fname -- Pathname to lock
- * pollinterval -- Interval (miliseconds) to check for lock, -1 return
+ * pollinterval -- Interval (milliseconds) to check for lock, -1 return
  */
 int
 dot_lock(const char *fname, int pollinterval)

--- a/dotlock.h
+++ b/dotlock.h
@@ -27,7 +27,7 @@
 
 /*
  * fname -- Pathname to lock
- * pollinterval -- Interval (miliseconds) to check for lock, -1 return
+ * pollinterval -- Interval (milliseconds) to check for lock, -1 return
  */
 int dot_lock(const char *fname, int pollinterval);
 void dot_unlock(const char *fname);

--- a/ed.chared.c
+++ b/ed.chared.c
@@ -33,15 +33,15 @@
   Bjorn Knutsson @ Thu Jun 24 19:02:17 1999
 
   e_dabbrev_expand() did not do proper completion if quoted spaces were present
-  in the string being completed. Exemple:
+  in the string being completed. Example:
 
   # echo hello\ world
   hello world
-  # echo h<press key bound to dabbrev-expande>
+  # echo h<press key bound to dabbrev-expand>
   # echo hello\<cursor>
 
   Correct behavior is:
-  # echo h<press key bound to dabbrev-expande>
+  # echo h<press key bound to dabbrev-expand>
   # echo hello\ world<cursor>
 
   The same problem occurred if spaces were present in a string withing
@@ -49,7 +49,7 @@
 
   # echo "hello world"
   hello world
-  # echo "h<press key bound to dabbrev-expande>
+  # echo "h<press key bound to dabbrev-expand>
   # echo "hello<cursor>
 
   The former problem could be solved with minor modifications of c_preword()
@@ -539,7 +539,7 @@ excl_sw:
 	     */
 	    if (all_dig) {
 		if (all_dig == 2)
-		    i = -i;	/* make it negitive */
+		    i = -i;	/* make it negative */
 		if (i < 0)	/* if !-4 (for example) */
 		    i = eventno + 1 + i;	/* remember: i is < 0 */
 		for (; h; h = h->Hnext) {
@@ -3779,7 +3779,7 @@ v_undo(Char c)
 	cp = UndoPtr;
 	Cursor = UndoPtr;
 	kp = UndoBuf;
-	size = (int)(Cursor-LastChar); /*  NOT NSL independant */
+	size = (int)(Cursor-LastChar); /*  NOT NSL independent */
 	if (size < UndoSize)
 	    size = UndoSize;
 	for (loop = 0; loop < size; loop++) {

--- a/ed.defns.c
+++ b/ed.defns.c
@@ -597,7 +597,7 @@ static KEYCMD  CcViMap[] = {
 #else /* !KSHVI */
     F_UNASSIGNED,		/* ^@ */   /* NOTE: These mapping do NOT */
     F_TOBEG,			/* ^A */   /* Correspond well to the KSH */
-    F_CHARBACK,			/* ^B */   /* VI editting assignments    */
+    F_CHARBACK,			/* ^B */   /* VI editing assignments    */
     F_TTY_INT,			/* ^C */   /* On the other hand they are */
     F_LIST_EOF,			/* ^D */   /* convenient any many people */
     F_TOEND,			/* ^E */   /* have gotten used to them   */

--- a/ed.h
+++ b/ed.h
@@ -75,7 +75,7 @@ extern struct KeyFuncs FuncNames[];	/* string names vs. CcFuncTbl indices */
 extern KEYCMD NumFuns;		/* number of KEYCMDs in above table */
 
 #define	CC_ERROR		100	/* there should NOT be 100 different... */
-#define CC_FATAL		101	/* fatal error: inconsistant, must
+#define CC_FATAL		101	/* fatal error: inconsistent, must
 					 * reset */
 #define	CC_NORM			0
 #define	CC_NEWLINE		1
@@ -172,7 +172,7 @@ EXTERN Char *KeyMacro[MAXMACROLEVELS];
    in the middle of a multiple-column character. */
 EXTERN Char **Display;		/* display buffer seed vector */
 EXTERN int CursorV,		/* real cursor vertical (line) */
-        CursorH,		/* real cursor horisontal (column) */
+        CursorH,		/* real cursor horizontal (column) */
         TermV,			/* number of real screen lines
 				 * (sizeof(DisplayBuf) / width */
         TermH;			/* screen width */

--- a/ed.inputl.c
+++ b/ed.inputl.c
@@ -215,7 +215,7 @@ Inputl(void)
 
 	case CC_WHICH:		/* tell what this command does */
 	    tellwhat = 1;
-	    *LastChar++ = '\n';	/* for the benifit of CSH */
+	    *LastChar++ = '\n';	/* for the benefit of CSH */
 	    num = (int) (LastChar - InputBuf);	/* number characters read */
 	    break;
 
@@ -827,7 +827,7 @@ GetNextChar(Char *cp)
  * (which may have trailing newline).
  * If cmdonly is set, only check spelling of command words.
  * Return value:
- * -1: Something was incorrectible, and nothing was corrected
+ * -1: Something was uncorrectable, and nothing was corrected
  *  0: Everything was correct
  *  1: Something was corrected
  */

--- a/ed.refresh.c
+++ b/ed.refresh.c
@@ -178,7 +178,7 @@ Draw(Char *cp, int nocomb, int drawPrompt)
 	    /* ~(UNDER | BOLD | STANDOUT) = 0xf1ffffff */
 	    c = *cp & ~(UNDER | BOLD | STANDOUT);
 
-	    /* if c is ctrl code, we handle *cp as havnig no attributes */
+	    /* if c is ctrl code, we handle *cp as having no attributes */
 	    if ((c < 0x20 && c >= 0) || c == 0x7f) {
 		attr = 0;
 		c = *cp;
@@ -656,7 +656,7 @@ update_line(Char *old, Char *new, int cur_line)
     nls = n;
 
     /*
-     * find same begining and same end
+     * find same beginning and same end
      */
     osb = ols;
     nsb = nls;
@@ -856,7 +856,7 @@ update_line(Char *old, Char *new, int cur_line)
     p = (ols != oe) ? oe : ose;
 
     /*
-     * if (There is a diffence in the beginning) && (we need to insert
+     * if (There is a difference in the beginning) && (we need to insert
      * characters) && (the number of characters to insert is less than the term
      * width) We need to do an insert! else if (we need to delete characters)
      * We need to delete characters! else No insert or delete

--- a/ed.screen.c
+++ b/ed.screen.c
@@ -38,7 +38,7 @@
 
 /*
  * IMPORTANT NOTE: these routines are allowed to look at the current screen
- * and the current possition assuming that it is correct.  If this is not
+ * and the current position assuming that it is correct.  If this is not
  * true, then the update will be WRONG!  This is (should be) a valid
  * assumption...
  */
@@ -1079,7 +1079,7 @@ mc_again:
 
     if (where >= TermH) {
 #ifdef DEBUG_SCREEN
-	xprintf("MoveToChar: where is riduculous: %d\r\n", where);
+	xprintf("MoveToChar: where is ridiculous: %d\r\n", where);
 	flush();
 #endif /* DEBUG_SCREEN */
 	return;
@@ -1152,7 +1152,7 @@ so_write(Char *cp, int n)
 
     if (n > TermH) {
 #ifdef DEBUG_SCREEN
-	xprintf("so_write: n is riduculous: %d\r\n", n);
+	xprintf("so_write: n is ridiculous: %d\r\n", n);
 	flush();
 #endif /* DEBUG_SCREEN */
 	return;
@@ -1248,7 +1248,7 @@ DeleteChars(int num)		/* deletes <num> characters */
 
     if (num > TermH) {
 #ifdef DEBUG_SCREEN
-	xprintf(CGETS(7, 17, "DeleteChars: num is riduculous: %d\r\n"), num);
+	xprintf(CGETS(7, 17, "DeleteChars: num is ridiculous: %d\r\n"), num);
 	flush();
 #endif /* DEBUG_SCREEN */
 	return;
@@ -1288,7 +1288,7 @@ Insert_write(Char *cp, int num)
 
     if (num > TermH) {
 #ifdef DEBUG_SCREEN
-	xprintf(CGETS(7, 19, "StartInsert: num is riduculous: %d\r\n"), num);
+	xprintf(CGETS(7, 19, "StartInsert: num is ridiculous: %d\r\n"), num);
 	flush();
 #endif /* DEBUG_SCREEN */
 	return;
@@ -1388,7 +1388,7 @@ ClearToBottom(void)
 
 void
 GetTermCaps(void)
-{				/* read in the needed terminal capabilites */
+{				/* read in the needed terminal capabilities */
     int i;
     const char   *ptr;
     char    buf[TC_BUFSIZE];

--- a/ed.term.h
+++ b/ed.term.h
@@ -494,7 +494,7 @@
 #define C_SH(A)		(1 << (A))
 
 /*
- * Terminal dependend data structures
+ * Terminal dependent data structures
  */
 typedef struct {
 #ifdef WINNT_NATIVE

--- a/glob.c
+++ b/glob.c
@@ -657,7 +657,7 @@ glob3(struct strbuf *pathbuf, const Char *pattern, const Char *restpattern,
 
 
 /*
- * Extend the gl_pathv member of a glob_t structure to accomodate a new item,
+ * Extend the gl_pathv member of a glob_t structure to accommodate a new item,
  * add the new item, and update gl_pathc.
  *
  * This assumes the BSD realloc, which only copies the block when its size

--- a/host.defs
+++ b/host.defs
@@ -960,7 +960,7 @@ ostype	:						: "masscomp"
 enddef	:
 
 newdef	: defined(MACHTEN)
-comment : Machintosh
+comment : Macintosh
 vendor	:						: "Tenon"
 hosttype:						: "Macintosh"
 ostype	:						: "MachTen"

--- a/ma.setp.c
+++ b/ma.setp.c
@@ -48,7 +48,7 @@
  *	-c oldpath newpath	change oldpath to newpath
  *	-c# newpath		change position # to newpath
  *
- *  The "-i newpath" command is equivilent to "-ib 'localsyspath' newpath".
+ *  The "-i newpath" command is equivalent to "-ib 'localsyspath' newpath".
  *
  *  If 'dosuffix' is true, the appropriate suffix will be added to
  *  all command operands for any system path in 'paths'.

--- a/mi.termios.c
+++ b/mi.termios.c
@@ -197,7 +197,7 @@ struct termios *termios_p;
 
     /* Minix local flags:
      *   ECHO:    set if ECHO is set
-     *   ECHOE:   set if ECHO is set (ERASE echoed as error-corecting backspace)
+     *   ECHOE:   set if ECHO is set (ERASE echoed as error-correcting backspace)
      *   ECHOK:   set if ECHO is set ('\n' echoed after KILL char)
      *   ECHONL:  forced off ('\n' not echoed when ECHO isn't set)
      *   ICANON:  set if neither CBREAK nor RAW
@@ -254,7 +254,7 @@ struct termios *termios_p;
      * but only the input baudrate is valid for both.
      * As our termios emulation will fail, if input baudrate differs
      * from output baudrate, force them to be equal.
-     * Otherwise it would be very suprisingly not to be able to set
+     * Otherwise it would be very surprisingly not to be able to set
      * the terminal back to the state returned by tcgetattr :).
      */
     termios_p->c_ospeed =
@@ -313,7 +313,7 @@ struct termios *termios_p;
      * invalid or unsupported by the hardware, they just couldn't be satisfied
      * by the driver). Not returning an error might be even worse because the
      * driver will act different to what the application requires it to act
-     * after sucessfully setting the attributes as specified.
+     * after successfully setting the attributes as specified.
      * Settings that cannot be emulated fully include:
      *   c_ospeed != 110 && c_cflag & CSTOPB
      *   c_ospeed == 110 && ! c_cflag & CSTOPB

--- a/nls/C/set2
+++ b/nls/C/set2
@@ -75,7 +75,7 @@ $set 2
 73 Third Last Realtime Signal
 74 Second Last Realtime Signal
 75 Last Realtime Signal
-76 LAN Asyncronous I/O
+76 LAN Asynchronous I/O
 77 PTY read/write availability
 78 I/O intervention required
 79 HFT monitor mode granted

--- a/nls/german/set2
+++ b/nls/german/set2
@@ -75,7 +75,7 @@ $set 2
 73 Third Last Realtime Signal
 74 Second Last Realtime Signal
 75 Last Realtime Signal
-76 LAN Asyncronous I/O
+76 LAN Asynchronous I/O
 77 PTY read/write availability
 78 I/O intervention required
 79 HFT monitor mode granted

--- a/nls/pl/set2
+++ b/nls/pl/set2
@@ -75,7 +75,7 @@ $set 2
 73 Third Last Realtime Signal
 74 Second Last Realtime Signal
 75 Last Realtime Signal
-76 LAN Asyncronous I/O
+76 LAN Asynchronous I/O
 77 PTY read/write availability
 78 I/O intervention required
 79 HFT monitor mode granted

--- a/nls/russian/set2
+++ b/nls/russian/set2
@@ -75,7 +75,7 @@ $set 2
 73 Third Last Realtime Signal
 74 Second Last Realtime Signal
 75 Last Realtime Signal
-76 LAN Asyncronous I/O
+76 LAN Asynchronous I/O
 77 PTY read/write availability
 78 I/O intervention required
 79 HFT monitor mode granted

--- a/nls/ukrainian/set2
+++ b/nls/ukrainian/set2
@@ -75,7 +75,7 @@ $set 2
 73 Third Last Realtime Signal
 74 Second Last Realtime Signal
 75 Last Realtime Signal
-76 LAN Asyncronous I/O
+76 LAN Asynchronous I/O
 77 PTY read/write availability
 78 I/O intervention required
 79 HFT monitor mode granted

--- a/sh.c
+++ b/sh.c
@@ -114,7 +114,7 @@ int tcsh;
 
 /*
  * This preserves the input state of the shell. It is used by
- * st_save and st_restore to manupulate shell state.
+ * st_save and st_restore to manipulate shell state.
  */
 struct saved_state {
     int		  insource;
@@ -523,7 +523,7 @@ main(int argc, char **argv)
      * terminal.
      *
      * bugfix by Rich Salz <rsalz@PINEAPPLE.BBN.COM>: For root rsh things
-     * allways first check to see if loginsh or really root, then do things
+     * always first check to see if loginsh or really root, then do things
      * with ttyname()
      *
      * Also by Jean-Francois Lamy <lamy%ai.toronto.edu@RELAY.CS.NET>: check the
@@ -1195,7 +1195,7 @@ main(int argc, char **argv)
 #endif
 	    /*
 	     * Wait till in foreground, in case someone stupidly runs csh &
-	     * dont want to try to grab away the tty.
+	     * don't want to try to grab away the tty.
 	     */
 	    if (isatty(FSHDIAG))
 		f = FSHDIAG;

--- a/sh.dir.c
+++ b/sh.dir.c
@@ -458,7 +458,7 @@ dnormalize(const Char *cp, int expnd)
 	    /* Reduction of ".." following the stuff we collected in buf
 	     * only makes sense if the directory item in buf really exists.
 	     * Avoid reduction of "-I../.." (typical compiler call) to ""
-	     * or "/usr/nonexistant/../bin" to "/usr/bin":
+	     * or "/usr/nonexistent/../bin" to "/usr/bin":
 	     */
 	    if (cwd[0]) {
 	        struct stat exists;
@@ -604,7 +604,7 @@ dfollow(Char *cp, int old)
 
     /*
      * if we are ignoring symlinks, try to fix relatives now.
-     * if we are expading symlinks, it should be done by now.
+     * if we are expanding symlinks, it should be done by now.
      */
     dp = dnormalize(cp, symlinks == SYM_IGNORE);
     if (chdir(short2str(dp)) >= 0) {

--- a/sh.dol.c
+++ b/sh.dol.c
@@ -43,7 +43,7 @@
  * input words.  Here we expand variables and turn quoting via ' and " into
  * QUOTE bits on characters (which prevent further interpretation).
  * If the `:q' modifier was applied during history expansion, then
- * some QUOTEing may have occurred already, so we dont "trim()" here.
+ * some QUOTEing may have occurred already, so we don't "trim()" here.
  */
 
 static eChar Dpeekc;		/* Peek for DgetC */

--- a/sh.exec.c
+++ b/sh.exec.c
@@ -689,7 +689,7 @@ dohash(Char **vv, struct command *c)
     xhash = xcalloc(hashlength * hashwidth, 1);
 #endif /* FASTHASH */
 
-    (void) getusername(NULL);	/* flush the tilde cashe */
+    (void) getusername(NULL);	/* flush the tilde cache */
     tw_cmd_free();
     havhash = 1;
     if (v == NULL)

--- a/sh.file.c
+++ b/sh.file.c
@@ -711,7 +711,7 @@ tenex(Char *inputline, size_t inputline_size)
 	    --str_end;		/* wipeout trailing cmd Char */
 	*str_end = '\0';
 	/*
-	 * Find LAST occurence of a delimiter in the inputline. The word start
+	 * Find LAST occurrence of a delimiter in the inputline. The word start
 	 * is one Character past it.
 	 */
 	for (word_start = str_end; word_start > inputline; --word_start)

--- a/sh.func.c
+++ b/sh.func.c
@@ -391,7 +391,7 @@ reexecute(struct command *kp)
     kp->t_dflg &= F_SAVE;
     kp->t_dflg |= F_REPEAT;
     /*
-     * If tty is still ours to arbitrate, arbitrate it; otherwise dont even set
+     * If tty is still ours to arbitrate, arbitrate it; otherwise don't even set
      * pgrp's as the jobs would then have no way to get the tty (we can't give
      * it to them, and our parent wouldn't know their pgrp, etc.
      */

--- a/sh.h
+++ b/sh.h
@@ -439,7 +439,7 @@ typedef long tcsh_number_t;
 # include <arpa/inet.h>
 # include <sys/socket.h>
 # if (defined(_SS_SIZE) || defined(_SS_MAXSIZE)) && defined(HAVE_STRUCT_SOCKADDR_STORAGE_SS_FAMILY)
-#  if !defined(__APPLE__) /* Damnit, where is getnameinfo() folks? */
+#  if !defined(__APPLE__) /* Damn it, where is getnameinfo() folks? */
 #   if !defined(sgi)
 #    define INET6
 #   endif /* sgi */
@@ -734,7 +734,7 @@ extern struct sigaction parterm;	/* Parents terminate catch */
  * By fix for handling unicode name file, 32nd bit is used.
  * We need use '&' instead of '> or <' when comparing with INVALID_BYTE etc..
  * Cast to uChar is not recommended,
- *  becase Char is 4bytes but uChar is 8bytes on I32LP64. */
+ *  because Char is 4bytes but uChar is 8bytes on I32LP64. */
 # define	QUOTE		0x80000000
 # define	TRIM		0x7FFFFFFF /* Mask to strip quote bit */
 # define	UNDER		0x08000000 /* Underline flag */
@@ -878,7 +878,7 @@ EXTERN size_t lap; /* N/A if == labuf.len, index into labuf.s otherwise */
  *
  * Each command is parsed to a tree of command structures and
  * flags are set bottom up during this process, to be propagated down
- * as needed during the semantics/exeuction pass (sh.sem.c).
+ * as needed during the semantics/execution pass (sh.sem.c).
  */
 struct command {
     unsigned char   t_dtyp;	/* Type of node 		 */

--- a/sh.hist.c
+++ b/sh.hist.c
@@ -348,7 +348,7 @@ finalizeHash(struct hashValue *h)
 
 #else
 #define hashFcnName "add-mul"
-/* Simple multipy and add hash. */
+/* Simple multiply and add hash. */
 #define PRIME_LENGTH 1			/* need "good" HTL */
 struct hashValue { uint32_t h; };
 static void
@@ -1313,7 +1313,7 @@ rechist(Char *xfname, int ref)
 #ifndef WINNT_NATIVE
 		char *lockpath = strsave(short2str(fname));
 		cleanup_push(lockpath, xfree);
-		/* Poll in 100 miliseconds interval to obtain the lock. */
+		/* Poll in 100 milliseconds interval to obtain the lock. */
 		if ((dot_lock(lockpath, 100) == 0))
 		    cleanup_push(lockpath, dotlock_cleanup);
 #endif

--- a/sh.init.c
+++ b/sh.init.c
@@ -804,7 +804,7 @@ mesginit(void)
     /* aiws */
     if (mesg[SIGAIO].pname == NULL) {
 	mesg[SIGAIO].iname = "AIO";
-	mesg[SIGAIO].pname = CSAVS(2, 76, "LAN Asyncronous I/O");
+	mesg[SIGAIO].pname = CSAVS(2, 76, "LAN Asynchronous I/O");
     }
 #endif /* SIGAIO */
 
@@ -837,7 +837,7 @@ mesginit(void)
     if (mesg[SIGRETRACT].pname == NULL) {
 	mesg[SIGRETRACT].iname = "RETRACT";
 	mesg[SIGRETRACT].pname = CSAVS(2, 80,
-				  "HFT monitor mode should be relinguished");
+				  "HFT monitor mode should be relinquished");
     }
 #endif /* SIGRETRACT */
 
@@ -987,7 +987,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGNMEM].pname == NULL) {
 	mesg[SIGNMEM].iname = "NMEM";
-	mesg[SIGNMEM].pname = CSAVS(2, 99, "exce error for no memory");
+	mesg[SIGNMEM].pname = CSAVS(2, 99, "exec error for no memory");
     }
 #endif /* SIGNMEM */
 
@@ -1031,7 +1031,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGXXMU].pname == NULL) {
 	mesg[SIGXXMU].iname = "XXMU";
-	mesg[SIGXXMU].pname = CSAVS(2, 104, "exeeded XMU size limit");
+	mesg[SIGXXMU].pname = CSAVS(2, 104, "exceeded XMU size limit");
     }
 #endif /* SIGXXMU */
 
@@ -1039,7 +1039,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGXRLG0].pname == NULL) {
 	mesg[SIGXRLG0].iname = "XRLG0";
-	mesg[SIGXRLG0].pname = CSAVS(2, 105, "exeeded RLG0 limit");
+	mesg[SIGXRLG0].pname = CSAVS(2, 105, "exceeded RLG0 limit");
     }
 #endif /* SIGXRLG0 */
 
@@ -1047,7 +1047,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGXRLG1].pname == NULL) {
 	mesg[SIGXRLG1].iname = "XRLG1";
-	mesg[SIGXRLG1].pname = CSAVS(2, 106, "exeeded RLG1 limit");
+	mesg[SIGXRLG1].pname = CSAVS(2, 106, "exceeded RLG1 limit");
     }
 #endif /* SIGXRLG1 */
 
@@ -1055,7 +1055,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGXRLG2].pname == NULL) {
 	mesg[SIGXRLG2].iname = "XRLG2";
-	mesg[SIGXRLG2].pname = CSAVS(2, 107, "exeeded RLG2 limit");
+	mesg[SIGXRLG2].pname = CSAVS(2, 107, "exceeded RLG2 limit");
     }
 #endif /* SIGXRLG2 */
 
@@ -1063,7 +1063,7 @@ mesginit(void)
     /* SX-4 */
     if (mesg[SIGXRLG3].pname == NULL) {
 	mesg[SIGXRLG3].iname = "XRLG3";
-	mesg[SIGXRLG3].pname = CSAVS(2, 108, "exeeded RLG3 limit");
+	mesg[SIGXRLG3].pname = CSAVS(2, 108, "exceeded RLG3 limit");
     }
 #endif /* SIGXRLG3 */
 }

--- a/sh.misc.c
+++ b/sh.misc.c
@@ -1,5 +1,5 @@
 /*
- * sh.misc.c: Miscelaneous functions
+ * sh.misc.c: Miscellaneous functions
  */
 /*-
  * Copyright (c) 1980, 1991 The Regents of the University of California.

--- a/sh.proc.c
+++ b/sh.proc.c
@@ -630,7 +630,7 @@ loop:
 	    /* wait for (or pick up alredy blocked) SIGCHLD */
 	    sigsuspend(&pause_mask);
 
-	    /* make the 'wait' interuptable by CTRL-C */
+	    /* make the 'wait' interruptible by CTRL-C */
 	    opintr_disabled = pintr_disabled;
 	    pintr_disabled = 0;
 	    gotsig = handle_pending_signals();

--- a/sh.set.c
+++ b/sh.set.c
@@ -147,7 +147,7 @@ update_vars(Char *vp)
 
 	cp = Strsave(varval(vp));	/* get the old value back */
 	/*
-	 * convert to cononical pathname (possibly resolving symlinks)
+	 * convert to canonical pathname (possibly resolving symlinks)
 	 */
 	canon = dcanon(cp, cp);
 	cleanup_push(canon, xfree);
@@ -680,7 +680,7 @@ set1(const Char *var, Char **vec, struct varent *head, int flags)
 	    for (num_items = 0; vec[num_items]; num_items++)
 	        continue;
 	    if (flags & VAR_FIRST) {
-		/* delete duplications, keeping first occurance */
+		/* delete duplications, keeping first occurrence */
 		for (i = 1; i < num_items; i++)
 		    for (j = 0; j < i; j++)
 			/* If have earlier identical item, remove i'th item */
@@ -690,7 +690,7 @@ set1(const Char *var, Char **vec, struct varent *head, int flags)
 			    break;
 			}
 	    } else if (flags & VAR_LAST) {
-	      /* delete duplications, keeping last occurance */
+	      /* delete duplications, keeping last occurrence */
 		for (i = 0; i < num_items - 1; i++)
 		    for (j = i + 1; j < num_items; j++)
 			/* If have later identical item, remove i'th item */

--- a/sh.time.c
+++ b/sh.time.c
@@ -245,7 +245,7 @@ ruadd(struct process_stats *ru, struct process_stats *ru2)
 
 /* Convert clicks (kernel pages) to kbytes ... */
 /* If there is no PGSHIFT defined, assume it is	11 */
-/* Is this needed for compatability with some old flavor of 4.2	or 4.1?	*/
+/* Is this needed for compatibility with some old flavor of 4.2	or 4.1?	*/
 #ifdef SUNOS4
 # ifndef PGSHIFT
 #  define pagetok(size)	  ((size) << 1)
@@ -332,7 +332,7 @@ prusage(struct tms *bs, struct tms *es, clock_t e, clock_t b)
 #ifdef BSDTIMES
 # ifdef	convex
     static struct system_information sysinfo;
-    long long memtmp;	/* let memory calculations exceede 2Gb */
+    long long memtmp;	/* let memory calculations exceed 2Gb */
 # endif	/* convex */
     int	    ms = (int)
     ((e->tv_sec	- b->tv_sec) * 100 + (e->tv_usec - b->tv_usec) / 10000);
@@ -570,7 +570,7 @@ prusage(struct tms *bs, struct tms *es, clock_t e, clock_t b)
 		    xprintf("?");
 		break;
 # endif	/* convex */
-	    case 'r':		/* PWP:	socket messages	recieved */
+	    case 'r':		/* PWP:	socket messages	received */
 #ifdef _OSD_POSIX
 		xprintf("0",0);
 #else

--- a/tc.func.c
+++ b/tc.func.c
@@ -498,7 +498,7 @@ dowhich(Char **v, struct command *c)
     USE(c);
 
     /*
-     * We don't want to glob dowhich args because we lose quoteing
+     * We don't want to glob dowhich args because we lose quoting
      * E.g. which \ls if ls is aliased will not work correctly if
      * we glob here.
      */

--- a/tc.os.c
+++ b/tc.os.c
@@ -1038,7 +1038,7 @@ fix_yp_bugs(void)
     extern int yp_get_default_domain (char **);
     /*
      * PWP: The previous version assumed that yp domain was the same as the
-     * internet name domain.  This isn't allways true. (Thanks to Mat Landau
+     * internet name domain.  This isn't always true. (Thanks to Mat Landau
      * <mlandau@bbn.com> for the original version of this.)
      */
     if (yp_get_default_domain(&mydomain) == 0) {	/* if we got a name */

--- a/tc.prompt.c
+++ b/tc.prompt.c
@@ -35,8 +35,8 @@
 
 /*
  * kfk 21oct1983 -- add @ (time) and / ($cwd) in prompt.
- * PWP 4/27/87 -- rearange for tcsh.
- * mrdch@com.tau.edu.il 6/26/89 - added ~, T and .# - rearanged to switch()
+ * PWP 4/27/87 -- rearrange for tcsh.
+ * mrdch@com.tau.edu.il 6/26/89 - added ~, T and .# - rearranged to switch()
  *                 instead of if/elseif
  * Luke Mewburn
  *	6-Sep-91	changed date format
@@ -311,7 +311,7 @@ tprintf(int what, const Char *fmt, const char *str, time_t tim, ptr_t info)
 		    cz = getenv("HOST");
 		/*
 		 * Bug pointed out by Laurent Dami <dami@cui.unige.ch>: don't
-		 * derefrence that NULL (if HOST is not set)...
+		 * dereference that NULL (if HOST is not set)...
 		 */
 		if (cz != NULL)
 		    tprintf_append_mbs(&buf, cz, attributes);

--- a/tc.wait.h
+++ b/tc.wait.h
@@ -138,7 +138,7 @@ union wait {
 
 
 # ifndef WNOHANG
-#  define WNOHANG	1	/* dont hang in wait */
+#  define WNOHANG	1	/* don't hang in wait */
 # endif
 
 # ifndef WUNTRACED

--- a/tcsh.man.in
+++ b/tcsh.man.in
@@ -5823,7 +5823,7 @@ If no
 .Ar title
 is provided, the process title will be cleared.
 .
-.\" adjacant multi-tag items; add a blank
+.\" adjacent multi-tag items; add a blank
 .Pp
 .
 .It Ic kill Fl l
@@ -6537,7 +6537,7 @@ the shell, it has access to shell variables and other structures.
 This provides a mechanism for changing one's working environment
 based on the time of day.
 .
-.\" adjacant multi-tag items; add a blank
+.\" adjacent multi-tag items; add a blank
 .Pp
 .
 .It Ic set
@@ -8207,7 +8207,7 @@ section.
 .Pp
 If contains
 .Ql ask ,
-an interacive confirmation is presented, rather than an
+an interactive confirmation is presented, rather than an
 error.
 .Pp
 If contains
@@ -8294,7 +8294,7 @@ versus
 .Sq 7:45:42 .
 .
 .It Ic parseoctal
-To retain compatibily with older versions numeric variables starting with
+To retain compatibility with older versions numeric variables starting with
 0 are not interpreted as octal.
 Setting this variable enables proper octal
 parsing.

--- a/tw.comp.c
+++ b/tw.comp.c
@@ -212,7 +212,7 @@ tw_pos(Char *ran, int wno)
 
 
 /* tw_tok():
- *	Return the next word from string, unquoteing it.
+ *	Return the next word from string, unquoting it.
  */
 static Char *
 tw_tok(Char *str)

--- a/tw.init.c
+++ b/tw.init.c
@@ -612,7 +612,7 @@ tw_logname_next(struct Strbuf *res, struct Strbuf *dir, int *flags)
     /*
      * We don't want to get interrupted inside getpwent()
      * because the yellow pages code is not interruptible,
-     * and if we call endpwent() immediatetely after
+     * and if we call endpwent() immediately after
      * (in pintr()) we may be freeing an invalid pointer
      */
     USE(flags);
@@ -678,7 +678,7 @@ tw_grpname_next(struct Strbuf *res, struct Strbuf *dir, int *flags)
     /*
      * We don't want to get interrupted inside getgrent()
      * because the yellow pages code is not interruptible,
-     * and if we call endgrent() immediatetely after
+     * and if we call endgrent() immediately after
      * (in pintr()) we may be freeing an invalid pointer
      */
     USE(flags);

--- a/tw.spell.c
+++ b/tw.spell.c
@@ -32,7 +32,7 @@
 #include "sh.h"
 #include "tw.h"
 
-/* spell_me : return corrrectly spelled filename.  From K&P spname */
+/* spell_me : return correctly spelled filename.  From K&P spname */
 int
 spell_me(struct Strbuf *oldname, int looking, Char *pat, eChar suf)
 {

--- a/win32/README.NT
+++ b/win32/README.NT
@@ -222,7 +222,7 @@ Special Variables
 
  
 
-* TCSH_NOASYNCGUI (Enviroment variable): 
+* TCSH_NOASYNCGUI (Environment variable): 
 
   Makes tcsh wait for win32 GUI apps to terminate, instead of returning 
   immediately.  This affects child processes, so it can be set/unset in 
@@ -370,7 +370,7 @@ set prompt='%{<ESC>[44mfoo%}\>',
 this will print the prompt in the appropriate colors.
 
 The color-ls patch in 6.07.09 implements parsing for ANSI escapes. To keep
-the prompt specification consistent with the availablity of this feature,
+the prompt specification consistent with the availability of this feature,
 the literal string will now accept ANSI escapes like color-ls would.
 
     set prompt='%{^[[1;34m%}%c03%{^[[0m%}\>'

--- a/win32/msg/makerc.pl
+++ b/win32/msg/makerc.pl
@@ -8,7 +8,7 @@
 #
 # This prints to stdout, so redirect to appropriate place.
 #
-# The alogrithm is simple :
+# The algorithm is simple :
 #
 # String ID = set number * 10,000 + message number
 #

--- a/win32/msg/makercrc.pl
+++ b/win32/msg/makercrc.pl
@@ -4,7 +4,7 @@
 #
 # This prints to stdout, so redirect to appropriate place.
 #
-# The alogrithm is simple :
+# The algorithm is simple :
 #
 # String ID = 666 + line number
 #

--- a/win32/nt.bind.c
+++ b/win32/nt.bind.c
@@ -477,7 +477,7 @@ KEYCMD  CcViMap[] = {
 #else /* !KSHVI */
 	F_UNASSIGNED,		/* ^@ */   /* NOTE: These mapping do NOT */
 	F_TOBEG,			/* ^A */   /* Correspond well to the KSH */
-	F_CHARBACK,			/* ^B */   /* VI editting assignments    */
+	F_CHARBACK,			/* ^B */   /* VI editing assignments    */
 	F_TTY_INT,			/* ^C */   /* On the other hand they are */
 	F_LIST_EOF,			/* ^D */   /* convenient any many people */
 	F_TOEND,			/* ^E */   /* have gotten used to them   */

--- a/win32/nt.screen.c
+++ b/win32/nt.screen.c
@@ -41,7 +41,7 @@
 
 /*
  * IMPORTANT NOTE: these routines are allowed to look at the current screen
- * and the current possition assuming that it is correct.  If this is not
+ * and the current position assuming that it is correct.  If this is not
  * true, then the update will be WRONG!  This is (should be) a valid
  * assumption...
  */
@@ -297,7 +297,7 @@ MoveToChar(int where)
 
 	if (where >= TermH) {
 #ifdef DEBUG_SCREEN
-		xprintf("MoveToChar: where is riduculous: %d\r\n", where);
+		xprintf("MoveToChar: where is ridiculous: %d\r\n", where);
 		flush();
 #endif /* DEBUG_SCREEN */
 		return;
@@ -367,7 +367,7 @@ DeleteChars(int num)		/* deletes <num> characters */
 
 	if (num > TermH) {
 #ifdef DEBUG_SCREEN
-		xprintf(CGETS(7, 17, "DeletChars: num is riduculous: %d\r\n"), num);
+		xprintf(CGETS(7, 17, "DeletChars: num is ridiculous: %d\r\n"), num);
 		flush();
 #endif /* DEBUG_SCREEN */
 		return;
@@ -394,7 +394,7 @@ Insert_write(register Char *cp, register int num)
 
 	if (num > TermH) {
 #ifdef DEBUG_SCREEN
-		xprintf(CGETS(7, 19, "StartInsert: num is riduculous: %d\r\n"), num);
+		xprintf(CGETS(7, 19, "StartInsert: num is ridiculous: %d\r\n"), num);
 		flush();
 #endif /* DEBUG_SCREEN */
 		return;

--- a/win32/support.c
+++ b/win32/support.c
@@ -466,7 +466,7 @@ int quoteProtect(char *dest, char *src,unsigned long destsize) {
 
 		// Protect " from MS-DOS expansion
 		if (*curr == '"') {
-			// Now, protect each preceeding backslash
+			// Now, protect each preceding backslash
 			for (prev = curr-1; prev >= src && *prev == '\\'; prev--) {
 				*dest++ = '\\';
 				destsize--;


### PR DESCRIPTION
_cf_: https://github.com/tcsh-org/tcsh/issues/120

@suominen 

mostly comments

a few messages

note however

sh.exp.c

```diff
  	    case 'R':
- 		i = (stb.st_dmonflags & IMIGRATED) == IMIGRATED;
+ 		i = (stb.st_dmonflags & IMMIGRATED) == IMMIGRATED;
  		break;
```

Please review the Issue comments which have been updated with a few unresponded to questions.